### PR TITLE
Fix logger and stateful set construction

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"fmt"
-	"go.uber.org/zap"
-	"os"
-
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/apis"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/controller"
+	"go.uber.org/zap"
+	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -20,9 +19,15 @@ var (
 	operatorMetricsPort int32 = 8686
 )
 
-func main() {
+func configureLogger() (*zap.Logger, error) {
 	// TODO: configure non development logger
-	log, err := zap.NewDevelopment()
+	logger, err := zap.NewDevelopment()
+	zap.ReplaceGlobals(logger)
+	return logger, err
+}
+
+func main() {
+	log, err := configureLogger()
 	if err != nil {
 		os.Exit(1)
 	}
@@ -42,9 +47,9 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          "temp",
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		Namespace: namespace,
 	})
+	
 	if err != nil {
 		os.Exit(1)
 	}

--- a/deploy/crds/mongodb.com_mongodbs_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodbs_crd.yaml
@@ -19,31 +19,30 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           description: MongoDBSpec defines the desired state of MongoDB
           properties:
-            kind:
-              description: Kind defines which kind of MongoDB deployment the resource
-                should create
-              type: string
             members:
               description: Members is the number of members in the replica set
-              format: int32
               type: integer
+            type:
+              description: Type defines which type of MongoDB deployment the resource
+                should create
+              type: string
             version:
               description: Version defines which version of MongoDB will be used
               type: string
           required:
-          - kind
+          - type
           - version
           type: object
         status:

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -7,7 +7,9 @@ import (
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/statefulset"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -65,7 +67,7 @@ type ReplicaSetReconciler struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReplicaSetReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log := zap.S().With("ReplicaSet", request.Name, request.Namespace)
+	log := zap.S().With("ReplicaSet", request.NamespacedName)
 	log.Info("Reconciling MongoDB")
 
 	// TODO: generalize preparation for resource
@@ -79,6 +81,7 @@ func (r *ReplicaSetReconciler) Reconcile(request reconcile.Request) (reconcile.R
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
+		log.Errorf("error reconciling MongoDB resource: %s", err)
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
@@ -99,16 +102,31 @@ func (r *ReplicaSetReconciler) Reconcile(request reconcile.Request) (reconcile.R
 
 	// TODO: Create the service for the MDB resource
 
+	labels := map[string]string{
+		"dummy": "label",
+	}
+
 	sts, err := statefulset.NewBuilder().
+		SetPodTemplateSpec(corev1.PodTemplateSpec{
+			ObjectMeta: v1.ObjectMeta{
+				Labels: labels,
+			},
+			Spec: corev1.PodSpec{},
+		}).
 		SetNamespace(request.NamespacedName.Namespace).
 		SetName(request.NamespacedName.Name).
 		SetReplicas(mdb.Spec.Members).
+		SetLabels(labels).
+		SetMatchLabels(labels).
 		Build()
+
 	if err != nil {
+		log.Errorf("error building StatefulSet: %s", err)
 		return reconcile.Result{}, err
 	}
 
 	if err = r.stsClient.CreateOrUpdate(sts); err != nil {
+		log.Errorf("error creating/updating StatefulSet: %s", err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -108,7 +108,7 @@ func (r *ReplicaSetReconciler) Reconcile(request reconcile.Request) (reconcile.R
 
 	sts, err := statefulset.NewBuilder().
 		SetPodTemplateSpec(corev1.PodTemplateSpec{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,
 			},
 			Spec: corev1.PodSpec{},


### PR DESCRIPTION
This PR fixes errors while reconciling the MongoDB resource

1. The logger needed to be configured globally to display error messages in the reconciliation loop
2. podSpec.labels need to match label selectors