### PR TITLE
CLOUDP-67051: Update CRD with TLS settings

### DIFF
--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -49,6 +49,46 @@ spec:
             members:
               description: Members is the number of members in the replica set
               type: integer
+            security:
+              description: Security configures security features, such as TLS, and
+                authentication settings for a deployment
+              properties:
+                tls:
+                  description: TLS configuration for both client-server and server-server
+                    communication
+                  properties:
+                    caConfigMapRef:
+                      description: CaConfigMap is a reference to a ConfigMap containing
+                        the certificate for the CA which signed the server certificates
+                        The certificate is expected to be available under the key
+                        "ca.crt"
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    certificateKeySecretRef:
+                      description: CertificateKeySecret is a reference to a Secret
+                        containing a private key and certificate to use for TLS The
+                        key and cert are expected to be PEM encoded and available
+                        at "tls.key" and "tls.crt"
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    enabled:
+                      type: boolean
+                    optional:
+                      description: Optional configures if TLS should be required or
+                        optional for connections
+                      type: boolean
+                  required:
+                  - enabled
+                  type: object
+              type: object
             type:
               description: Type defines which type of MongoDB deployment the resource
                 should create

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -73,7 +73,8 @@ spec:
                         containing a private key and certificate to use for TLS. The
                         key and cert are expected to be PEM encoded and available
                         at "tls.key" and "tls.crt". This is the same format used for
-                        the standard "kubernetes.io/tls" Secret type.
+                        the standard "kubernetes.io/tls" Secret type, but no specific
+                        type is required.
                       properties:
                         name:
                           type: string

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -70,9 +70,10 @@ spec:
                       type: object
                     certificateKeySecretRef:
                       description: CertificateKeySecret is a reference to a Secret
-                        containing a private key and certificate to use for TLS The
+                        containing a private key and certificate to use for TLS. The
                         key and cert are expected to be PEM encoded and available
-                        at "tls.key" and "tls.crt"
+                        at "tls.key" and "tls.crt". This is the same format used for
+                        the standard "kubernetes.io/tls" Secret type.
                       properties:
                         name:
                           type: string

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -58,15 +58,23 @@ type TLS struct {
 	// +optional
 	Optional bool `json:"optional"`
 
-	// ServerSecretName is the name of a secret containing a private key and certificate to use for TLS
+	// CertificateKeySecret is a reference to a Secret containing a private key and certificate to use for TLS
 	// The key and cert are expected to be PEM encoded and available at "tls.key" and "tls.crt"
 	// +optional
-	ServerSecretName string `json:"serverSecretName"`
+	CertificateKeySecret CertificateKeySecret `json:"certificateKeySecretRef"`
 
-	// CAConfigMapName is the name of a ConfigMap containing the certificate for the CA which signed the server certificates
+	// CaConfigMap is a reference to a ConfigMap containing the certificate for the CA which signed the server certificates
 	// The certificate is expected to be available under the key "ca.crt"
 	// +optional
-	CAConfigMapName string `json:"caConfigMapName"`
+	CaConfigMap CAConfigMap `json:"caConfigMapRef"`
+}
+
+type CertificateKeySecret struct {
+	Name string `json:"name"`
+}
+
+type CAConfigMap struct {
+	Name string `json:"name"`
 }
 
 type Authentication struct {
@@ -129,13 +137,13 @@ func (m MongoDB) ConfigMapName() string {
 // TLSConfigMapNamespacedName will get the namespaced name of the ConfigMap containing the CA certificate
 // As the ConfigMap will be mounted to our pods, it has to be in the same namespace as the MongoDB resource
 func (m MongoDB) TLSConfigMapNamespacedName() types.NamespacedName {
-	return types.NamespacedName{Name: m.Spec.Security.TLS.CAConfigMapName, Namespace: m.Namespace}
+	return types.NamespacedName{Name: m.Spec.Security.TLS.CaConfigMap.Name, Namespace: m.Namespace}
 }
 
 // TLSSecretNamespacedName will get the namespaced name of the Secret containing the server certificate and key
 // As the Secret will be mounted to our pods, it has to be in the same namespace as the MongoDB resource
 func (m MongoDB) TLSSecretNamespacedName() types.NamespacedName {
-	return types.NamespacedName{Name: m.Spec.Security.TLS.ServerSecretName, Namespace: m.Namespace}
+	return types.NamespacedName{Name: m.Spec.Security.TLS.CertificateKeySecret.Name, Namespace: m.Namespace}
 }
 
 func (m MongoDB) NamespacedName() types.NamespacedName {

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,12 +61,20 @@ type TLS struct {
 	// CertificateKeySecret is a reference to a Secret containing a private key and certificate to use for TLS
 	// The key and cert are expected to be PEM encoded and available at "tls.key" and "tls.crt"
 	// +optional
-	CertificateKeySecret corev1.LocalObjectReference `json:"certificateKeySecretRef"`
+	CertificateKeySecret LocalObjectReference `json:"certificateKeySecretRef"`
 
 	// CaConfigMap is a reference to a ConfigMap containing the certificate for the CA which signed the server certificates
 	// The certificate is expected to be available under the key "ca.crt"
 	// +optional
-	CaConfigMap corev1.LocalObjectReference `json:"caConfigMapRef"`
+	CaConfigMap LocalObjectReference `json:"caConfigMapRef"`
+}
+
+// LocalObjectReference is a reference to another Kubernetes object by name.
+// TODO: Replace with a type from the K8s API. CoreV1 has an equivalent
+// 	"LocalObjectReference" type but it contains a TODO in its
+// 	description that we don't want in our CRD.
+type LocalObjectReference struct {
+	Name string `json:"name"`
 }
 
 type Authentication struct {

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -58,8 +58,9 @@ type TLS struct {
 	// +optional
 	Optional bool `json:"optional"`
 
-	// CertificateKeySecret is a reference to a Secret containing a private key and certificate to use for TLS
-	// The key and cert are expected to be PEM encoded and available at "tls.key" and "tls.crt"
+	// CertificateKeySecret is a reference to a Secret containing a private key and certificate to use for TLS.
+	// The key and cert are expected to be PEM encoded and available at "tls.key" and "tls.crt".
+	// This is the same format used for the standard "kubernetes.io/tls" Secret type.
 	// +optional
 	CertificateKeySecret LocalObjectReference `json:"certificateKeySecretRef"`
 

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -60,7 +60,7 @@ type TLS struct {
 
 	// CertificateKeySecret is a reference to a Secret containing a private key and certificate to use for TLS.
 	// The key and cert are expected to be PEM encoded and available at "tls.key" and "tls.crt".
-	// This is the same format used for the standard "kubernetes.io/tls" Secret type.
+	// This is the same format used for the standard "kubernetes.io/tls" Secret type, but no specific type is required.
 	// +optional
 	CertificateKeySecret LocalObjectReference `json:"certificateKeySecretRef"`
 

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,20 +63,12 @@ type TLS struct {
 	// CertificateKeySecret is a reference to a Secret containing a private key and certificate to use for TLS
 	// The key and cert are expected to be PEM encoded and available at "tls.key" and "tls.crt"
 	// +optional
-	CertificateKeySecret CertificateKeySecret `json:"certificateKeySecretRef"`
+	CertificateKeySecret corev1.LocalObjectReference `json:"certificateKeySecretRef"`
 
 	// CaConfigMap is a reference to a ConfigMap containing the certificate for the CA which signed the server certificates
 	// The certificate is expected to be available under the key "ca.crt"
 	// +optional
-	CaConfigMap CAConfigMap `json:"caConfigMapRef"`
-}
-
-type CertificateKeySecret struct {
-	Name string `json:"name"`
-}
-
-type CAConfigMap struct {
-	Name string `json:"name"`
+	CaConfigMap corev1.LocalObjectReference `json:"caConfigMapRef"`
 }
 
 type Authentication struct {

--- a/pkg/controller/mongodb/mongodb_tls.go
+++ b/pkg/controller/mongodb/mongodb_tls.go
@@ -111,12 +111,12 @@ func buildTLSPodSpecModification(mdb mdbv1.MongoDB) podtemplatespec.Modification
 
 	// Configure a volume which mounts the CA certificate from a ConfigMap
 	// The certificate is used by both mongod and the agent
-	caVolume := statefulset.CreateVolumeFromConfigMap("tls-ca", mdb.Spec.Security.TLS.CAConfigMapName)
+	caVolume := statefulset.CreateVolumeFromConfigMap("tls-ca", mdb.Spec.Security.TLS.CaConfigMap.Name)
 	caVolumeMount := statefulset.CreateVolumeMount(caVolume.Name, tlsCAMountPath, statefulset.WithReadOnly(true))
 
 	// Configure a volume which mounts the secret holding the server key and certificate
 	// The same key-certificate pair is used for all servers
-	tlsSecretVolume := statefulset.CreateVolumeFromSecret("tls-secret", mdb.Spec.Security.TLS.ServerSecretName)
+	tlsSecretVolume := statefulset.CreateVolumeFromSecret("tls-secret", mdb.Spec.Security.TLS.CertificateKeySecret.Name)
 	tlsSecretVolumeMount := statefulset.CreateVolumeMount(tlsSecretVolume.Name, tlsSecretMountPath, statefulset.WithReadOnly(true))
 
 	// MongoDB expects both key and certificate to be provided in a single PEM file

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -79,9 +79,13 @@ func newTestReplicaSetWithTLS() mdbv1.MongoDB {
 			Version: "4.2.2",
 			Security: mdbv1.Security{
 				TLS: mdbv1.TLS{
-					Enabled:          true,
-					CAConfigMapName:  "caConfigMap",
-					ServerSecretName: "serverSecret",
+					Enabled: true,
+					CaConfigMap: mdbv1.CAConfigMap{
+						Name: "caConfigMap",
+					},
+					CertificateKeySecret: mdbv1.CertificateKeySecret{
+						Name: "certificateKeySecret",
+					},
 				},
 			},
 		},
@@ -359,7 +363,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 	mgr := client.NewManager(&mdb)
 
 	s := secret.Builder().
-		SetName(mdb.Spec.Security.TLS.ServerSecretName).
+		SetName(mdb.Spec.Security.TLS.CertificateKeySecret.Name).
 		SetNamespace(mdb.Namespace).
 		SetField("tls.crt", "CERT").
 		SetField("tls.key", "KEY").
@@ -368,7 +372,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 	mgr.GetClient().Create(context.TODO(), &s)
 
 	configMap := configmap.Builder().
-		SetName(mdb.Spec.Security.TLS.CAConfigMapName).
+		SetName(mdb.Spec.Security.TLS.CaConfigMap.Name).
 		SetNamespace(mdb.Namespace).
 		SetField("ca.crt", "CERT").
 		Build()
@@ -396,7 +400,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: mdb.Spec.Security.TLS.CAConfigMapName,
+					Name: mdb.Spec.Security.TLS.CaConfigMap.Name,
 				},
 			},
 		},
@@ -405,7 +409,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		Name: "tls-secret",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: mdb.Spec.Security.TLS.ServerSecretName,
+				SecretName: mdb.Spec.Security.TLS.CertificateKeySecret.Name,
 			},
 		},
 	})

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -80,10 +80,10 @@ func newTestReplicaSetWithTLS() mdbv1.MongoDB {
 			Security: mdbv1.Security{
 				TLS: mdbv1.TLS{
 					Enabled: true,
-					CaConfigMap: corev1.LocalObjectReference{
+					CaConfigMap: mdbv1.LocalObjectReference{
 						Name: "caConfigMap",
 					},
-					CertificateKeySecret: corev1.LocalObjectReference{
+					CertificateKeySecret: mdbv1.LocalObjectReference{
 						Name: "certificateKeySecret",
 					},
 				},
@@ -399,7 +399,9 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		Name: "tls-ca",
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: mdb.Spec.Security.TLS.CaConfigMap,
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: mdb.Spec.Security.TLS.CaConfigMap.Name,
+				},
 			},
 		},
 	})

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -80,10 +80,10 @@ func newTestReplicaSetWithTLS() mdbv1.MongoDB {
 			Security: mdbv1.Security{
 				TLS: mdbv1.TLS{
 					Enabled: true,
-					CaConfigMap: mdbv1.CAConfigMap{
+					CaConfigMap: corev1.LocalObjectReference{
 						Name: "caConfigMap",
 					},
-					CertificateKeySecret: mdbv1.CertificateKeySecret{
+					CertificateKeySecret: corev1.LocalObjectReference{
 						Name: "certificateKeySecret",
 					},
 				},
@@ -399,9 +399,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		Name: "tls-ca",
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: mdb.Spec.Security.TLS.CaConfigMap.Name,
-				},
+				LocalObjectReference: mdb.Spec.Security.TLS.CaConfigMap,
 			},
 		},
 	})

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -129,9 +129,13 @@ func NewTestMongoDB(name string) mdbv1.MongoDB {
 
 func NewTestTLSConfig(optional bool) mdbv1.TLS {
 	return mdbv1.TLS{
-		Enabled:          true,
-		Optional:         optional,
-		ServerSecretName: "test-tls-secret",
-		CAConfigMapName:  "test-tls-ca",
+		Enabled:  true,
+		Optional: optional,
+		CertificateKeySecret: mdbv1.CertificateKeySecret{
+			Name: "test-tls-secret",
+		},
+		CaConfigMap: mdbv1.CAConfigMap{
+			Name: "test-tls-ca",
+		},
 	}
 }

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -131,10 +131,10 @@ func NewTestTLSConfig(optional bool) mdbv1.TLS {
 	return mdbv1.TLS{
 		Enabled:  true,
 		Optional: optional,
-		CertificateKeySecret: mdbv1.CertificateKeySecret{
+		CertificateKeySecret: corev1.LocalObjectReference{
 			Name: "test-tls-secret",
 		},
-		CaConfigMap: mdbv1.CAConfigMap{
+		CaConfigMap: corev1.LocalObjectReference{
 			Name: "test-tls-ca",
 		},
 	}

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -131,10 +131,10 @@ func NewTestTLSConfig(optional bool) mdbv1.TLS {
 	return mdbv1.TLS{
 		Enabled:  true,
 		Optional: optional,
-		CertificateKeySecret: corev1.LocalObjectReference{
+		CertificateKeySecret: mdbv1.LocalObjectReference{
 			Name: "test-tls-secret",
 		},
-		CaConfigMap: corev1.LocalObjectReference{
+		CaConfigMap: mdbv1.LocalObjectReference{
 			Name: "test-tls-ca",
 		},
 	}

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -57,7 +57,7 @@ func CreateTLSResources(namespace string, ctx *f.TestCtx) error {
 	}
 
 	caConfigMap := configmap.Builder().
-		SetName(tlsConfig.CAConfigMapName).
+		SetName(tlsConfig.CaConfigMap.Name).
 		SetNamespace(namespace).
 		SetField("ca.crt", string(ca)).
 		Build()
@@ -78,7 +78,7 @@ func CreateTLSResources(namespace string, ctx *f.TestCtx) error {
 	}
 
 	certKeySecret := secret.Builder().
-		SetName(tlsConfig.ServerSecretName).
+		SetName(tlsConfig.CertificateKeySecret.Name).
 		SetNamespace(namespace).
 		SetField("tls.crt", string(cert)).
 		SetField("tls.key", string(key)).


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR adds TLS settings to the CRD. The design we settled upon looks like this:

```
apiVersion: mongodb.com/v1
kind: MongoDB
metadata:
  name: example-mongodb
spec:
  members: 3
  type: ReplicaSet
  version: "4.2.8"
  security:
    tls:
      enabled: true
      caConfigMapRef:
        name: "example-mongodb-ca"
      certificateKeySecretRef:
        name: "example-mongodb-tls"
```