### PR TITLE
CLOUDP-60686: Create HaveEqualSpec function and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/yaml v1.1.0
+	github.com/imdario/mergo v0.3.8
 )
 
 // TODO: These replace statements need to be completely removed. These exist as the operator-sdk currently requires

--- a/pkg/kube/statefulset/statefulset.go
+++ b/pkg/kube/statefulset/statefulset.go
@@ -82,9 +82,8 @@ func IsReady(sts appsv1.StatefulSet) bool {
 	return allUpdated && allReady
 }
 
-// HaveEqualSpec accepts a StatefulSet built, and the StatefulSet that existed already
-// in the API server. HaveEqualSpec returns true if all the changes made in the built StatefulSet
-// are different in any way from the StatefulSet that exists in the API server
+// HaveEqualSpec accepts a StatefulSet builtSts, and a second existingSts, and compares
+// the Spec of both inputs but only comparing the fields that were specified in builtSts
 func HaveEqualSpec(builtSts appsv1.StatefulSet, existingSts appsv1.StatefulSet) (bool, error) {
 	stsToMerge := *existingSts.DeepCopyObject().(*appsv1.StatefulSet)
 	if err := mergo.Merge(&stsToMerge, builtSts, mergo.WithOverride); err != nil {

--- a/pkg/kube/statefulset/statefulset_test.go
+++ b/pkg/kube/statefulset/statefulset_test.go
@@ -218,7 +218,7 @@ func TestHaveEqualSpec(t *testing.T) {
 		existingSts, _ := defaultStatefulSetBuilder().Build()
 		areEqual, err := HaveEqualSpec(builtSts, existingSts)
 		assert.NoError(t, err)
-		assert.False(t, areEqual, "We have specified a field that is different from the existring StatefulSet, so these should be considered different")
+		assert.False(t, areEqual, "We have specified a field that is different from the existing StatefulSet, so these should be considered different")
 	})
 	t.Run("Existing StatefulSet has values we don't specify", func(t *testing.T) {
 		builtSts, _ := defaultStatefulSetBuilder().Build()


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

This PR adds a function which will compare only the changed fields on StatefulSet that we are building. This allows us to construct a stateful set struct that does not include all of the fields that are populated by the api server when doing a comparison.
