### PR TITLE
CLOUDP-66801: Switch to "tls" settings

### DIFF
--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -131,21 +131,21 @@ type Args26 struct {
 
 type Net struct {
 	Port int        `json:"port"`
-	SSL  MongoDBSSL `json:"ssl"`
+	SSL  MongoDBSSL `json:"tls"`
 }
 
 type SSLMode string
 
 const (
 	SSLModeDisabled  SSLMode = "disabled"
-	SSLModeAllowed   SSLMode = "allowSSL"
-	SSLModePreferred SSLMode = "preferSSL"
-	SSLModeRequired  SSLMode = "requireSSL"
+	SSLModeAllowed   SSLMode = "allowTLS"
+	SSLModePreferred SSLMode = "preferTLS"
+	SSLModeRequired  SSLMode = "requireTLS"
 )
 
 type MongoDBSSL struct {
 	Mode                               SSLMode `json:"mode"`
-	PEMKeyFile                         string  `json:"PEMKeyFile,omitempty"`
+	PEMKeyFile                         string  `json:"certificateKeyFile,omitempty"`
 	CAFile                             string  `json:"CAFile,omitempty"`
 	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
 }
@@ -195,7 +195,7 @@ type AutomationConfig struct {
 	Processes   []Process    `json:"processes"`
 	ReplicaSets []ReplicaSet `json:"replicaSets"`
 	Auth        Auth         `json:"auth"`
-	SSL         SSL          `json:"ssl"`
+	SSL         SSL          `json:"tls"`
 
 	Versions     []MongoDbVersionConfig `json:"mongoDbVersions"`
 	ToolsVersion ToolsVersion           `json:"mongoDbToolsVersion"`

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -83,8 +83,8 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 		Args26: Args26{
 			Net: Net{
 				Port: 27017,
-				SSL: MongoDBSSL{
-					Mode: SSLModeDisabled,
+				TLS: MongoDBTLS{
+					Mode: TLSModeDisabled,
 				},
 			},
 			Storage: Storage{
@@ -131,20 +131,20 @@ type Args26 struct {
 
 type Net struct {
 	Port int        `json:"port"`
-	SSL  MongoDBSSL `json:"tls"`
+	TLS  MongoDBTLS `json:"tls"`
 }
 
-type SSLMode string
+type TLSMode string
 
 const (
-	SSLModeDisabled  SSLMode = "disabled"
-	SSLModeAllowed   SSLMode = "allowTLS"
-	SSLModePreferred SSLMode = "preferTLS"
-	SSLModeRequired  SSLMode = "requireTLS"
+	TLSModeDisabled  TLSMode = "disabled"
+	TLSModeAllowed   TLSMode = "allowTLS"
+	TLSModePreferred TLSMode = "preferTLS"
+	TLSModeRequired  TLSMode = "requireTLS"
 )
 
-type MongoDBSSL struct {
-	Mode                               SSLMode `json:"mode"`
+type MongoDBTLS struct {
+	Mode                               TLSMode `json:"mode"`
 	PEMKeyFile                         string  `json:"certificateKeyFile,omitempty"`
 	CAFile                             string  `json:"CAFile,omitempty"`
 	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
@@ -185,21 +185,21 @@ const (
 	ClientCertificateModeRequired                       = "REQUIRED"
 )
 
-type SSL struct {
-	CAFilePath            string                `json:"CAFilePath"`
-	ClientCertificateMode ClientCertificateMode `json:"clientCertificateMode"`
-}
-
 type AutomationConfig struct {
 	Version     int          `json:"version"`
 	Processes   []Process    `json:"processes"`
 	ReplicaSets []ReplicaSet `json:"replicaSets"`
 	Auth        Auth         `json:"auth"`
-	SSL         SSL          `json:"tls"`
+	TLS         TLS          `json:"tls"`
 
 	Versions     []MongoDbVersionConfig `json:"mongoDbVersions"`
 	ToolsVersion ToolsVersion           `json:"mongoDbToolsVersion"`
 	Options      Options                `json:"options"`
+}
+
+type TLS struct {
+	CAFilePath            string                `json:"CAFilePath"`
+	ClientCertificateMode ClientCertificateMode `json:"clientCertificateMode"`
 }
 
 type ToolsVersion struct {

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -26,7 +26,7 @@ type Builder struct {
 	previousAC        AutomationConfig
 	tlsCAFile         string
 	tlsCertAndKeyFile string
-	tlsMode           SSLMode
+	tlsMode           TLSMode
 	// MongoDB installable versions
 	versions     []MongoDbVersionConfig
 	toolsVersion ToolsVersion
@@ -65,7 +65,7 @@ func (b *Builder) SetFCV(fcv string) *Builder {
 	return b
 }
 
-func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode SSLMode) *Builder {
+func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode TLSMode) *Builder {
 	b.tlsCAFile = caFile
 	b.tlsCertAndKeyFile = certAndKeyFile
 	b.tlsMode = mode
@@ -73,7 +73,7 @@ func (b *Builder) SetTLS(caFile, certAndKeyFile string, mode SSLMode) *Builder {
 }
 
 func (b *Builder) isTLSEnabled() bool {
-	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != SSLModeDisabled
+	return b.tlsCAFile != "" && b.tlsCertAndKeyFile != "" && b.tlsMode != TLSModeDisabled
 }
 
 func (b *Builder) SetToolsVersion(version ToolsVersion) *Builder {
@@ -133,11 +133,11 @@ func (b *Builder) Build() (AutomationConfig, error) {
 				ProtocolVersion: "1",
 			},
 		},
-		Versions: b.versions,
+		Versions:     b.versions,
 		ToolsVersion: b.toolsVersion,
-		Options:  Options{DownloadBase: "/var/lib/mongodb-mms-automation"},
-		Auth:     DisabledAuth(),
-		SSL: SSL{
+		Options:      Options{DownloadBase: "/var/lib/mongodb-mms-automation"},
+		Auth:         DisabledAuth(),
+		TLS: TLS{
 			ClientCertificateMode: ClientCertificateModeOptional,
 		},
 	}
@@ -145,7 +145,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 	// Set up TLS between agent and server
 	// Agent needs to trust the certificate presented by the server
 	if b.isTLSEnabled() {
-		currentAc.SSL.CAFilePath = b.tlsCAFile
+		currentAc.TLS.CAFilePath = b.tlsCAFile
 	}
 
 	// Here we compare the bytes of the two automationconfigs,
@@ -181,9 +181,9 @@ func withFCV(fcv string) func(*Process) {
 }
 
 // withTLS enables TLS for the mongod process
-func withTLS(caFile, tlsKeyFile string, mode SSLMode) func(*Process) {
+func withTLS(caFile, tlsKeyFile string, mode TLSMode) func(*Process) {
 	return func(process *Process) {
-		process.Args26.Net.SSL = MongoDBSSL{
+		process.Args26.Net.TLS = MongoDBTLS{
 			Mode:                               mode,
 			CAFile:                             caFile,
 			PEMKeyFile:                         tlsKeyFile,

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -41,14 +41,14 @@ func TestBuildAutomationConfig(t *testing.T) {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
 		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Storage.DBPath)
-		assert.Equal(t, SSLModeDisabled, p.Args26.Net.SSL.Mode)
+		assert.Equal(t, TLSModeDisabled, p.Args26.Net.TLS.Mode)
 		assert.Equal(t, "my-rs", p.Args26.Replication.ReplicaSetName, "replication should be configured based on the replica set name provided")
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
 	}
 
-	assert.Empty(t, ac.SSL.CAFilePath, "the config shouldn't have a trusted CA")
+	assert.Empty(t, ac.TLS.CAFilePath, "the config shouldn't have a trusted CA")
 
 	assert.Len(t, ac.ReplicaSets, 1)
 	rs := ac.ReplicaSets[0]
@@ -179,7 +179,7 @@ func TestVersionManifest_BuildsForVersion(t *testing.T) {
 func TestTLS(t *testing.T) {
 	caPath := "/path/to/ca"
 	certAndKeyPath := "/path/to/cert"
-	mode := SSLModeRequired
+	mode := TLSModeRequired
 
 	ac, err := NewBuilder().
 		SetName("my-rs").
@@ -195,36 +195,36 @@ func TestTLS(t *testing.T) {
 
 	// Ensure every process has TLS configured
 	for _, p := range ac.Processes {
-		assert.Equal(t, mode, p.Args26.Net.SSL.Mode)
-		assert.Equal(t, caPath, p.Args26.Net.SSL.CAFile)
-		assert.Equal(t, certAndKeyPath, p.Args26.Net.SSL.PEMKeyFile)
-		assert.True(t, p.Args26.Net.SSL.AllowConnectionsWithoutCertificate)
+		assert.Equal(t, mode, p.Args26.Net.TLS.Mode)
+		assert.Equal(t, caPath, p.Args26.Net.TLS.CAFile)
+		assert.Equal(t, certAndKeyPath, p.Args26.Net.TLS.PEMKeyFile)
+		assert.True(t, p.Args26.Net.TLS.AllowConnectionsWithoutCertificate)
 	}
 
 	// Ensure the CA was configured as trusted for the agent
-	assert.Equal(t, caPath, ac.SSL.CAFilePath)
-	assert.Equal(t, ClientCertificateModeOptional, ac.SSL.ClientCertificateMode)
+	assert.Equal(t, caPath, ac.TLS.CAFilePath)
+	assert.Equal(t, ClientCertificateModeOptional, ac.TLS.ClientCertificateMode)
 }
 
 func TestTLSIsEnabled(t *testing.T) {
 	// TLS should only be considered enabled if both a CA cert, a cert-key file and a non-disabled mode are set
 	builder := NewBuilder().
-		SetTLS("", "", SSLModeRequired)
+		SetTLS("", "", TLSModeRequired)
 	assert.False(t, builder.isTLSEnabled())
 
 	builder = NewBuilder().
-		SetTLS("/path", "", SSLModeRequired)
+		SetTLS("/path", "", TLSModeRequired)
 	assert.False(t, builder.isTLSEnabled())
 
 	builder = NewBuilder().
-		SetTLS("", "/path", SSLModeRequired)
+		SetTLS("", "/path", TLSModeRequired)
 	assert.False(t, builder.isTLSEnabled())
 
 	builder = NewBuilder().
-		SetTLS("/path", "/path", SSLModeDisabled)
+		SetTLS("/path", "/path", TLSModeDisabled)
 	assert.False(t, builder.isTLSEnabled())
 
 	builder = NewBuilder().
-		SetTLS("/path", "/path", SSLModeRequired)
+		SetTLS("/path", "/path", TLSModeRequired)
 	assert.True(t, builder.isTLSEnabled())
 }

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -357,10 +357,10 @@ func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.
 	// The agent needs these to be in place before the config is updated.
 	// The agents will handle the gradual enabling of TLS as recommended in: https://docs.mongodb.com/manual/tutorial/upgrade-cluster-to-ssl/
 	if mdb.Spec.Security.TLS.Enabled && hasRolledOutTLS(mdb) {
-		mode := automationconfig.SSLModeRequired
+		mode := automationconfig.TLSModeRequired
 		if mdb.Spec.Security.TLS.Optional {
-			// SSLModePreferred requires server-server connections to use TLS but makes it optional for clients.
-			mode = automationconfig.SSLModePreferred
+			// TLSModePreferred requires server-server connections to use TLS but makes it optional for clients.
+			mode = automationconfig.TLSModePreferred
 		}
 
 		builder.SetTLS(

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -385,15 +385,15 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		mdb := newTestReplicaSet()
 		ac := createAC(mdb)
 
-		assert.Equal(t, automationconfig.SSL{
+		assert.Equal(t, automationconfig.TLS{
 			CAFilePath:            "",
 			ClientCertificateMode: automationconfig.ClientCertificateModeOptional,
-		}, ac.SSL)
+		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			assert.Equal(t, automationconfig.MongoDBSSL{
-				Mode: automationconfig.SSLModeDisabled,
-			}, process.Args26.Net.SSL)
+			assert.Equal(t, automationconfig.MongoDBTLS{
+				Mode: automationconfig.TLSModeDisabled,
+			}, process.Args26.Net.TLS)
 		}
 	})
 
@@ -401,15 +401,15 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		mdb := newTestReplicaSetWithTLS()
 		ac := createAC(mdb)
 
-		assert.Equal(t, automationconfig.SSL{
+		assert.Equal(t, automationconfig.TLS{
 			CAFilePath:            "",
 			ClientCertificateMode: automationconfig.ClientCertificateModeOptional,
-		}, ac.SSL)
+		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			assert.Equal(t, automationconfig.MongoDBSSL{
-				Mode: automationconfig.SSLModeDisabled,
-			}, process.Args26.Net.SSL)
+			assert.Equal(t, automationconfig.MongoDBTLS{
+				Mode: automationconfig.TLSModeDisabled,
+			}, process.Args26.Net.TLS)
 		}
 	})
 
@@ -418,18 +418,18 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		mdb.Annotations[tLSRolledOutAnnotationKey] = "true"
 		ac := createAC(mdb)
 
-		assert.Equal(t, automationconfig.SSL{
+		assert.Equal(t, automationconfig.TLS{
 			CAFilePath:            tlsCAMountPath + tlsCACertName,
 			ClientCertificateMode: automationconfig.ClientCertificateModeOptional,
-		}, ac.SSL)
+		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			assert.Equal(t, automationconfig.MongoDBSSL{
-				Mode:                               automationconfig.SSLModeRequired,
+			assert.Equal(t, automationconfig.MongoDBTLS{
+				Mode:                               automationconfig.TLSModeRequired,
 				PEMKeyFile:                         tlsServerMountPath + tlsServerFileName,
 				CAFile:                             tlsCAMountPath + tlsCACertName,
 				AllowConnectionsWithoutCertificate: true,
-			}, process.Args26.Net.SSL)
+			}, process.Args26.Net.TLS)
 		}
 	})
 
@@ -439,18 +439,18 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		mdb.Spec.Security.TLS.Optional = true
 		ac := createAC(mdb)
 
-		assert.Equal(t, automationconfig.SSL{
+		assert.Equal(t, automationconfig.TLS{
 			CAFilePath:            tlsCAMountPath + tlsCACertName,
 			ClientCertificateMode: automationconfig.ClientCertificateModeOptional,
-		}, ac.SSL)
+		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			assert.Equal(t, automationconfig.MongoDBSSL{
-				Mode:                               automationconfig.SSLModePreferred,
+			assert.Equal(t, automationconfig.MongoDBTLS{
+				Mode:                               automationconfig.TLSModePreferred,
 				PEMKeyFile:                         tlsServerMountPath + tlsServerFileName,
 				CAFile:                             tlsCAMountPath + tlsCACertName,
 				AllowConnectionsWithoutCertificate: true,
-			}, process.Args26.Net.SSL)
+			}, process.Args26.Net.TLS)
 		}
 	})
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR updates the automation config to use the new "tls" settings instead of the now deprecated "ssl" ones. The agent was updated to 10.15 with #86 and the new version can automatically fall back to "ssl" for older version of MongoDB. This PR also updates all internal SSL references to TLS instead.