### PR TITLE
Set encoding to UTF-8 when reading logs after E2E tests

### DIFF
--- a/scripts/dev/dump_diagnostic.py
+++ b/scripts/dev/dump_diagnostic.py
@@ -45,7 +45,7 @@ def dump_stateful_sets_namespaced(diagnostic_file: typing.TextIO, namespace: str
 
 def dump_pod_log_namespaced(namespace: str, name: str, containers: list):
     for container in containers:
-        with open("logs/e2e/{}-{}.log".format(name, container.name), "w") as log_file:
+        with open("logs/e2e/{}-{}.log".format(name, container.name), mode="w", encoding="utf-8") as log_file:
             log_file.write(
                 k8s_request_data.get_pod_log_namespaced(namespace, name, container.name)
             )
@@ -70,10 +70,10 @@ def dump_all(namespace: str):
     if not os.path.exists("logs/e2e"):
         os.makedirs("logs/e2e")
 
-    with open("logs/e2e/diagnostics.txt", "w") as diagnostic_file:
+    with open("logs/e2e/diagnostics.txt", mode="w", encoding="utf-8") as diagnostic_file:
         dump_persistent_volume(diagnostic_file)
         dump_stateful_sets_namespaced(diagnostic_file, namespace)
         dump_pods_and_logs_namespaced(diagnostic_file, namespace)
 
-    with open("logs/e2e/crd.log", "w") as crd_log:
+    with open("logs/e2e/crd.log", mode="w", encoding="utf-8") as crd_log:
         dump_crd(crd_log)


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Sometimes our E2E tests fail when trying to dump the logs at the end. This is caused by the logs sometimes containing non-ASCII characters like 𝜇. This PR fixes this issue by writing the logs in UTF-8 encoding.