### PR TITLE
Ensure enum values for type

### DIFF
--- a/cmd/testrunner/crds/crds.go
+++ b/cmd/testrunner/crds/crds.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextentionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -30,7 +30,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	}
 
 	for _, filePath := range crdFilePaths {
-		crd := &apiextensionsv1beta1.CustomResourceDefinition{}
+		crd := &apiextentionv1.CustomResourceDefinition{}
 		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("error reading file: %v", err)
@@ -38,7 +38,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 		if err := marshalCRDFromYAMLBytes(data, crd); err != nil {
 			return fmt.Errorf("error converting yaml bytes to CRD: %v", err)
 		}
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+		_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
 
 		if apierrors.IsAlreadyExists(err) {
 			fmt.Println("CRD already exists")
@@ -52,7 +52,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	return nil
 }
 
-func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
+func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextentionv1.CustomResourceDefinition) error {
 	jsonBytes, err := yaml.YAMLToJSON(bytes)
 	if err != nil {
 		return err

--- a/cmd/testrunner/crds/crds.go
+++ b/cmd/testrunner/crds/crds.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	//apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,7 +30,6 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	}
 
 	for _, filePath := range crdFilePaths {
-		//crd := &apiextensionv1.CustomResourceDefinition{}
 		crd := &apiextensionsv1beta1.CustomResourceDefinition{}
 		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
@@ -40,7 +38,6 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 		if err := marshalCRDFromYAMLBytes(data, crd); err != nil {
 			return fmt.Errorf("error converting yaml bytes to CRD: %v", err)
 		}
-		//_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
 		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 
 		if apierrors.IsAlreadyExists(err) {
@@ -55,7 +52,6 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	return nil
 }
 
-//func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionv1.CustomResourceDefinition) error {
 func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
 	jsonBytes, err := yaml.YAMLToJSON(bytes)
 	if err != nil {

--- a/cmd/testrunner/crds/crds.go
+++ b/cmd/testrunner/crds/crds.go
@@ -10,7 +10,8 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	//apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -30,7 +31,8 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	}
 
 	for _, filePath := range crdFilePaths {
-		crd := &apiextensionv1.CustomResourceDefinition{}
+		//crd := &apiextensionv1.CustomResourceDefinition{}
+		crd := &apiextensionsv1beta1.CustomResourceDefinition{}
 		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("error reading file: %v", err)
@@ -38,7 +40,8 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 		if err := marshalCRDFromYAMLBytes(data, crd); err != nil {
 			return fmt.Errorf("error converting yaml bytes to CRD: %v", err)
 		}
-		_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
+		//_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
+		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 
 		if apierrors.IsAlreadyExists(err) {
 			fmt.Println("CRD already exists")
@@ -52,7 +55,8 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	return nil
 }
 
-func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionv1.CustomResourceDefinition) error {
+//func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionv1.CustomResourceDefinition) error {
+func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
 	jsonBytes, err := yaml.YAMLToJSON(bytes)
 	if err != nil {
 		return err

--- a/cmd/testrunner/crds/crds.go
+++ b/cmd/testrunner/crds/crds.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	apiextentionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -30,7 +30,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	}
 
 	for _, filePath := range crdFilePaths {
-		crd := &apiextentionsv1.CustomResourceDefinition{}
+		crd := &apiextensionv1.CustomResourceDefinition{}
 		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("error reading file: %v", err)
@@ -52,7 +52,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	return nil
 }
 
-func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextentionsv1.CustomResourceDefinition) error {
+func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionv1.CustomResourceDefinition) error {
 	jsonBytes, err := yaml.YAMLToJSON(bytes)
 	if err != nil {
 		return err

--- a/cmd/testrunner/crds/crds.go
+++ b/cmd/testrunner/crds/crds.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	apiextentionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextentionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -30,7 +30,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	}
 
 	for _, filePath := range crdFilePaths {
-		crd := &apiextentionv1.CustomResourceDefinition{}
+		crd := &apiextentionsv1.CustomResourceDefinition{}
 		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("error reading file: %v", err)
@@ -52,7 +52,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	return nil
 }
 
-func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextentionv1.CustomResourceDefinition) error {
+func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextentionsv1.CustomResourceDefinition) error {
 	jsonBytes, err := yaml.YAMLToJSON(bytes)
 	if err != nil {
 		return err

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -1,17 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mongodb.mongodb.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Current state of the MongoDB deployment
-    name: Phase
-    type: string
-  - JSONPath: .status.version
-    description: Version of MongoDB server
-    name: Version
-    type: string
   group: mongodb.com
   names:
     kind: MongoDB
@@ -21,59 +12,69 @@ spec:
     - mdb
     singular: mongodb
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MongoDB is the Schema for the mongodbs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MongoDBSpec defines the desired state of MongoDB
-          properties:
-            featureCompatibilityVersion:
-              description: FeatureCompatibilityVersion configures the feature compatibility
-                version that will be set for the deployment
-              type: string
-            members:
-              description: Members is the number of members in the replica set
-              type: integer
-            type:
-              description: Type defines which type of MongoDB deployment the resource
-                should create
-              type: string
-            version:
-              description: Version defines which version of MongoDB will be used
-              type: string
-          required:
-          - type
-          - version
-          type: object
-        status:
-          description: MongoDBStatus defines the observed state of MongoDB
-          properties:
-            mongoUri:
-              type: string
-            phase:
-              type: string
-          required:
-          - mongoUri
-          - phase
-          type: object
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Version of MongoDB server
+      jsonPath: .status.version
+      name: Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: MongoDB is the Schema for the mongodbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MongoDBSpec defines the desired state of MongoDB
+            properties:
+              featureCompatibilityVersion:
+                description: FeatureCompatibilityVersion configures the feature compatibility
+                  version that will be set for the deployment
+                type: string
+              members:
+                description: Members is the number of members in the replica set
+                type: integer
+              type:
+                description: Type defines which type of MongoDB deployment the resource
+                  should create
+                enum:
+                - ReplicaSet
+                type: string
+              version:
+                description: Version defines which version of MongoDB will be used
+                type: string
+            required:
+            - type
+            - version
+            type: object
+          status:
+            description: MongoDBStatus defines the observed state of MongoDB
+            properties:
+              mongoUri:
+                type: string
+              phase:
+                type: string
+            required:
+            - mongoUri
+            - phase
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -15,11 +15,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Current state of the MongoDB deployment
-      jsonPath: .status.phase
+      JSONPath: .status.phase # manually changed from jsonPath
       name: Phase
       type: string
     - description: Version of MongoDB server
-      jsonPath: .status.version
+      JSONPath: .status.version # manually changed from jsonPath
       name: Version
       type: string
     name: v1

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -1,8 +1,17 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mongodb.mongodb.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Current state of the MongoDB deployment
+    name: Phase
+    type: string
+  - JSONPath: .status.version
+    description: Version of MongoDB server
+    name: Version
+    type: string
   group: mongodb.com
   names:
     kind: MongoDB
@@ -12,69 +21,61 @@ spec:
     - mdb
     singular: mongodb
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: MongoDB is the Schema for the mongodbs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MongoDBSpec defines the desired state of MongoDB
+          properties:
+            featureCompatibilityVersion:
+              description: FeatureCompatibilityVersion configures the feature compatibility
+                version that will be set for the deployment
+              type: string
+            members:
+              description: Members is the number of members in the replica set
+              type: integer
+            type:
+              description: Type defines which type of MongoDB deployment the resource
+                should create
+              enum:
+              - ReplicaSet
+              type: string
+            version:
+              description: Version defines which version of MongoDB will be used
+              type: string
+          required:
+          - type
+          - version
+          type: object
+        status:
+          description: MongoDBStatus defines the observed state of MongoDB
+          properties:
+            mongoUri:
+              type: string
+            phase:
+              type: string
+          required:
+          - mongoUri
+          - phase
+          type: object
+      type: object
+  version: v1
   versions:
-  - additionalPrinterColumns:
-    - description: Current state of the MongoDB deployment
-      JSONPath: .status.phase # manually changed from jsonPath
-      name: Phase
-      type: string
-    - description: Version of MongoDB server
-      JSONPath: .status.version # manually changed from jsonPath
-      name: Version
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: MongoDB is the Schema for the mongodbs API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MongoDBSpec defines the desired state of MongoDB
-            properties:
-              featureCompatibilityVersion:
-                description: FeatureCompatibilityVersion configures the feature compatibility
-                  version that will be set for the deployment
-                type: string
-              members:
-                description: Members is the number of members in the replica set
-                type: integer
-              type:
-                description: Type defines which type of MongoDB deployment the resource
-                  should create
-                enum:
-                - ReplicaSet
-                type: string
-              version:
-                description: Version defines which version of MongoDB will be used
-                type: string
-            required:
-            - type
-            - version
-            type: object
-          status:
-            description: MongoDBStatus defines the observed state of MongoDB
-            properties:
-              mongoUri:
-                type: string
-              phase:
-                type: string
-            required:
-            - mongoUri
-            - phase
-            type: object
-        type: object
+  - name: v1
     served: true
     storage: true
-    subresources:
-      status: {}

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -31,6 +31,7 @@ type MongoDBSpec struct {
 	// +optional
 	Members int `json:"members"`
 	// Type defines which type of MongoDB deployment the resource should create
+	// +kubebuilder:validation:Enum=ReplicaSet
 	Type Type `json:"type"`
 	// Version defines which version of MongoDB will be used
 	Version string `json:"version"`


### PR DESCRIPTION
### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR adds CRD generation annotation to enforce the replica set type as an enum

~~CRD was generated with `operator-sdk generate crds`~~
`operator-sdk generate crds --crd-version v1beta1`

There is an [issue with v1 CRD generation](https://github.com/operator-framework/operator-sdk/issues/3005)

