### PR TITLE
Handle graceful shutdown properly

### DIFF
--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -128,7 +128,7 @@ func NewTestMongoDB(name string) mdbv1.MongoDB {
 		Spec: mdbv1.MongoDBSpec{
 			Members:                     3,
 			Type:                        "ReplicaSet",
-			Version:                     "4.0.6",
+			Version:                     "4.2.6",
 			FeatureCompatibilityVersion: "4.0",
 		},
 	}

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -27,20 +27,20 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 
 	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 3))
-	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
+	// Upgrade version to 4.2.8 while keeping the FCV set to 4.0
 	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
-			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
+			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.8"))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 		},
 	))
 	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
 	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 3))
 
-	// Downgrade version back to 4.0.6, checks that the FeatureCompatibilityVersion stayed at 4.0
+	// Downgrade version back to 4.2.6, checks that the FeatureCompatibilityVersion stayed at 4.0
 	t.Run("MongoDB is reachable while version is downgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
-			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
+			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 		},
 	))

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -29,10 +29,10 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 
 	t.Run("Test FeatureCompatibilityVersion is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 3))
-	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
+	// Upgrade version to 4.2.8 while keeping the FCV set to 4.0
 	t.Run("MongoDB is reachable", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
-			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
+			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.8"))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 			t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
 		},

--- a/test/e2e/replica_set_change_version/replica_set_test.go
+++ b/test/e2e/replica_set_change_version/replica_set_test.go
@@ -38,10 +38,10 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 			Phase:    mdbv1.Running,
 		}))
 
-	// Upgrade version to 4.0.8
+	// Upgrade version to 4.2.8
 	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
-			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.0.8"))
+			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.8"))
 			t.Run("StatefulSet has OnDelete update strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.OnDeleteStatefulSetStrategyType))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 			t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 2))
@@ -50,10 +50,10 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 	))
 	t.Run("StatefulSet has RollingUpgrade restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.RollingUpdateStatefulSetStrategyType))
 
-	// Downgrade version back to 4.0.6
+	// Downgrade version back to 4.2.6
 	t.Run("MongoDB is reachable while version is downgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
-			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
+			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
 			t.Run("StatefulSet has OnDelete restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.OnDeleteStatefulSetStrategyType))
 			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
 			t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

When Kubernetes shuts down a pod it will send a SIGTERM signal to every container and give the process 30 seconds to finish up. The way our mongod container is currently set up, the signal is lost and the `mongod` process is not shutdown gracefully. If that pod is currently the primary this will cause a failure. Since 4.0.8, MongoDB is able to automatically perform a step-down when a primary receives SIGTERM: https://docs.mongodb.com/manual/tutorial/manage-mongodb-processes/#sigterm-and-replica-sets.

Our current setup could cause issues when performing a scale down, deleting a pod, or when performing a rolling update, for example to enable TLS. As we are using a shell script to run `mongod`  we need to trap the signal and forward it to the main process. This PR implements the SIGTERM trapping in bash.

Right now most of our E2E tests are running on version 4.0.6 which doesn't support graceful shutdowns. This problem could explain some flakiness we have experienced with "e2e_test_replica_set_readiness_probe" which deletes a random pod. Because of this, I've also updated all tests to run on 4.2.