### PR TITLE
CLOUDP-65917: Fix pre-stop hook status check

### DIFF
--- a/cmd/prestop/main.go
+++ b/cmd/prestop/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/agenthealth"
 	"go.uber.org/zap"
@@ -22,18 +23,177 @@ var logger *zap.SugaredLogger
 const (
 	agentStatusFilePathEnv = "AGENT_STATUS_FILEPATH"
 	logFilePathEnv         = "PRE_STOP_HOOK_LOG_PATH"
-	defaultNamespace       = "default"
+
+	defaultNamespace = "default"
+
+	pollingInterval time.Duration = 1 * time.Second
+	pollingDuration time.Duration = 30 * time.Second
 )
 
-func getNamespace() (string, error) {
-	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+func main() {
+	fmt.Println("Calling pre-stop hook!")
+
+	if err := ensureEnvironmentVariables(logFilePathEnv, agentStatusFilePathEnv); err != nil {
+		zap.S().Fatal("Not all required environment variables are present: %s", err)
+		os.Exit(1)
+	}
+
+	logger := setupLogger()
+
+	logger.Info("Waiting for agent health status...")
+	health, err := waitForAgentHealthStatus()
 	if err != nil {
-		return "", err
+		logger.Errorf("Error getting the agent health file: %s", err)
 	}
-	if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-		return ns, nil
+
+	shouldDelete, err := shouldDeletePod(health)
+	if err != nil {
+		logger.Errorf("Error checking if pod should be deleted: %s", err)
 	}
-	return defaultNamespace, nil
+
+	if shouldDelete {
+		logger.Infof("Pod should be deleted")
+		if err := deletePod(); err != nil {
+			// We should not raise an error if the Pod could not be deleted. It can have even
+			// worst consequences: Pod being restarted with the same version, and the agent
+			// killing it immediately after.
+			logger.Errorf("Could not manually trigger restart of this Pod because of: %s", err)
+			logger.Errorf("Make sure the Pod is restarted in order for the upgrade process to continue")
+		}
+
+		// If the Pod needs to be killed, we'll wait until the Pod
+		// is killed by Kubernetes, bringing the new container image
+		// into play.
+		var quit = make(chan struct{})
+		logger.Info("A Pod killed itself, waiting...")
+		<-quit
+	} else {
+		logger.Info("Pod should not be deleted, container will restart...")
+	}
+}
+
+func ensureEnvironmentVariables(requiredEnvVars ...string) error {
+	var missingEnvVars []string
+	for _, envVar := range requiredEnvVars {
+		if val := os.Getenv(envVar); val == "" {
+			missingEnvVars = append(missingEnvVars, envVar)
+		}
+	}
+	if len(missingEnvVars) > 0 {
+		return fmt.Errorf("missing envars: %s", strings.Join(missingEnvVars, ","))
+	}
+	return nil
+}
+
+func setupLogger() *zap.SugaredLogger {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.OutputPaths = []string{
+		os.Getenv(logFilePathEnv),
+	}
+	log, err := cfg.Build()
+	if err != nil {
+		zap.S().Errorf("Error building logger config: %s", err)
+		os.Exit(1)
+	}
+
+	return log.Sugar()
+}
+
+// waitForAgentHealthStatus will poll the health status file and wait for it to be updated.
+// The agent doesn't write the plan to the file right away and hence we need to wait for the
+// latest plan to be written.
+func waitForAgentHealthStatus() (agenthealth.Health, error) {
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+	totalTime := time.Duration(0)
+	for {
+		select {
+		case <-ticker.C:
+			if totalTime > pollingDuration {
+				return agenthealth.Health{}, fmt.Errorf("agenth health status not ready after waiting %s", pollingDuration.String())
+			}
+			totalTime += pollingInterval
+
+			health, err := getAgentHealthStatus()
+			if err != nil {
+				return agenthealth.Health{}, err
+			}
+
+			status, ok := health.Healthiness[getHostname()]
+			if !ok {
+				return agenthealth.Health{}, fmt.Errorf("couldn't find status for hostname %s", getHostname())
+			}
+
+			// We determine if the file has been updated by checking if the process is not in goal state.
+			// As the agent is currently executing a plan, the process should not be in goal state.
+			if !status.IsInGoalState {
+				return health, nil
+			}
+		}
+	}
+}
+
+// getAgentHealthStatus returns an instance of agenthealth.Health read
+// from the health file on disk
+func getAgentHealthStatus() (agenthealth.Health, error) {
+	f, err := os.Open(os.Getenv(agentStatusFilePathEnv))
+	if err != nil {
+		return agenthealth.Health{}, fmt.Errorf("error opening file: %s", err)
+	}
+	defer f.Close()
+
+	h, err := readAgentHealthStatus(f)
+	if err != nil {
+		return agenthealth.Health{}, fmt.Errorf("error reading health status: %s", err)
+	}
+	return h, err
+}
+
+// readAgentHealthStatus reads an instance of health.Health from the provided
+// io.Reader
+func readAgentHealthStatus(reader io.Reader) (agenthealth.Health, error) {
+	var h agenthealth.Health
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return h, err
+	}
+	err = json.Unmarshal(data, &h)
+	return h, err
+}
+
+func getHostname() string {
+	return os.Getenv("HOSTNAME")
+}
+
+// shouldDeletePod returns a boolean value indicating if this pod should be deleted
+// this would be the case if the agent is currently trying to upgrade the version
+// of mongodb.
+func shouldDeletePod(health agenthealth.Health) (bool, error) {
+	status, ok := health.ProcessPlans[getHostname()]
+	if !ok {
+		return false, fmt.Errorf("hostname %s was not in the process plans", getHostname())
+	}
+	return isWaitingToBeDeleted(status), nil
+}
+
+// isWaitingToBeDeleted determines if the agent is currently waiting
+// on the mongod pod to be restarted. In order to do this, we need to check the agent
+// status file and determine if the mongod has been stopped and if we are in the process
+// of a version change.
+func isWaitingToBeDeleted(healthStatus agenthealth.MmsDirectorStatus) bool {
+	if len(healthStatus.Plans) == 0 {
+		return false
+	}
+	lastPlan := healthStatus.Plans[len(healthStatus.Plans)-1]
+	for _, m := range lastPlan.Moves {
+		// When changing version the plan will contain a "ChangeVersion" step
+		switch m.Move {
+		case "ChangeVersion":
+			return true
+		}
+	}
+	return false
 }
 
 // deletePod attempts to delete the pod this mongod is running in
@@ -53,59 +213,9 @@ func deletePod() error {
 	return nil
 }
 
-func inClusterClient() (client.Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("error getting cluster config: %+v", err)
-	}
-
-	k8sClient, err := client.New(config, client.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("error creating client: %+v", err)
-	}
-	return k8sClient, nil
-}
-
-func prettyPrint(i interface{}) {
-	b, err := json.MarshalIndent(i, "", "  ")
-	if err != nil {
-		fmt.Println("error:", err)
-	}
-	fmt.Println(string(b))
-}
-
-// shouldDeletePod returns a boolean value indicating if this pod should be deleted
-// this would be the case if the agent is currently trying to upgrade the version
-// of mongodb.
-func shouldDeletePod(health agenthealth.Health) (bool, error) {
-	hostname := os.Getenv("HOSTNAME")
-	status, ok := health.ProcessPlans[hostname]
-	if !ok {
-		return false, fmt.Errorf("hostname %s was not in the process plans", hostname)
-	}
-	return isWaitingToBeDeleted(status), nil
-}
-
-// getAgentHealthStatus returns an instance of agenthealth.Health read
-// from the health file on disk
-func getAgentHealthStatus() (agenthealth.Health, error) {
-	f, err := os.Open(os.Getenv(agentStatusFilePathEnv))
-	if err != nil {
-		return agenthealth.Health{}, fmt.Errorf("error opening file: %s", err)
-	}
-	defer f.Close()
-
-	h, err := readAgentHealthStatus(f)
-	if err != nil {
-		return agenthealth.Health{}, fmt.Errorf("error reading health status: %s", err)
-	}
-	return h, err
-
-}
-
 // getThisPod returns an instance of corev1.Pod that points to the current pod
 func getThisPod() (corev1.Pod, error) {
-	podName := os.Getenv("HOSTNAME")
+	podName := getHostname()
 	if podName == "" {
 		return corev1.Pod{}, fmt.Errorf("environment variable HOSTNAME was not present")
 	}
@@ -123,104 +233,26 @@ func getThisPod() (corev1.Pod, error) {
 	}, nil
 }
 
-// readAgentHealthStatus reads an instance of health.Health from the provided
-// io.Reader
-func readAgentHealthStatus(reader io.Reader) (agenthealth.Health, error) {
-	var h agenthealth.Health
-	data, err := ioutil.ReadAll(reader)
+func inClusterClient() (client.Client, error) {
+	config, err := rest.InClusterConfig()
 	if err != nil {
-		return h, err
+		return nil, fmt.Errorf("error getting cluster config: %+v", err)
 	}
-	err = json.Unmarshal(data, &h)
-	return h, err
+
+	k8sClient, err := client.New(config, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %+v", err)
+	}
+	return k8sClient, nil
 }
 
-func ensureEnvironmentVariables(requiredEnvVars ...string) error {
-	var missingEnvVars []string
-	for _, envVar := range requiredEnvVars {
-		if val := os.Getenv(envVar); val == "" {
-			missingEnvVars = append(missingEnvVars, envVar)
-		}
-	}
-	if len(missingEnvVars) > 0 {
-		return fmt.Errorf("missing envars: %s", strings.Join(missingEnvVars, ","))
-	}
-	return nil
-}
-
-func main() {
-	fmt.Println("Calling pre-stop hook!")
-	cfg := zap.NewDevelopmentConfig()
-	if err := ensureEnvironmentVariables(logFilePathEnv, agentStatusFilePathEnv); err != nil {
-		zap.S().Fatal("Not all required environment variables are present: %s", err)
-		os.Exit(1)
-	}
-	cfg.OutputPaths = []string{
-		os.Getenv(logFilePathEnv),
-	}
-	log, err := cfg.Build()
+func getNamespace() (string, error) {
+	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
-		zap.S().Errorf("Error building logger config: %s", err)
-		os.Exit(1)
+		return "", err
 	}
-	logger = log.Sugar()
-	health, err := getAgentHealthStatus()
-	if err != nil {
-		logger.Errorf("Error getting the agent health file: %s", err)
+	if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+		return ns, nil
 	}
-
-	shouldDelete, err := shouldDeletePod(health)
-	logger.Debugf("shouldDeletePod=%t", shouldDelete)
-	if err != nil {
-		logger.Errorf("Error in shouldDeletePod: %s", err)
-	}
-
-	if shouldDelete {
-		if err := deletePod(); err != nil {
-			// We should not raise an error if the Pod could not be deleted. It can have even
-			// worst consequences: Pod being restarted with the same version, and the agent
-			// killing it immediately after.
-			logger.Errorf("Could not manually trigger restart of this Pod because of: %s", err)
-			logger.Errorf("Make sure the Pod is restarted in order for the upgrade process to continue")
-		}
-
-		// If the Pod needs to be killed, we'll wait until the Pod
-		// is killed by Kubernetes, bringing the new container image
-		// into play.
-		var quit = make(chan struct{})
-		logger.Info("A Pod killed itself, waiting...")
-		<-quit
-	}
-}
-
-// isWaitingToBeDeleted determines if the agent is currently waiting
-// on the mongod pod to be restarted. In order to do this, we need to check the agent
-// status file and determine if the mongod has been stopped and if we are in the process
-// of a version change.
-func isWaitingToBeDeleted(healthStatus agenthealth.MmsDirectorStatus) bool {
-	if len(healthStatus.Plans) == 0 {
-		return false
-	}
-	lastPlan := healthStatus.Plans[len(healthStatus.Plans)-1]
-	for _, m := range lastPlan.Moves {
-
-		// The next conditions are based on observations on the outcome
-		// of the agent after they have stopped the mongo server.
-
-		switch m.Move {
-		case "WaitFeatureCompatibilityVersionCorrect":
-			// First condition observed. This is the Plan reported by the
-			// agent on the first MongoD stopped.
-			for _, s := range m.Steps {
-				if s.Step == "WaitFeatureCompatibilityVersionCorrect" &&
-					s.Result == "" {
-					return true
-				}
-			}
-		case "ChangeVersion":
-			// This is the condition observed in the 2nd and 3rd Pods.
-			return true
-		}
-	}
-	return false
+	return defaultNamespace, nil
 }

--- a/cmd/prestop/main.go
+++ b/cmd/prestop/main.go
@@ -188,8 +188,7 @@ func isWaitingToBeDeleted(healthStatus agenthealth.MmsDirectorStatus) bool {
 	lastPlan := healthStatus.Plans[len(healthStatus.Plans)-1]
 	for _, m := range lastPlan.Moves {
 		// When changing version the plan will contain a "ChangeVersion" step
-		switch m.Move {
-		case "ChangeVersion":
+		if m.Move == "ChangeVersion" {
 			return true
 		}
 	}

--- a/cmd/prestop/main.go
+++ b/cmd/prestop/main.go
@@ -27,7 +27,7 @@ const (
 	defaultNamespace = "default"
 
 	pollingInterval time.Duration = 1 * time.Second
-	pollingDuration time.Duration = 30 * time.Second
+	pollingDuration time.Duration = 60 * time.Second
 )
 
 func main() {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Before this PR, our pre-stop hook couldn't correctly identify a version change and would restart the pod for all automation config changes. This was because the hook would check for a `WaitFeatureCompatibilityVersionCorrect` move in the automation plan. Unfortunately, this move is used for most automation config changes and not just version changes.

After talking with the agent team, we came to the conclusion that it should be possible to only look for the `ChangeVersion` move. The reason this hadn't worked until now was that the agent wouldn't immediately write the plan to file and the hook would hence read an outdated version of the health status.

With this PR, we change the hook to wait until the health status file has been updated and the latest plan is available. We do this by polling the file and checking if the process is in goal state. If it is not, that indicates that the agent is in the middle of executing a new plan and we are ready to inspect it. Based on my testing it takes roughly 5-10 seconds from the hook starting to the health status file being updated, the hook will wait up to 60 seconds.