### PR TITLE
Added FeatureCompatibilityVersion e2e test

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -136,6 +136,14 @@ tasks:
       - func: clone
       - func: go_test
 
+  - name: e2e_test_feature_compatibility_version
+    commands:
+      - func: clone
+      - func: setup_kubernetes_environment
+      - func: run_e2e_test
+        vars:
+          test: feature_compatibility_version
+
   - name: e2e_test_replica_set
     commands:
       - func: clone
@@ -194,6 +202,7 @@ buildvariants:
       - name: e2e_test_replica_set_readiness_probe
       - name: e2e_test_replica_set_scale
       - name: e2e_test_replica_set_change_version
+      - name: e2e_test_feature_compatibility_version
 
   - name: init_test_run
     display_name: init_test_run

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -144,6 +144,14 @@ tasks:
         vars:
           test: feature_compatibility_version
 
+  - name: e2e_test_feature_compatibility_version_upgrade
+    commands:
+      - func: clone
+      - func: setup_kubernetes_environment
+      - func: run_e2e_test
+        vars:
+          test: feature_compatibility_version
+
   - name: e2e_test_replica_set
     commands:
       - func: clone
@@ -203,6 +211,7 @@ buildvariants:
       - name: e2e_test_replica_set_scale
       - name: e2e_test_replica_set_change_version
       - name: e2e_test_feature_compatibility_version
+      - name: e2e_test_feature_compatibility_version_upgrade
 
   - name: init_test_run
     display_name: init_test_run

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -25,7 +25,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 
-	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
+	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 1))
 	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
 	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
@@ -34,7 +34,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 		},
 	))
 	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
-	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 1))
 
 	// Downgrade version back to 4.0.6, checks that the FeatureCompatibilityVersion stayed at 4.0
 	t.Run("MongoDB is reachable while version is downgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
@@ -43,5 +43,5 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 		},
 	))
-	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
+	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 1))
 }

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -17,25 +17,15 @@ func TestMain(m *testing.M) {
 func TestFeatureCompatibilityVersion(t *testing.T) {
 	ctx := f.NewContext(t)
 	defer ctx.Cleanup()
-
-	// register our types with the testing framework
 	if err := e2eutil.RegisterTypesWithFramework(&mdbv1.MongoDB{}); err != nil {
 		t.Fatal(err)
 	}
 
 	mdb := e2eutil.NewTestMongoDB()
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
-	t.Run("Config Map Was Correctly Created", mongodbtests.AutomationConfigConfigMapExists(&mdb))
-	t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsReady(&mdb))
-	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
-	t.Run("Test Basic Connectivity", mongodbtests.BasicConnectivity(&mdb))
-	t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
-		mdbv1.MongoDBStatus{
-			MongoURI: mdb.MongoURI(),
-			Phase:    mdbv1.Running,
-		}))
-	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 
+	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
 	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
 	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
@@ -44,7 +34,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 		},
 	))
 	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
-	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
 
 	// Downgrade version back to 4.0.6, checks that the FeatureCompatibilityVersion stayed at 4.0
 	t.Run("MongoDB is reachable while version is downgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
@@ -53,5 +43,5 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 		},
 	))
-	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
 }

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -1,0 +1,57 @@
+package feature_compatibility_version
+
+import (
+	"testing"
+	"time"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/pkg/apis/mongodb/v1"
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	f "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	f.MainEntry(m)
+}
+
+func TestFeatureCompatibilityVersion(t *testing.T) {
+	ctx := f.NewContext(t)
+	defer ctx.Cleanup()
+
+	// register our types with the testing framework
+	if err := e2eutil.RegisterTypesWithFramework(&mdbv1.MongoDB{}); err != nil {
+		t.Fatal(err)
+	}
+
+	mdb := e2eutil.NewTestMongoDB()
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Config Map Was Correctly Created", mongodbtests.AutomationConfigConfigMapExists(&mdb))
+	t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsReady(&mdb))
+	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+	t.Run("Test Basic Connectivity", mongodbtests.BasicConnectivity(&mdb))
+	t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
+		mdbv1.MongoDBStatus{
+			MongoURI: mdb.MongoURI(),
+			Phase:    mdbv1.Running,
+		}))
+	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+
+	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
+	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
+		func() {
+			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+		},
+	))
+	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+
+	// Downgrade version back to 4.0.6, checks that the FeatureCompatibilityVersion stayed at 4.0
+	t.Run("MongoDB is reachable while version is downgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
+		func() {
+			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+		},
+	))
+	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+}

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -1,0 +1,58 @@
+package feature_compatibility_version_upgrade
+
+import (
+	"testing"
+	"time"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/pkg/apis/mongodb/v1"
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	f "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	f.MainEntry(m)
+}
+
+func TestFeatureCompatibilityVersion(t *testing.T) {
+	ctx := f.NewContext(t)
+	defer ctx.Cleanup()
+
+	// register our types with the testing framework
+	if err := e2eutil.RegisterTypesWithFramework(&mdbv1.MongoDB{}); err != nil {
+		t.Fatal(err)
+	}
+
+	mdb := e2eutil.NewTestMongoDB()
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Config Map Was Correctly Created", mongodbtests.AutomationConfigConfigMapExists(&mdb))
+	t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsReady(&mdb))
+	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+	t.Run("Test Basic Connectivity", mongodbtests.BasicConnectivity(&mdb))
+	t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
+		mdbv1.MongoDBStatus{
+			MongoURI: mdb.MongoURI(),
+			Phase:    mdbv1.Running,
+		}))
+	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+
+	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
+	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
+		func() {
+			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+		},
+	))
+	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+
+	t.Run("MongoDB is reachable while FeatureCompatibilityVersion is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
+		func() {
+			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersionAndFeatureCompatibilityVersion(&mdb, "4.2.6", "4.2"))
+			t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsUpdated(&mdb))
+		},
+	))
+
+	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.2"))
+}

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -17,42 +17,34 @@ func TestMain(m *testing.M) {
 func TestFeatureCompatibilityVersion(t *testing.T) {
 	ctx := f.NewContext(t)
 	defer ctx.Cleanup()
-
-	// register our types with the testing framework
 	if err := e2eutil.RegisterTypesWithFramework(&mdbv1.MongoDB{}); err != nil {
 		t.Fatal(err)
 	}
 
 	mdb := e2eutil.NewTestMongoDB()
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
-	t.Run("Config Map Was Correctly Created", mongodbtests.AutomationConfigConfigMapExists(&mdb))
-	t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsReady(&mdb))
-	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
-	t.Run("Test Basic Connectivity", mongodbtests.BasicConnectivity(&mdb))
-	t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
-		mdbv1.MongoDBStatus{
-			MongoURI: mdb.MongoURI(),
-			Phase:    mdbv1.Running,
-		}))
-	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 
+	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
 	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
-	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
+	t.Run("MongoDB is reachable", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
 			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
 		},
 	))
-	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
 	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0"))
 
-	t.Run("MongoDB is reachable while FeatureCompatibilityVersion is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
+	t.Run("MongoDB is reachable", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
 			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersionAndFeatureCompatibilityVersion(&mdb, "4.2.6", "4.2"))
 			t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 		},
 	))
 
-	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+	// TODO: don't kill me I'm working on a proper solution now!
+	time.Sleep(60)
 	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.2"))
 }

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 	f.MainEntry(m)
 }
 
-func TestFeatureCompatibilityVersion(t *testing.T) {
+func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 	ctx := f.NewContext(t)
 	defer ctx.Cleanup()
 	if err := e2eutil.RegisterTypesWithFramework(&mdbv1.MongoDB{}); err != nil {
@@ -26,7 +26,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 
-	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
+	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 1))
 	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
 	t.Run("MongoDB is reachable", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
@@ -35,7 +35,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 			t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
 		},
 	))
-	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.0", 1))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 1))
 
 	t.Run("MongoDB is reachable", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
@@ -50,5 +50,5 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 		},
 	))
 
-	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", mongodbtests.FeatureCompatibilityVersion(&mdb, "4.2", 3))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.2", 3))
 }


### PR DESCRIPTION
## Summary

Added 2 new e2e tests that check FCV configurations:

* feature_compatibility_version: Changes the DB version from 4.0 to 4.2 while keeping the FCV to 4.0. It downgrades the DB *back* to 4.0.
* feature_compatibility_version_upgrade: Changes the DB version from 4.0 to 4.2 and *then* updates the FCV to 4.2