### PR TITLE
CLOUDP-57661: Create basic stateful set from CR

### DIFF
--- a/mongodb-kubernetes-operator/deploy/crds/mongodb.com_mongodbs_crd.yaml
+++ b/mongodb-kubernetes-operator/deploy/crds/mongodb.com_mongodbs_crd.yaml
@@ -14,8 +14,43 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: MongoDB is the Schema for the mongodbs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MongoDBSpec defines the desired state of MongoDB
+          properties:
+            kind:
+              description: Kind defines which kind of MongoDB deployment the resource
+                should create
+              type: string
+            members:
+              description: Members is the number of members in the replica set
+              format: int32
+              type: integer
+            version:
+              description: Version defines which version of MongoDB will be used
+              type: string
+          required:
+          - kind
+          - version
+          type: object
+        status:
+          description: MongoDBStatus defines the observed state of MongoDB
+          type: object
       type: object
-      x-kubernetes-preserve-unknown-fields: true
+  version: v1
   versions:
   - name: v1
     served: true

--- a/mongodb-kubernetes-operator/deploy/crds/mongodb.com_v1_mongodb_cr.yaml
+++ b/mongodb-kubernetes-operator/deploy/crds/mongodb.com_v1_mongodb_cr.yaml
@@ -3,5 +3,6 @@ kind: MongoDB
 metadata:
   name: example-mongodb
 spec:
-  # Add fields here
-  size: 3
+  members: 3
+  kind: ReplicaSet
+  version: "4.0.6"

--- a/mongodb-kubernetes-operator/kube/statefulset/statefulset.go
+++ b/mongodb-kubernetes-operator/kube/statefulset/statefulset.go
@@ -1,0 +1,67 @@
+package statefulset
+
+import (
+	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewClient(client k8sclient.Client) Client {
+	return Client{
+		client: client,
+	}
+}
+
+type Client struct {
+	client k8sclient.Client
+}
+
+// Get provides a thin wrapper and client.Client to access appsv1.StatefulSet types
+func (c Client) Get(key k8sclient.ObjectKey) (appsv1.StatefulSet, error) {
+	set := appsv1.StatefulSet{}
+	if err := c.client.Get(context.TODO(), key, &set); err != nil {
+		return appsv1.StatefulSet{}, err
+	}
+	return set, nil
+}
+
+// Update provides a thin wrapper and client.Client to update appsv1.StatefulSet types
+func (c Client) Update(set appsv1.StatefulSet) error {
+	if err := c.client.Update(context.TODO(), &set); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create provides a thin wrapper and client.Client to create appsv1.StatefulSet types
+func (c Client) Create(set appsv1.StatefulSet) error {
+	if err := c.client.Create(context.TODO(), &set); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete provides a thin wrapper and client.Client to delete appsv1.StatefulSet types
+func (c Client) Delete(set appsv1.StatefulSet) error {
+	if err := c.client.Delete(context.TODO(), &set); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateOrUpdate will either Create the stateful set if it doesn't exist, or Update it
+// if it does
+func (c Client) CreateOrUpdate(set appsv1.StatefulSet) error {
+	_, err := c.Get(types.NamespacedName{Name: set.Name, Namespace: set.Namespace})
+	if err != nil && errors.IsNotFound(err) {
+		return c.Create(set)
+	} else if err != nil {
+		return err
+	}
+	if err := c.Update(set); err != nil {
+		return err
+	}
+	return nil
+}

--- a/mongodb-kubernetes-operator/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/mongodb-kubernetes-operator/pkg/apis/mongodb/v1/mongodb_types.go
@@ -1,24 +1,31 @@
 package v1
 
 import (
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+type Kind string
+
+var (
+	ReplicaSet Kind = "ReplicaSet"
+)
 
 // MongoDBSpec defines the desired state of MongoDB
 type MongoDBSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+	// Members is the number of members in the replica set
+	// +optional
+	Members int32 `json:"members"`
+	// Kind defines which kind of MongoDB deployment the resource should create
+	Kind Kind `json:"kind"`
+	// Version defines which version of MongoDB will be used
+	Version string `json:"version"`
 }
 
 // MongoDBStatus defines the observed state of MongoDB
 type MongoDBStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -32,6 +39,49 @@ type MongoDB struct {
 
 	Spec   MongoDBSpec   `json:"spec,omitempty"`
 	Status MongoDBStatus `json:"status,omitempty"`
+}
+
+// ServiceName returns the name of the Service that should be created for
+// this resource
+func (m *MongoDB) ServiceName() string {
+	return m.Name + "-svc"
+}
+
+// TODO: build the correct statefulset - this is a dummy implementation
+// BuildStatefulSet constructs an instance of appsv1.StatefulSet
+// which should be created during reconciliation
+func (m MongoDB) BuildStatefulSet() appsv1.StatefulSet {
+	labels := map[string]string{
+		"app": m.ServiceName(),
+	}
+	replicas := m.Spec.Members
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.Name,
+			Namespace: m.Namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      m.Name,
+					Namespace: m.Namespace,
+					Labels:    labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "mongo",
+							Image: fmt.Sprintf("mongo:%s", m.Spec.Version),
+						},
+					},
+				},
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/mongodb-kubernetes-operator/pkg/controller/mongodb/mongodb_controller.go
+++ b/mongodb-kubernetes-operator/pkg/controller/mongodb/mongodb_controller.go
@@ -2,16 +2,12 @@ package mongodb
 
 import (
 	"context"
-
+	"github.com/mongodb/mongodb-kubernetes-operator/mongodb-kubernetes-operator/kube/statefulset"
 	mongodbv1 "github.com/mongodb/mongodb-kubernetes-operator/mongodb-kubernetes-operator/pkg/apis/mongodb/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -21,11 +17,6 @@ import (
 
 var log = logf.Log.WithName("controller_mongodb")
 
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
-
 // Add creates a new MongoDB Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -34,7 +25,8 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileMongoDB{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	mgrClient := mgr.GetClient()
+	return &ReconcileMongoDB{client: mgrClient, scheme: mgr.GetScheme(), stsClient: statefulset.NewClient(mgrClient)}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -50,17 +42,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return err
 	}
-
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner MongoDB
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &mongodbv1.MongoDB{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -71,8 +52,9 @@ var _ reconcile.Reconciler = &ReconcileMongoDB{}
 type ReconcileMongoDB struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client client.Client
-	scheme *runtime.Scheme
+	client    client.Client
+	scheme    *runtime.Scheme
+	stsClient statefulset.Client
 }
 
 // Reconcile reads that state of the cluster for a MongoDB object and makes changes based on the state read
@@ -86,9 +68,10 @@ func (r *ReconcileMongoDB) Reconcile(request reconcile.Request) (reconcile.Resul
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling MongoDB")
 
+	// TODO: generalize preparation for resource
 	// Fetch the MongoDB instance
-	instance := &mongodbv1.MongoDB{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	mdb := mongodbv1.MongoDB{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, &mdb)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -100,54 +83,12 @@ func (r *ReconcileMongoDB) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	// Define a new Pod object
-	pod := newPodForCR(instance)
-
-	// Set MongoDB instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+	sts := mdb.BuildStatefulSet()
+	if err := r.stsClient.CreateOrUpdate(sts); err != nil {
+		reqLogger.Error(err, "failed Creating/Updating StatefulSet")
 		return reconcile.Result{}, err
 	}
 
-	// Check if this Pod already exists
-	found := &corev1.Pod{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
-		err = r.client.Create(context.TODO(), pod)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		// Pod created successfully - don't requeue
-		return reconcile.Result{}, nil
-	} else if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Pod already exists - don't requeue
-	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	reqLogger.Info("Successfully finished reconciliation", "MongoDB.Spec:", mdb.Spec, "MongoDB.Status", mdb.Status)
 	return reconcile.Result{}, nil
-}
-
-// newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *mongodbv1.MongoDB) *corev1.Pod {
-	labels := map[string]string{
-		"app": cr.Name,
-	}
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-pod",
-			Namespace: cr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "busybox",
-					Image:   "busybox",
-					Command: []string{"sleep", "3600"},
-				},
-			},
-		},
-	}
 }


### PR DESCRIPTION
This PR removes a lot of the boiler plate code (generate busy box pod) and replaces it with creating a StatefulSet that uses a community mongodb image.

The following resource 

```yaml
apiVersion: mongodb.com/v1
kind: MongoDB
metadata:
  name: example-mongodb
spec:
  members: 3
  kind: ReplicaSet
  version: "4.0.6"
```

Produces the following pods and stateful set
```bash
NAME              READY   AGE
example-mongodb   5/5     10m  # StatefulSet

# Pods
NAME                                           READY   STATUS    RESTARTS   AGE
example-mongodb-0                              1/1     Running   0          4m48s
example-mongodb-1                              1/1     Running   0          3m30s
example-mongodb-2                              1/1     Running   0          3m
example-mongodb-3                              1/1     Running   0          2m44s
example-mongodb-4                              1/1     Running   0          2m24s
mongodb-kubernetes-operator-5bbcd9d4f5-47258   1/1     Running   0          9m47s
```


The CRD was generated using

`operator-sdk generate crds`