### PR TITLE
(DOCSP-10035): Add architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To upgrade the MongoDB Community Kubernetes Operator:
 
 ## Deploy and Configure a MongoDB Resource
 
-The `/deploy/crds` directory contains example MongoDB resources that you can modify and deploy.
+The [`/deploy/crds`](deploy/crds) directory contains example MongoDB resources that you can modify and deploy.
 
 ### Deploy a Replica Set
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If you are a MongoDB Enterprise customer, or need Enterprise features such as Ba
 - [Contribute](#contribute)
 - [License](#license)
 
-
 ## Install the Operator
 
 ### Prerequisites
@@ -64,7 +63,6 @@ To install the MongoDB Community Kubernetes Operator:
       kubectl get pods --namespace <my-namespace>
       ```
 
-
 ## Upgrade the Operator
 
 To upgrade the MongoDB Community Kubernetes Operator:
@@ -74,7 +72,6 @@ To upgrade the MongoDB Community Kubernetes Operator:
    ```
    kubectl apply -f deploy/crds/mongodb.com_mongodb_crd.yaml
    ```
-
 
 ## Deploy and Configure a MongoDB Resource
 
@@ -163,13 +160,14 @@ The MongoDB Community Kubernetes Operator supports the following features:
 
 ## Contribute
 
-Please get familiar with the architecture.md document and then go ahead and read
-the [contributing guide](contributing.md).
+Before you contribute to the MongoDB Community Kubernetes Operator, please read:
+
+- [MongoDB Community Kubernetes Operator Architecture](architecture.md)
+- [Contributing to MongoDB Community Kubernetes Operator](contributing.md)
 
 Please file issues before filing PRs. For PRs to be accepted, contributors must sign our [CLA](https://www.mongodb.com/legal/contributor-agreement).
 
 Reviewers, please ensure that the CLA has been signed by referring to [the contributors tool](https://contributors.corp.mongodb.com/) (internal link).
-
 
 ## License
 

--- a/architecture.md
+++ b/architecture.md
@@ -18,53 +18,53 @@ You create and update MongoDB resources by defining a MongoDB resource definitio
    - A container for the [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/index.html) process binary. </br>
      `mongod` is the primary daemon process for the MongoDB system. It handles data requests, manages data access, and performs background management operations.
 
-   - A container for the Automation Agent. </br>
-     The Automation Agent handles configuring, stopping, and restarting the `mongod` process. The Automation Agent periodically polls the `mongod` to determine status and can deploy changes as needed. 
+   - A container for the MongoDB Agent. </br>
+     The Automation function of the MongoDB Agent handles configuring, stopping, and restarting the `mongod` process. The MongoDB Agent periodically polls the `mongod` to determine status and can deploy changes as needed. 
 1. Writes the Automation configuration as a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) and mounts it to each pod. 
-1. Initiates the Automation Agent, which in turn creates the database configuration and launches the `mongod` process according to your MongoDB resource definition.
+1. Initiates the MongoDB Agent, which in turn creates the database configuration and launches the `mongod` process according to your [MongoDB resource definition](deploy/crds/mongodb.com_v1_mongodb_cr.yaml).
 
 <!--
 <img src="" alt="Architecure diagram of the MongoDB Community Kubernetes Operator">
 -->
 
-This architecture maximizes use of the Automation Agent while integrating naturally with Kubernetes to produce a number of benefits.
+This architecture maximizes use of the MongoDB Agent while integrating naturally with Kubernetes to produce a number of benefits.
 
-- MongoDB containers are not tied to the Operator or the Agent, so you can:
-  - Run any MongoDB container.
+- The database container is not tied to the lifecycle of the Agent container or to the Operator, so you can:
   - Use your preferred Linux distribution inside the container.
   - Update operating system packages on your own schedule.
+  - Upgrade the Operator or Agent without affecting the database image or uptime of the MongoDB servers.
 - Containers are immutable and have a single responsibility or process, so you can:
   - Describe and understand each container.
   - Configure resources independently for easier debugging and triage.
   - Inspect resources independently, including tailing the logs.
   - Expose the state of each container.
 - Pods are defined as StatefulSets so they benefit from stable identities.
-- You can upgrade the Operator without restarting either the database or the Automation Agent containers.
-- You can set up a MongoDB Kubernetes cluster offline once you download the Docker containers for the database and Automation Agent.
+- You can upgrade the Operator without restarting either the database or the MongoDB Agent containers.
+- You can set up a MongoDB Kubernetes cluster offline once you download the Docker containers for the database and MongoDB Agent.
 
 ## Example: MongoDB Version Upgrade
 
-The MongoDB Community Kubernetes Operator uses the Automation Agent to efficiently handle rolling upgrades. The Operator configures the StatefulSet to block Kubernetes from performing native rolling upgrades because the native process can trigger multiple  re-elections in your MongoDB cluster. 
+The MongoDB Community Kubernetes Operator uses the Automation function of the MongoDB Agent to efficiently handle rolling upgrades. The Operator configures the StatefulSet to block Kubernetes from performing native rolling upgrades because the native process can trigger multiple re-elections in your MongoDB cluster. 
 
 When you update the MongoDB version in your resource definition and reapply it to your Kubernetes environment, the Operator initiates a rolling upgrade:
 
 1. The Operator changes the StatefulSet [update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) from `RollingUpdate` to `OnDelete`.
 
-1. The Operator updates the [image](https://kubernetes.io/docs/concepts/containers/images/) specification to the new version of MongoDB and writes a new Automation Agent configuration ConfigMap to each pod.
+1. The Operator updates the [image](https://kubernetes.io/docs/concepts/containers/images/) specification to the new version of MongoDB and writes a new Automation configuration ConfigMap to each pod.
 
-1. The Automation Agent chooses the first pod to upgrade and stops the `mongod` process using a local connection and [`db.shutdownServer`](https://docs.mongodb.com/manual/reference/method/db.shutdownServer/#db.shutdownServer).
+1. The MongoDB Agent chooses the first pod to upgrade and stops the `mongod` process using a local connection and [`db.shutdownServer`](https://docs.mongodb.com/manual/reference/method/db.shutdownServer/#db.shutdownServer).
 
-1. A pre-stop hook on the database container checks the state of the Automation Agent. If the Automation Agent expects the `mongod` process to start with a new version, the hook uses a Kubernetes API call to delete the pod.
+1. A pre-stop hook on the database container checks the state of the MongoDB Agent. If the MongoDB Agent expects the `mongod` process to start with a new version, the hook uses a Kubernetes API call to delete the pod.
 
 1. The Kubernetes Controller downloads the target version of MongoDB from its default docker registry and restarts the pod with the target version of `mongod` in the database container.
 
-1. The Automation Agent starts. It checks the target version of the new `mongod`, then generates the configuration file for the `mongod` process.
+1. The MongoDB Agent starts. It checks the target version of the new `mongod`, then generates the configuration file for the `mongod` process.
 
-1. The `mongod` process receives the configuration file from the Automation Agent and starts.
+1. The `mongod` process receives the configuration file from the MongoDB Agent and starts.
 
-1. The Automation Agent reaches goal state.
+1. The MongoDB Agent reaches goal state.
 
-1. The Automation Agent chooses the next pod to upgrade and repeats the process until all pods are upgraded.
+1. The MongoDB Agent chooses the next pod to upgrade and repeats the process until all pods are upgraded.
 
 1. The Operator changes the StatefulSet update strategy from `OnDelete` back to `RollingUpdate`.
 
@@ -72,14 +72,14 @@ When you update the MongoDB version in your resource definition and reapply it t
 <img src="" alt="Rolling upgrade flow diagram for the MongoDB Community Kubernetes Operator">
 -->
 
-This upgrade process allows the Automation Agent to:
+This upgrade process allows the MongoDB Agent to:
 
-- Perform pre-conditions
-- Upgrade the secondaries first
-- Wait for the secondaries' oplogs to catch up before triggering an election
-- Upgrade quickly for large replica sets
-- Consider voting nodes
-- Ensure a replica set is always available throughout the entire upgrade process
+- Perform pre-conditions.
+- Upgrade the secondaries first.
+- Wait for the secondaries' oplogs to catch up before triggering an election.
+- Upgrade quickly for large replica sets.
+- Consider voting nodes.
+- Ensure a replica set is always available throughout the entire upgrade process.
 
 ## MongoDB Docker Images
 

--- a/architecture.md
+++ b/architecture.md
@@ -1,11 +1,62 @@
 # MongoDB Community Operator Architecture
 
-**Work in Progress**
+--------------------
 
-## Topics
+## Table of Contents
 
-* Automation Agent
-* Cluster Configuration and ConfigMap
-* MongoDB Docker Images
-* Example case: MongoDB version upgrade
+- [MongoDB Docker Images](#mongodb-docker-images)
+- [Example: MongoDB Version Upgrade](#example:-mongodb-version-upgrade)
 
+--------------------
+
+You create and update MongoDB resources by defining a MongoDB resource definition. When you apply the MongoDB resource definition to your Kubernetes environment, the Operator:
+
+1. Creates a [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) that contains one [pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/) for each [replica set](https://docs.mongodb.com/manual/replication/) member. 
+2. Creates two [containers](https://kubernetes.io/docs/concepts/containers/overview/) in each pod: 
+   - A container for the [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/index.html) process binary.
+   - A container for the Automation Agent. 
+3. Writes the Automation configuration and initiates the Automation Agent, which in turn launches the `mongod` process according to your MongoDB resource definition.
+
+While the Kubernetes Operator handles startup of the StatefulSet, the MongoDB Automation Agent handles configuring, stopping, and restarting the `mongod` process. The Automation Agent periodically polls the `mongod` to determine status and can deploy changes as needed. 
+
+This architecure maximizes use of the Automation Agent while integrating naturally with Kubernetes to produce a number of benefits:
+
+- Pods are defined as StatefulSets so they benefit from stable identities.
+- Because the design is based on containers and not binaries, you can run any MongoDB container. This allows you to:
+  - Use your preferred Linux distrobution inside the container.
+  - Update operating system packages on your own schedule.
+- Containers are immutable and have a single responsibility or process, which allows you to:
+  - Describe and understand each container.
+  - Configure resources independently for easier debugging and triage.
+  - Inspect resources independently, including tailing the logs.
+  - Expose the state of each container.
+- You can upgrade the Operator without restarting either the database or the Automation Agent containers.
+- You can set up a MongoDB Kubernetes cluster offline once you download the Docker containers for the database and Automation Agent.
+
+## MongoDB Docker Images
+
+MongoDB images are available on [Docker Hub](https://hub.docker.com/_/mongo?tab=tags&page=1&ordering=last_updated).
+
+## Example: MongoDB Version Upgrade
+
+The MongoDB Community Kubernetes Operator uses the Automation Agent to efficiently handle rolling upgrades. The StatefulSet is configured to block Kubernetes from performing native rolling upgrades because the native process can trigger multiple  re-elections in your MongoDB cluster. 
+
+When you update the MongoDB version in your resource definition and reapply it to your Kubernetes environment, the Operator initiates a rolling upgrade:
+
+1. The Operator updates the [image](https://kubernetes.io/docs/concepts/containers/images/) specification to the new version of MongoDB and writes a new Automation Agent configuration to each pod.
+2. The Automation Agent chooses the first pod to upgrade and stops the `mongod` process using a local connection and [`db.shutdownServer`](https://docs.mongodb.com/manual/reference/method/db.shutdownServer/#db.shutdownServer).
+3. A pre-stop hook on the database container checks the state of the Automation Agent. If the Automation Agent expects the `mongod` process to start with a new version, the hook uses a Kubernetes API call to delete the pod.
+4. The Kubernetes Controller downloads the target version of MongoDB from its default docker registry and restarts the pod with the target version of `mongod` in the database container.
+5. The Automation Agent starts. It finds and checks the target version of the new `mongod`, then generates the configuration file for the `mongod` process.
+6. The `mongod` process finds the configuration file from the Automation Agent and starts.
+7. The Automation Agent reaches goal state.
+8. The Automation Agent chooses the next pod to upgrade and repeats the process until all pods are upgraded.
+
+This upgrade process allows the Automation Agent to:
+
+- Perform pre-conditions
+- Upgrade the secondaries first
+- Wait for the secondaries' oplogs to catch up before triggering an election
+- Upgrade quickly for large replica sets
+- Consider voting nodes
+- Ensure a replica set is always avialable throughout the entire upgrade process

--- a/architecture.md
+++ b/architecture.md
@@ -1,13 +1,14 @@
-# MongoDB Community Operator Architecture
+# MongoDB Community Kubernetes Operator Architecture
 
---------------------
+The MongoDB Community Kubernetes Operator is a [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) and a [Controller](https://kubernetes.io/docs/concepts/architecture/controller/).
 
 ## Table of Contents
 
+- [Cluster Configuration](#cluster-configuration)
+- [Example: MongoDB Version Upgrade](#example-mongodb-version-upgrade)
 - [MongoDB Docker Images](#mongodb-docker-images)
-- [Example: MongoDB Version Upgrade](#example:-mongodb-version-upgrade)
 
---------------------
+## Cluster Configuration
 
 You create and update MongoDB resources by defining a MongoDB resource definition. When you apply the MongoDB resource definition to your Kubernetes environment, the Operator:
 
@@ -15,42 +16,48 @@ You create and update MongoDB resources by defining a MongoDB resource definitio
 2. Creates two [containers](https://kubernetes.io/docs/concepts/containers/overview/) in each pod: 
    - A container for the [`mongod`](https://docs.mongodb.com/manual/reference/program/mongod/index.html) process binary.
    - A container for the Automation Agent. 
-3. Writes the Automation configuration and initiates the Automation Agent, which in turn launches the `mongod` process according to your MongoDB resource definition.
+3. Writes the Automation configuration as a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) and mounts it to each pod. 
+4. Initiates the Automation Agent, which in turn creates the database configuration and launches the `mongod` process according to your MongoDB resource definition.
 
-While the Kubernetes Operator handles startup of the StatefulSet, the MongoDB Automation Agent handles configuring, stopping, and restarting the `mongod` process. The Automation Agent periodically polls the `mongod` to determine status and can deploy changes as needed. 
+<!-- Waiting for diagram from Louis
+<img src="" alt="Architecure diagram of the MongoDB Community Kubernetes Operator">
+-->
 
-This architecure maximizes use of the Automation Agent while integrating naturally with Kubernetes to produce a number of benefits:
+While the Operator handles startup of the StatefulSet, the Automation Agent handles configuring, stopping, and restarting the `mongod` process. The Automation Agent periodically polls the `mongod` to determine status and can deploy changes as needed. 
 
-- Pods are defined as StatefulSets so they benefit from stable identities.
-- Because the design is based on containers and not binaries, you can run any MongoDB container. This allows you to:
+This architecure maximizes use of the Automation Agent while integrating naturally with Kubernetes to produce a number of benefits.
+
+- Architecture is based on containers and not binaries, so you can:
+  - Run any MongoDB container.
   - Use your preferred Linux distrobution inside the container.
   - Update operating system packages on your own schedule.
-- Containers are immutable and have a single responsibility or process, which allows you to:
+- Containers are immutable and have a single responsibility or process, so you can:
   - Describe and understand each container.
   - Configure resources independently for easier debugging and triage.
   - Inspect resources independently, including tailing the logs.
   - Expose the state of each container.
+- Pods are defined as StatefulSets so they benefit from stable identities.
 - You can upgrade the Operator without restarting either the database or the Automation Agent containers.
 - You can set up a MongoDB Kubernetes cluster offline once you download the Docker containers for the database and Automation Agent.
 
-## MongoDB Docker Images
-
-MongoDB images are available on [Docker Hub](https://hub.docker.com/_/mongo?tab=tags&page=1&ordering=last_updated).
-
 ## Example: MongoDB Version Upgrade
 
-The MongoDB Community Kubernetes Operator uses the Automation Agent to efficiently handle rolling upgrades. The StatefulSet is configured to block Kubernetes from performing native rolling upgrades because the native process can trigger multiple  re-elections in your MongoDB cluster. 
+The MongoDB Community Kubernetes Operator uses the Automation Agent to efficiently handle rolling upgrades. The Operator configures the StatefulSet to block Kubernetes from performing native rolling upgrades because the native process can trigger multiple  re-elections in your MongoDB cluster. 
 
 When you update the MongoDB version in your resource definition and reapply it to your Kubernetes environment, the Operator initiates a rolling upgrade:
 
-1. The Operator updates the [image](https://kubernetes.io/docs/concepts/containers/images/) specification to the new version of MongoDB and writes a new Automation Agent configuration to each pod.
+1. The Operator updates the [image](https://kubernetes.io/docs/concepts/containers/images/) specification to the new version of MongoDB and writes a new Automation Agent configuration ConfigMap to each pod.
 2. The Automation Agent chooses the first pod to upgrade and stops the `mongod` process using a local connection and [`db.shutdownServer`](https://docs.mongodb.com/manual/reference/method/db.shutdownServer/#db.shutdownServer).
 3. A pre-stop hook on the database container checks the state of the Automation Agent. If the Automation Agent expects the `mongod` process to start with a new version, the hook uses a Kubernetes API call to delete the pod.
 4. The Kubernetes Controller downloads the target version of MongoDB from its default docker registry and restarts the pod with the target version of `mongod` in the database container.
-5. The Automation Agent starts. It finds and checks the target version of the new `mongod`, then generates the configuration file for the `mongod` process.
-6. The `mongod` process finds the configuration file from the Automation Agent and starts.
+5. The Automation Agent starts. It checks the target version of the new `mongod`, then generates the configuration file for the `mongod` process.
+6. The `mongod` process receives the configuration file from the Automation Agent and starts.
 7. The Automation Agent reaches goal state.
 8. The Automation Agent chooses the next pod to upgrade and repeats the process until all pods are upgraded.
+
+<!-- Waiting for diagram from Louis
+<img src="" alt="Rolling upgrade flow diagram for the MongoDB Community Kubernetes Operator">
+-->
 
 This upgrade process allows the Automation Agent to:
 
@@ -59,4 +66,8 @@ This upgrade process allows the Automation Agent to:
 - Wait for the secondaries' oplogs to catch up before triggering an election
 - Upgrade quickly for large replica sets
 - Consider voting nodes
-- Ensure a replica set is always avialable throughout the entire upgrade process
+- Ensure a replica set is always available throughout the entire upgrade process
+
+## MongoDB Docker Images
+
+MongoDB images are available on [Docker Hub](https://hub.docker.com/_/mongo?tab=tags&page=1&ordering=last_updated).


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-10035)

This PR:
- Creates an [architecture topic](https://github.com/melissamahoney-mongodb/mongodb-kubernetes-operator/blob/DOCSP-10035/architecture.md)
- Updates the [readme](https://github.com/melissamahoney-mongodb/mongodb-kubernetes-operator/blob/DOCSP-10035/README.md#contribute) to point to the architecture topic

I've spoken to @LouisPlisso about getting diagrams. I can take a screenshot from the [Google doc](https://docs.google.com/document/d/1XR7E6daNGI8QITmZjfHzI9-EBoiBy18aZfgtnqYF9lA/edit#) if I have to, or we can wait to add them.
