### PR TITLE
Fixed OnDelete strategy

### DIFF
--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -21,12 +21,6 @@ const (
 	Running Phase = "Running"
 )
 
-const (
-	// LastVersionAnnotationKey should indicate which version of MongoDB was last
-	// configured
-	LastVersionAnnotationKey = "lastVersion"
-)
-
 // MongoDBSpec defines the desired state of MongoDB
 type MongoDBSpec struct {
 	// Members is the number of members in the replica set
@@ -68,13 +62,6 @@ type MongoDB struct {
 func (m *MongoDB) UpdateSuccess() {
 	m.Status.MongoURI = m.MongoURI()
 	m.Status.Phase = Running
-}
-
-func (m MongoDB) IsChangingVersion() bool {
-	if lastVersion, ok := m.Annotations[LastVersionAnnotationKey]; ok {
-		return (m.Spec.Version != lastVersion) && lastVersion != ""
-	}
-	return false
 }
 
 // MongoURI returns a mongo uri which can be used to connect to this deployment

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -152,7 +152,6 @@ func (r *ReplicaSetReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		r.log.Warnf("Error creating/updating StatefulSet: %+v", err)
 		return reconcile.Result{}, err
 	}
-	//time.Sleep(10 * time.Second)
 
 	currentSts := appsv1.StatefulSet{}
 	if err := r.client.Get(context.TODO(), mdb.NamespacedName(), &currentSts); err != nil {

--- a/pkg/kube/client/mocked_client.go
+++ b/pkg/kube/client/mocked_client.go
@@ -86,10 +86,6 @@ func (m *mockedClient) Update(_ context.Context, obj runtime.Object, _ ...k8sCli
 	if err != nil {
 		return err
 	}
-	switch v := obj.(type) {
-	case *appsv1.StatefulSet:
-		makeStatefulSetReady(v)
-	}
 	relevantMap[objKey] = obj
 	return nil
 }

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/statefulset"
+
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/pkg/apis/mongodb/v1"
 	f "github.com/operator-framework/operator-sdk/pkg/test"
 	appsv1 "k8s.io/api/apps/v1"
@@ -77,15 +79,8 @@ func WaitForStatefulSetToHaveUpdateStrategy(t *testing.T, mdb *mdbv1.MongoDB, st
 // have reached the ready status
 func WaitForStatefulSetToBeReady(t *testing.T, mdb *mdbv1.MongoDB, retryInterval, timeout time.Duration) error {
 	return waitForStatefulSetCondition(t, mdb, retryInterval, timeout, func(sts appsv1.StatefulSet) bool {
-		return sts.Status.ReadyReplicas == int32(mdb.Spec.Members)
-	})
-}
-
-// waitForStatefulSetToBeUpdated waits until all replicas of the StatefulSet with the given name
-// are updated.
-func WaitForStatefulSetToBeUpdated(t *testing.T, mdb *mdbv1.MongoDB, retryInterval, timeout time.Duration) error {
-	return waitForStatefulSetCondition(t, mdb, retryInterval, timeout, func(sts appsv1.StatefulSet) bool {
-		return sts.Status.UpdatedReplicas == int32(mdb.Spec.Members)
+		return statefulset.IsReady(sts, mdb.Spec.Members)
+		//return sts.Status.ReadyReplicas == int32(mdb.Spec.Members)
 	})
 }
 

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -80,7 +80,6 @@ func WaitForStatefulSetToHaveUpdateStrategy(t *testing.T, mdb *mdbv1.MongoDB, st
 func WaitForStatefulSetToBeReady(t *testing.T, mdb *mdbv1.MongoDB, retryInterval, timeout time.Duration) error {
 	return waitForStatefulSetCondition(t, mdb, retryInterval, timeout, func(sts appsv1.StatefulSet) bool {
 		return statefulset.IsReady(sts, mdb.Spec.Members)
-		//return sts.Status.ReadyReplicas == int32(mdb.Spec.Members)
 	})
 }
 

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -31,7 +31,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while version is upgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
 			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
-			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
 		},
 	))
 	t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
@@ -41,7 +41,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while version is downgraded", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
 			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
-			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
 		},
 	))
 	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", mongodbtests.HasFeatureCompatibilityVersion(&mdb, "4.0", 3))

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -33,7 +33,7 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable", mongodbtests.IsReachableDuring(&mdb, time.Second*10,
 		func() {
 			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
-			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
 			t.Run("Test Basic Connectivity after upgrade has completed", mongodbtests.BasicConnectivity(&mdb))
 		},
 	))
@@ -47,7 +47,7 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 				})
 				assert.NoError(t, err)
 			})
-			t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsReady(&mdb))
 			t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 		},
 	))

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -60,23 +60,11 @@ func StatefulSetHasOwnerReference(mdb *mdbv1.MongoDB, expectedOwnerReference met
 	}
 }
 
-// StatefulSetIsUpdated ensures that all the Pods of the StatefulSet are
-// in "Updated" condition.
-func StatefulSetIsUpdated(mdb *mdbv1.MongoDB) func(t *testing.T) {
-	return func(t *testing.T) {
-		err := e2eutil.WaitForStatefulSetToBeUpdated(t, mdb, time.Second*15, time.Minute*5)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Logf("StatefulSet %s/%s is updated!", mdb.Namespace, mdb.Name)
-	}
-}
-
 // StatefulSetHasUpdateStrategy verifies that the StatefulSet holding this MongoDB
 // resource has the correct Update Strategy
 func StatefulSetHasUpdateStrategy(mdb *mdbv1.MongoDB, strategy appsv1.StatefulSetUpdateStrategyType) func(t *testing.T) {
 	return func(t *testing.T) {
-		err := e2eutil.WaitForStatefulSetToHaveUpdateStrategy(t, mdb, appsv1.RollingUpdateStatefulSetStrategyType, time.Second*15, time.Minute*5)
+		err := e2eutil.WaitForStatefulSetToHaveUpdateStrategy(t, mdb, strategy, time.Second*15, time.Minute*5)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -142,8 +130,6 @@ func HasFeatureCompatibilityVersion(mdb *mdbv1.MongoDB, fcv string, tries int) f
 			case <-time.After(10 * time.Second):
 				var result bson.M
 				err = database.RunCommand(ctx, runCommand).Decode(&result)
-				assert.NoError(t, err)
-
 				expected := primitive.M{"version": fcv}
 				if reflect.DeepEqual(expected, result["featureCompatibilityVersion"]) {
 					found = true

--- a/test/e2e/replica_set_change_version/replica_set_test.go
+++ b/test/e2e/replica_set_change_version/replica_set_test.go
@@ -43,9 +43,8 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 		func() {
 			t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.0.8"))
 			t.Run("StatefulSet has OnDelete update strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.OnDeleteStatefulSetStrategyType))
-			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
 			t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 2))
-
 		},
 	))
 	t.Run("StatefulSet has RollingUpgrade restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.RollingUpdateStatefulSetStrategyType))
@@ -55,9 +54,8 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 		func() {
 			t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
 			t.Run("StatefulSet has OnDelete restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.OnDeleteStatefulSetStrategyType))
-			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsUpdated(&mdb))
+			t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
 			t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))
-
 		},
 	))
 	t.Run("StatefulSet has RollingUpgrade restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.RollingUpdateStatefulSetStrategyType))


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Our strategy for changing the StatefulSet update strategy to OnDelete was not working as intended.

Our isReady check was not working, as once we set the strategy to OnDelete, this no longer triggers a rolling upgrade. We need a mechanism to track if the StatefulSet became un-ready while being set to OnDelete. I used annotations for this purpose.