### PR TITLE
Build Test Runner image for every evergreen run

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -111,6 +111,16 @@ tasks:
           image: quay.io/mongodb/community-operator-e2e:${version_id}
           image_type: e2e
 
+  - name: build_testrunner_image
+    priority: 60
+    exec_timeout_secs: 600
+    commands:
+      - func: clone
+      - func: build_and_push_image
+        vars:
+          image: quay.io/mongodb/community-operator-testrunner:${version_id}
+          image_type: testrunner
+
   - name: unit_tests
     commands:
       - func: clone
@@ -157,6 +167,8 @@ buildvariants:
         variant: init_test_run
       - name: build_e2e_image
         variant: init_test_run
+      - name: build_testrunner_image
+        variant: init_test_run
     tasks:
       - name: e2e_test_replica_set
       - name: e2e_test_replica_set_readiness_probe
@@ -169,3 +181,4 @@ buildvariants:
     tasks:
       - name: build_operator_image
       - name: build_e2e_image
+      - name: build_testrunner_image

--- a/scripts/ci/run_test.sh
+++ b/scripts/ci/run_test.sh
@@ -19,7 +19,7 @@ kubectl apply -f deploy/testrunner
 kubectl run test-runner --generator=run-pod/v1 \
   --restart=Never \
   --image-pull-policy=Always \
-  --image=quay.io/chatton/test-runner \
+  --image=quay.io/mongodb/community-operator-testrunner:${version_id} \
   --serviceaccount=test-runner \
   --command -- ./runner  --operatorImage quay.io/mongodb/community-operator-dev:${version_id} --testImage quay.io/mongodb/community-operator-e2e:${version_id} --test=${test}
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR adds the building and pushing of the test runner image on each evergreen run

Evg: https://evergreen.mongodb.com/version/5ea84373d1fe07711489f9e7