### PR TITLE
Upgrade pre-stop hook to 1.0.1 in example deployment files

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -33,4 +33,4 @@ spec:
             - name: AGENT_IMAGE # The MongoDB Agent the operator will deploy to manage MongoDB deployments
               value: quay.io/mongodb/mongodb-agent:10.13.0.6199-1
             - name: PRE_STOP_HOOK_IMAGE
-              value: quay.io/mongodb/mongodb-kubernetes-operator-pre-stop-hook:1.0.0
+              value: quay.io/mongodb/mongodb-kubernetes-operator-pre-stop-hook:1.0.1


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

#73 fixes a few issues in the pre-stop hook. These fixes are now available in quay.io/mongodb/mongodb-kubernetes-operator-pre-stop-hook:1.0.1 and this PR updates our example deployments to use the new image.