### PR TITLE
CLOUDP-65806: Add TLS/SSL settings to automation config

### DIFF
--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -83,6 +83,9 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 		Args26: Args26{
 			Net: Net{
 				Port: 27017,
+				SSL: MongoDBSSL{
+					Mode: SSLModeDisabled,
+				},
 			},
 			Storage: Storage{
 				DBPath: DefaultMongoDBDataDir,
@@ -127,7 +130,24 @@ type Args26 struct {
 }
 
 type Net struct {
-	Port int `json:"port"`
+	Port int        `json:"port"`
+	SSL  MongoDBSSL `json:"ssl"`
+}
+
+type SSLMode string
+
+const (
+	SSLModeDisabled  SSLMode = "disabled"
+	SSLModeAllowed           = "allowSSL"
+	SSLModePreferred         = "preferSSL"
+	SSLModeRequired          = "requireSSL"
+)
+
+type MongoDBSSL struct {
+	Mode                               SSLMode `json:"mode"`
+	PEMKeyFile                         string  `json:"PEMKeyFile,omitempty"`
+	CAFile                             string  `json:"CAFile,omitempty"`
+	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
 }
 
 type Security struct {
@@ -158,11 +178,24 @@ func newReplicaSetMember(p Process, id int) ReplicaSetMember {
 	}
 }
 
+type ClientCertificateMode string
+
+const (
+	ClientCertificateModeOptional ClientCertificateMode = "OPTIONAL"
+	ClientCertificateModeRequired                       = "REQUIRED"
+)
+
+type SSL struct {
+	CAFilePath            string                `json:"CAFilePath"`
+	ClientCertificateMode ClientCertificateMode `json:"clientCertificateMode"`
+}
+
 type AutomationConfig struct {
 	Version     int          `json:"version"`
 	Processes   []Process    `json:"processes"`
 	ReplicaSets []ReplicaSet `json:"replicaSets"`
 	Auth        Auth         `json:"auth"`
+	SSL         SSL          `json:"ssl"`
 
 	Versions []MongoDbVersionConfig `json:"mongoDbVersions"`
 	Options  Options                `json:"options"`

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -83,8 +83,8 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 		Args26: Args26{
 			Net: Net{
 				Port: 27017,
-				SSL: MongoDBSSL{
-					Mode: SSLModeDisabled,
+				TLS: MongoDBTLS{
+					Mode: TLSModeDisabled,
 				},
 			},
 			Storage: Storage{
@@ -131,21 +131,21 @@ type Args26 struct {
 
 type Net struct {
 	Port int        `json:"port"`
-	SSL  MongoDBSSL `json:"ssl"`
+	TLS  MongoDBTLS `json:"tls"`
 }
 
-type SSLMode string
+type TLSMode string
 
 const (
-	SSLModeDisabled  SSLMode = "disabled"
-	SSLModeAllowed   SSLMode = "allowSSL"
-	SSLModePreferred SSLMode = "preferSSL"
-	SSLModeRequired  SSLMode = "requireSSL"
+	TLSModeDisabled  TLSMode = "disabled"
+	TLSModeAllowed   TLSMode = "allowTLS"
+	TLSModePreferred TLSMode = "preferTLS"
+	TLSModeRequired  TLSMode = "requireTLS"
 )
 
-type MongoDBSSL struct {
-	Mode                               SSLMode `json:"mode"`
-	PEMKeyFile                         string  `json:"PEMKeyFile,omitempty"`
+type MongoDBTLS struct {
+	Mode                               TLSMode `json:"mode"`
+	CertificateKeyFile                 string  `json:"certificateKeyFile,omitempty"`
 	CAFile                             string  `json:"CAFile,omitempty"`
 	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
 }
@@ -185,7 +185,7 @@ const (
 	ClientCertificateModeRequired                       = "REQUIRED"
 )
 
-type SSL struct {
+type TLS struct {
 	CAFilePath            string                `json:"CAFilePath"`
 	ClientCertificateMode ClientCertificateMode `json:"clientCertificateMode"`
 }
@@ -195,7 +195,7 @@ type AutomationConfig struct {
 	Processes   []Process    `json:"processes"`
 	ReplicaSets []ReplicaSet `json:"replicaSets"`
 	Auth        Auth         `json:"auth"`
-	SSL         SSL          `json:"ssl"`
+	TLS         TLS          `json:"tls"`
 
 	Versions []MongoDbVersionConfig `json:"mongoDbVersions"`
 	Options  Options                `json:"options"`

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -138,9 +138,9 @@ type SSLMode string
 
 const (
 	SSLModeDisabled  SSLMode = "disabled"
-	SSLModeAllowed           = "allowSSL"
-	SSLModePreferred         = "preferSSL"
-	SSLModeRequired          = "requireSSL"
+	SSLModeAllowed   SSLMode = "allowSSL"
+	SSLModePreferred SSLMode = "preferSSL"
+	SSLModeRequired  SSLMode = "requireSSL"
 )
 
 type MongoDBSSL struct {

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -83,8 +83,8 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 		Args26: Args26{
 			Net: Net{
 				Port: 27017,
-				TLS: MongoDBTLS{
-					Mode: TLSModeDisabled,
+				SSL: MongoDBSSL{
+					Mode: SSLModeDisabled,
 				},
 			},
 			Storage: Storage{
@@ -131,21 +131,21 @@ type Args26 struct {
 
 type Net struct {
 	Port int        `json:"port"`
-	TLS  MongoDBTLS `json:"tls"`
+	SSL  MongoDBSSL `json:"ssl"`
 }
 
-type TLSMode string
+type SSLMode string
 
 const (
-	TLSModeDisabled  TLSMode = "disabled"
-	TLSModeAllowed   TLSMode = "allowTLS"
-	TLSModePreferred TLSMode = "preferTLS"
-	TLSModeRequired  TLSMode = "requireTLS"
+	SSLModeDisabled  SSLMode = "disabled"
+	SSLModeAllowed   SSLMode = "allowSSL"
+	SSLModePreferred SSLMode = "preferSSL"
+	SSLModeRequired  SSLMode = "requireSSL"
 )
 
-type MongoDBTLS struct {
-	Mode                               TLSMode `json:"mode"`
-	CertificateKeyFile                 string  `json:"certificateKeyFile,omitempty"`
+type MongoDBSSL struct {
+	Mode                               SSLMode `json:"mode"`
+	PEMKeyFile                         string  `json:"PEMKeyFile,omitempty"`
 	CAFile                             string  `json:"CAFile,omitempty"`
 	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
 }
@@ -185,7 +185,7 @@ const (
 	ClientCertificateModeRequired                       = "REQUIRED"
 )
 
-type TLS struct {
+type SSL struct {
 	CAFilePath            string                `json:"CAFilePath"`
 	ClientCertificateMode ClientCertificateMode `json:"clientCertificateMode"`
 }
@@ -195,7 +195,7 @@ type AutomationConfig struct {
 	Processes   []Process    `json:"processes"`
 	ReplicaSets []ReplicaSet `json:"replicaSets"`
 	Auth        Auth         `json:"auth"`
-	TLS         TLS          `json:"tls"`
+	SSL         SSL          `json:"ssl"`
 
 	Versions []MongoDbVersionConfig `json:"mongoDbVersions"`
 	Options  Options                `json:"options"`

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -26,7 +26,7 @@ type Builder struct {
 	previousAC        AutomationConfig
 	tlsCAFile         string
 	tlsCertAndKeyFile string
-	tlsMode           TLSMode
+	tlsMode           SSLMode
 	// MongoDB installable versions
 	versions []MongoDbVersionConfig
 }
@@ -64,7 +64,7 @@ func (b *Builder) SetFCV(fcv string) *Builder {
 	return b
 }
 
-func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode TLSMode) *Builder {
+func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode SSLMode) *Builder {
 	b.tlsCAFile = caFile
 	b.tlsCertAndKeyFile = certAndKeyFile
 	b.tlsMode = mode
@@ -72,7 +72,7 @@ func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode TLSMode) *Builder {
 }
 
 func (b *Builder) isTLSEnabled() bool {
-	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != TLSModeDisabled
+	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != SSLModeDisabled
 }
 
 func (b *Builder) AddVersion(version MongoDbVersionConfig) *Builder {
@@ -130,7 +130,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		Versions: b.versions,
 		Options:  Options{DownloadBase: "/var/lib/mongodb-mms-automation"},
 		Auth:     DisabledAuth(),
-		TLS: TLS{
+		SSL: SSL{
 			ClientCertificateMode: ClientCertificateModeOptional,
 		},
 	}
@@ -138,7 +138,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 	// Set up TLS between agent and server
 	// Agent needs to trust the certificate presented by the server
 	if b.isTLSEnabled() {
-		currentAc.TLS.CAFilePath = b.tlsCAFile
+		currentAc.SSL.CAFilePath = b.tlsCAFile
 	}
 
 	// Here we compare the bytes of the two automationconfigs,
@@ -174,12 +174,12 @@ func withFCV(fcv string) func(*Process) {
 }
 
 // withTLS enables TLS for the mongod process
-func withTLS(caFile, tlsKeyFile string, mode TLSMode) func(*Process) {
+func withTLS(caFile, tlsKeyFile string, mode SSLMode) func(*Process) {
 	return func(process *Process) {
-		process.Args26.Net.TLS = MongoDBTLS{
+		process.Args26.Net.SSL = MongoDBSSL{
 			Mode:                               mode,
 			CAFile:                             caFile,
-			CertificateKeyFile:                 tlsKeyFile,
+			PEMKeyFile:                         tlsKeyFile,
 			AllowConnectionsWithoutCertificate: true,
 		}
 	}

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -26,7 +26,7 @@ type Builder struct {
 	previousAC        AutomationConfig
 	tlsCAFile         string
 	tlsCertAndKeyFile string
-	tlsMode           SSLMode
+	tlsMode           TLSMode
 	// MongoDB installable versions
 	versions []MongoDbVersionConfig
 }
@@ -64,7 +64,7 @@ func (b *Builder) SetFCV(fcv string) *Builder {
 	return b
 }
 
-func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode SSLMode) *Builder {
+func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode TLSMode) *Builder {
 	b.tlsCAFile = caFile
 	b.tlsCertAndKeyFile = certAndKeyFile
 	b.tlsMode = mode
@@ -72,7 +72,7 @@ func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode SSLMode) *Builder {
 }
 
 func (b *Builder) isTLSEnabled() bool {
-	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != SSLModeDisabled
+	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != TLSModeDisabled
 }
 
 func (b *Builder) AddVersion(version MongoDbVersionConfig) *Builder {
@@ -130,7 +130,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		Versions: b.versions,
 		Options:  Options{DownloadBase: "/var/lib/mongodb-mms-automation"},
 		Auth:     DisabledAuth(),
-		SSL: SSL{
+		TLS: TLS{
 			ClientCertificateMode: ClientCertificateModeOptional,
 		},
 	}
@@ -138,7 +138,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 	// Set up TLS between agent and server
 	// Agent needs to trust the certificate presented by the server
 	if b.isTLSEnabled() {
-		currentAc.SSL.CAFilePath = b.tlsCAFile
+		currentAc.TLS.CAFilePath = b.tlsCAFile
 	}
 
 	// Here we compare the bytes of the two automationconfigs,
@@ -174,12 +174,12 @@ func withFCV(fcv string) func(*Process) {
 }
 
 // withTLS enables TLS for the mongod process
-func withTLS(caFile, tlsKeyFile string, mode SSLMode) func(*Process) {
+func withTLS(caFile, tlsKeyFile string, mode TLSMode) func(*Process) {
 	return func(process *Process) {
-		process.Args26.Net.SSL = MongoDBSSL{
+		process.Args26.Net.TLS = MongoDBTLS{
 			Mode:                               mode,
 			CAFile:                             caFile,
-			PEMKeyFile:                         tlsKeyFile,
+			CertificateKeyFile:                 tlsKeyFile,
 			AllowConnectionsWithoutCertificate: true,
 		}
 	}

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -72,7 +72,7 @@ func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode SSLMode) *Builder {
 }
 
 func (b *Builder) isTLSEnabled() bool {
-	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != ""
+	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != SSLModeDisabled
 }
 
 func (b *Builder) AddVersion(version MongoDbVersionConfig) *Builder {

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -41,14 +41,14 @@ func TestBuildAutomationConfig(t *testing.T) {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
 		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Storage.DBPath)
-		assert.Equal(t, SSLModeDisabled, p.Args26.Net.SSL.Mode)
+		assert.Equal(t, TLSModeDisabled, p.Args26.Net.TLS.Mode)
 		assert.Equal(t, "my-rs", p.Args26.Replication.ReplicaSetName, "replication should be configured based on the replica set name provided")
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
 	}
 
-	assert.Empty(t, ac.SSL.CAFilePath, "the config shouldn't have a trusted CA")
+	assert.Empty(t, ac.TLS.CAFilePath, "the config shouldn't have a trusted CA")
 
 	assert.Len(t, ac.ReplicaSets, 1)
 	rs := ac.ReplicaSets[0]
@@ -179,7 +179,7 @@ func TestVersionManifest_BuildsForVersion(t *testing.T) {
 func TestTLS(t *testing.T) {
 	caPath := "/path/to/ca"
 	certAndKeyPath := "/path/to/cert"
-	mode := SSLModeRequired
+	mode := TLSModeRequired
 
 	ac, err := NewBuilder().
 		SetName("my-rs").
@@ -195,13 +195,13 @@ func TestTLS(t *testing.T) {
 
 	// Ensure every process has TLS configured
 	for _, p := range ac.Processes {
-		assert.Equal(t, mode, p.Args26.Net.SSL.Mode)
-		assert.Equal(t, caPath, p.Args26.Net.SSL.CAFile)
-		assert.Equal(t, certAndKeyPath, p.Args26.Net.SSL.PEMKeyFile)
-		assert.True(t, p.Args26.Net.SSL.AllowConnectionsWithoutCertificate)
+		assert.Equal(t, mode, p.Args26.Net.TLS.Mode)
+		assert.Equal(t, caPath, p.Args26.Net.TLS.CAFile)
+		assert.Equal(t, certAndKeyPath, p.Args26.Net.TLS.CertificateKeyFile)
+		assert.True(t, p.Args26.Net.TLS.AllowConnectionsWithoutCertificate)
 	}
 
 	// Ensure the CA was configured as trusted for the agent
-	assert.Equal(t, caPath, ac.SSL.CAFilePath)
-	assert.Equal(t, ClientCertificateModeOptional, ac.SSL.ClientCertificateMode)
+	assert.Equal(t, caPath, ac.TLS.CAFilePath)
+	assert.Equal(t, ClientCertificateModeOptional, ac.TLS.ClientCertificateMode)
 }

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -25,7 +25,6 @@ func defaultMongoDbVersion(version string) MongoDbVersionConfig {
 }
 
 func TestBuildAutomationConfig(t *testing.T) {
-
 	ac, err := NewBuilder().
 		SetName("my-rs").
 		SetDomain("my-ns.svc.cluster.local").
@@ -42,11 +41,14 @@ func TestBuildAutomationConfig(t *testing.T) {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
 		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Storage.DBPath)
+		assert.Equal(t, SSLModeDisabled, p.Args26.Net.SSL.Mode)
 		assert.Equal(t, "my-rs", p.Args26.Replication.ReplicaSetName, "replication should be configured based on the replica set name provided")
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
 	}
+
+	assert.Empty(t, ac.SSL.CAFilePath, "the config shouldn't have a trusted CA")
 
 	assert.Len(t, ac.ReplicaSets, 1)
 	rs := ac.ReplicaSets[0]
@@ -62,7 +64,6 @@ func TestBuildAutomationConfig(t *testing.T) {
 }
 
 func TestMongoDbVersions(t *testing.T) {
-
 	ac, err := NewBuilder().
 		SetName("my-rs").
 		SetDomain("my-ns.svc.cluster.local").
@@ -173,4 +174,34 @@ func TestVersionManifest_BuildsForVersion(t *testing.T) {
 
 	version = vm.BuildsForVersion("4.2.1")
 	assert.Empty(t, version.Builds)
+}
+
+func TestTLS(t *testing.T) {
+	caPath := "/path/to/ca"
+	certAndKeyPath := "/path/to/cert"
+	mode := SSLModeRequired
+
+	ac, err := NewBuilder().
+		SetName("my-rs").
+		SetDomain("my-ns.svc.cluster.local").
+		SetMongoDBVersion("4.2.0").
+		SetMembers(3).
+		SetFCV("4.0").
+		SetTLS(caPath, certAndKeyPath, mode).
+		Build()
+
+	assert.NoError(t, err)
+	assert.Len(t, ac.Processes, 3)
+
+	// Ensure every process has TLS configured
+	for _, p := range ac.Processes {
+		assert.Equal(t, mode, p.Args26.Net.SSL.Mode)
+		assert.Equal(t, caPath, p.Args26.Net.SSL.CAFile)
+		assert.Equal(t, certAndKeyPath, p.Args26.Net.SSL.PEMKeyFile)
+		assert.True(t, p.Args26.Net.SSL.AllowConnectionsWithoutCertificate)
+	}
+
+	// Ensure the CA was configured as trusted for the agent
+	assert.Equal(t, caPath, ac.SSL.CAFilePath)
+	assert.Equal(t, ClientCertificateModeOptional, ac.SSL.ClientCertificateMode)
 }

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -205,3 +205,26 @@ func TestTLS(t *testing.T) {
 	assert.Equal(t, caPath, ac.SSL.CAFilePath)
 	assert.Equal(t, ClientCertificateModeOptional, ac.SSL.ClientCertificateMode)
 }
+
+func TestTLSIsEnabled(t *testing.T) {
+	// TLS should only be considered enabled if both a CA cert, a cert-key file and a non-disabled mode are set
+	builder := NewBuilder().
+		SetTLS("", "", SSLModeRequired)
+	assert.False(t, builder.isTLSEnabled())
+
+	builder = NewBuilder().
+		SetTLS("/path", "", SSLModeRequired)
+	assert.False(t, builder.isTLSEnabled())
+
+	builder = NewBuilder().
+		SetTLS("", "/path", SSLModeRequired)
+	assert.False(t, builder.isTLSEnabled())
+
+	builder = NewBuilder().
+		SetTLS("/path", "/path", SSLModeDisabled)
+	assert.False(t, builder.isTLSEnabled())
+
+	builder = NewBuilder().
+		SetTLS("/path", "/path", SSLModeRequired)
+	assert.True(t, builder.isTLSEnabled())
+}

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -41,14 +41,14 @@ func TestBuildAutomationConfig(t *testing.T) {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
 		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Storage.DBPath)
-		assert.Equal(t, TLSModeDisabled, p.Args26.Net.TLS.Mode)
+		assert.Equal(t, SSLModeDisabled, p.Args26.Net.SSL.Mode)
 		assert.Equal(t, "my-rs", p.Args26.Replication.ReplicaSetName, "replication should be configured based on the replica set name provided")
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
 	}
 
-	assert.Empty(t, ac.TLS.CAFilePath, "the config shouldn't have a trusted CA")
+	assert.Empty(t, ac.SSL.CAFilePath, "the config shouldn't have a trusted CA")
 
 	assert.Len(t, ac.ReplicaSets, 1)
 	rs := ac.ReplicaSets[0]
@@ -179,7 +179,7 @@ func TestVersionManifest_BuildsForVersion(t *testing.T) {
 func TestTLS(t *testing.T) {
 	caPath := "/path/to/ca"
 	certAndKeyPath := "/path/to/cert"
-	mode := TLSModeRequired
+	mode := SSLModeRequired
 
 	ac, err := NewBuilder().
 		SetName("my-rs").
@@ -195,13 +195,13 @@ func TestTLS(t *testing.T) {
 
 	// Ensure every process has TLS configured
 	for _, p := range ac.Processes {
-		assert.Equal(t, mode, p.Args26.Net.TLS.Mode)
-		assert.Equal(t, caPath, p.Args26.Net.TLS.CAFile)
-		assert.Equal(t, certAndKeyPath, p.Args26.Net.TLS.CertificateKeyFile)
-		assert.True(t, p.Args26.Net.TLS.AllowConnectionsWithoutCertificate)
+		assert.Equal(t, mode, p.Args26.Net.SSL.Mode)
+		assert.Equal(t, caPath, p.Args26.Net.SSL.CAFile)
+		assert.Equal(t, certAndKeyPath, p.Args26.Net.SSL.PEMKeyFile)
+		assert.True(t, p.Args26.Net.SSL.AllowConnectionsWithoutCertificate)
 	}
 
 	// Ensure the CA was configured as trusted for the agent
-	assert.Equal(t, caPath, ac.TLS.CAFilePath)
-	assert.Equal(t, ClientCertificateModeOptional, ac.TLS.ClientCertificateMode)
+	assert.Equal(t, caPath, ac.SSL.CAFilePath)
+	assert.Equal(t, ClientCertificateModeOptional, ac.SSL.ClientCertificateMode)
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

This PR adds the settings necessary to implement TLS/SSL to the automation config. It only adds the old `ssl` fields and not the new `tls` fields in 4.2. This will be fixed in a later PR.