### PR TITLE
CLOUDP-65796: Update CRD API version

### DIFF
--- a/cmd/testrunner/crds/crds.go
+++ b/cmd/testrunner/crds/crds.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -30,7 +30,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	}
 
 	for _, filePath := range crdFilePaths {
-		crd := &apiextensionsv1beta1.CustomResourceDefinition{}
+		crd := &apiextensionsv1.CustomResourceDefinition{}
 		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("error reading file: %v", err)
@@ -38,7 +38,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 		if err := marshalCRDFromYAMLBytes(data, crd); err != nil {
 			return fmt.Errorf("error converting yaml bytes to CRD: %v", err)
 		}
-		_, err = apiextensionsClientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+		_, err = apiextensionsClientSet.ApiextensionsV1().CustomResourceDefinitions().Create(crd)
 
 		if apierrors.IsAlreadyExists(err) {
 			fmt.Println("CRD already exists")
@@ -52,7 +52,7 @@ func EnsureCreation(config *rest.Config, deployDir string) error {
 	return nil
 }
 
-func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
+func marshalCRDFromYAMLBytes(bytes []byte, crd *apiextensionsv1.CustomResourceDefinition) error {
 	jsonBytes, err := yaml.YAMLToJSON(bytes)
 	if err != nil {
 		return err

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -1,17 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mongodb.mongodb.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Current state of the MongoDB deployment
-    name: Phase
-    type: string
-  - JSONPath: .status.version
-    description: Version of MongoDB server
-    name: Version
-    type: string
   group: mongodb.com
   names:
     kind: MongoDB
@@ -21,61 +12,69 @@ spec:
     - mdb
     singular: mongodb
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MongoDB is the Schema for the mongodbs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MongoDBSpec defines the desired state of MongoDB
-          properties:
-            featureCompatibilityVersion:
-              description: FeatureCompatibilityVersion configures the feature compatibility
-                version that will be set for the deployment
-              type: string
-            members:
-              description: Members is the number of members in the replica set
-              type: integer
-            type:
-              description: Type defines which type of MongoDB deployment the resource
-                should create
-              enum:
-              - ReplicaSet
-              type: string
-            version:
-              description: Version defines which version of MongoDB will be used
-              type: string
-          required:
-          - type
-          - version
-          type: object
-        status:
-          description: MongoDBStatus defines the observed state of MongoDB
-          properties:
-            mongoUri:
-              type: string
-            phase:
-              type: string
-          required:
-          - mongoUri
-          - phase
-          type: object
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Version of MongoDB server
+      jsonPath: .status.version
+      name: Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: MongoDB is the Schema for the mongodbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MongoDBSpec defines the desired state of MongoDB
+            properties:
+              featureCompatibilityVersion:
+                description: FeatureCompatibilityVersion configures the feature compatibility
+                  version that will be set for the deployment
+                type: string
+              members:
+                description: Members is the number of members in the replica set
+                type: integer
+              type:
+                description: Type defines which type of MongoDB deployment the resource
+                  should create
+                enum:
+                - ReplicaSet
+                type: string
+              version:
+                description: Version defines which version of MongoDB will be used
+                type: string
+            required:
+            - type
+            - version
+            type: object
+          status:
+            description: MongoDBStatus defines the observed state of MongoDB
+            properties:
+              mongoUri:
+                type: string
+              phase:
+                type: string
+            required:
+            - mongoUri
+            - phase
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/scripts/dev/build_and_deploy_operator.py
+++ b/scripts/dev/build_and_deploy_operator.py
@@ -44,7 +44,7 @@ def _ensure_crds():
     """
     ensure_crds makes sure that all the required CRDs have been created
     """
-    crdv1 = client.ApiextensionsV1beta1Api()
+    crdv1 = client.ApiextensionsV1Api()
     crd = _load_mongodb_crd()
 
     k8s_conditions.ignore_if_doesnt_exist(

--- a/scripts/dev/templates/Dockerfile.template
+++ b/scripts/dev/templates/Dockerfile.template
@@ -8,7 +8,7 @@ FROM {{base_image}}
 {% block packages -%}
 {% endblock -%}
 
-ENV OPERATOR_SDK_VERSION v0.17.0
+ENV OPERATOR_SDK_VERSION v0.18.0
 ENV GO111MODULE=on
 ENV GOPATH ""
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Since Kubernetes 1.16, CRDs are GA and the API version has been updated to `apiextensions.k8s.io/v1`. We are still using apiextensions.k8s.io/v1beta1 which according to this PR will be deprecated in the upcoming 1.19.

Operator SDK 0.18 now generates this version by default and the latest version was used (0.18.1) for this PR.