### PR TITLE
Refactor authentication and TLS with unified automation config modification

### DIFF
--- a/pkg/authentication/scram/scram.go
+++ b/pkg/authentication/scram/scram.go
@@ -12,16 +12,16 @@ import (
 )
 
 // EnsureAgentSecret make sure that the agent password and keyfile exist in the secret and returns
-// the scram authEnabler configured with this values
-func EnsureAgentSecret(getUpdateCreator secret.GetUpdateCreator, secretNsName types.NamespacedName) (automationconfig.AuthEnabler, error) {
+// an automation config modification function with these values
+func EnsureAgentSecret(getUpdateCreator secret.GetUpdateCreator, secretNsName types.NamespacedName) (automationconfig.Modification, error) {
 	generatedPassword, err := generate.RandomFixedLengthStringOfSize(20)
 	if err != nil {
-		return authEnabler{}, fmt.Errorf("error generating password: %s", err)
+		return automationconfig.NOOP(), fmt.Errorf("error generating password: %s", err)
 	}
 
 	generatedContents, err := generate.KeyFileContents()
 	if err != nil {
-		return authEnabler{}, fmt.Errorf("error generating keyfile contents: %s", err)
+		return automationconfig.NOOP(), fmt.Errorf("error generating keyfile contents: %s", err)
 	}
 
 	agentSecret, err := getUpdateCreator.GetSecret(secretNsName)
@@ -33,12 +33,10 @@ func EnsureAgentSecret(getUpdateCreator secret.GetUpdateCreator, secretNsName ty
 				SetField(AgentPasswordKey, generatedPassword).
 				SetField(AgentKeyfileKey, generatedContents).
 				Build()
-			return authEnabler{
-				agentPassword: generatedPassword,
-				agentKeyFile:  generatedContents,
-			}, getUpdateCreator.CreateSecret(s)
+			return automationConfigModification(generatedPassword, generatedContents), getUpdateCreator.CreateSecret(s)
 		}
-		return authEnabler{}, err
+
+		return automationconfig.NOOP(), err
 	}
 
 	if _, ok := agentSecret.Data[AgentPasswordKey]; !ok {
@@ -49,8 +47,8 @@ func EnsureAgentSecret(getUpdateCreator secret.GetUpdateCreator, secretNsName ty
 		agentSecret.Data[AgentKeyfileKey] = []byte(generatedContents)
 	}
 
-	return authEnabler{
-		agentPassword: string(agentSecret.Data[AgentPasswordKey]),
-		agentKeyFile:  string(agentSecret.Data[AgentKeyfileKey]),
-	}, getUpdateCreator.UpdateSecret(agentSecret)
+	return automationConfigModification(
+		string(agentSecret.Data[AgentPasswordKey]),
+		string(agentSecret.Data[AgentKeyfileKey]),
+	), getUpdateCreator.UpdateSecret(agentSecret)
 }

--- a/pkg/authentication/scram/scram_enabler.go
+++ b/pkg/authentication/scram/scram_enabler.go
@@ -14,15 +14,11 @@ const (
 	AgentKeyfileKey                       = "keyfile"
 )
 
-type authEnabler struct {
-	agentPassword string
-	agentKeyFile  string
-}
-
-func (s authEnabler) EnableAuth(auth automationconfig.Auth) automationconfig.Auth {
-	enableAgentAuthentication(&auth, s.agentPassword, s.agentKeyFile)
-	enableDeploymentMechanisms(&auth)
-	return auth
+func automationConfigModification(agentPassword, agentKeyFile string) automationconfig.Modification {
+	return func(config *automationconfig.AutomationConfig) {
+		enableAgentAuthentication(&config.Auth, agentPassword, agentKeyFile)
+		enableDeploymentMechanisms(&config.Auth)
+	}
 }
 
 func enableAgentAuthentication(auth *automationconfig.Auth, agentPassword, agentKeyFileContents string) {

--- a/pkg/authentication/scram/scram_enabler_test.go
+++ b/pkg/authentication/scram/scram_enabler_test.go
@@ -7,28 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestScramEnabler(t *testing.T) {
-	enabler := authEnabler{
-		agentPassword: "password",
-		agentKeyFile:  "keyfilecontents",
-	}
-	auth := enabler.EnableAuth(automationconfig.Auth{})
+func TestScramAutomationConfig(t *testing.T) {
+	modificationFunc := automationConfigModification("password", "keyfilecontents")
+	config := automationconfig.AutomationConfig{}
+
 	t.Run("Authentication is correctly configured", func(t *testing.T) {
-		assert.Equal(t, AgentName, auth.AutoUser)
-		assert.Equal(t, "keyfilecontents", auth.Key)
-		assert.Equal(t, "password", auth.AutoPwd)
-		assert.Equal(t, scram256, auth.AutoAuthMechanism)
-		assert.Len(t, auth.DeploymentAuthMechanisms, 1)
-		assert.Len(t, auth.AutoAuthMechanisms, 1)
-		assert.Equal(t, []string{scram256}, auth.DeploymentAuthMechanisms)
-		assert.Equal(t, []string{scram256}, auth.AutoAuthMechanisms)
-		assert.Equal(t, automationAgentKeyFilePathInContainer, auth.KeyFile)
-		assert.Equal(t, automationAgentWindowsKeyFilePath, auth.KeyFileWindows)
+		modificationFunc(&config)
+
+		assert.Equal(t, AgentName, config.Auth.AutoUser)
+		assert.Equal(t, "keyfilecontents", config.Auth.Key)
+		assert.Equal(t, "password", config.Auth.AutoPwd)
+		assert.Equal(t, scram256, config.Auth.AutoAuthMechanism)
+		assert.Len(t, config.Auth.DeploymentAuthMechanisms, 1)
+		assert.Len(t, config.Auth.AutoAuthMechanisms, 1)
+		assert.Equal(t, []string{scram256}, config.Auth.DeploymentAuthMechanisms)
+		assert.Equal(t, []string{scram256}, config.Auth.AutoAuthMechanisms)
+		assert.Equal(t, automationAgentKeyFilePathInContainer, config.Auth.KeyFile)
+		assert.Equal(t, automationAgentWindowsKeyFilePath, config.Auth.KeyFileWindows)
 	})
 
 	t.Run("Subsequent configuration doesn't add to deployment auth mechanisms", func(t *testing.T) {
-		auth = enabler.EnableAuth(auth)
-		assert.Equal(t, []string{scram256}, auth.DeploymentAuthMechanisms)
+		modificationFunc(&config)
+		assert.Equal(t, []string{scram256}, config.Auth.DeploymentAuthMechanisms)
 	})
-
 }

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -1,16 +1,148 @@
 package automationconfig
 
-import (
-	"path"
-)
-
-type ProcessType string
+import "path"
 
 const (
 	Mongod                ProcessType = "mongod"
 	DefaultMongoDBDataDir string      = "/data"
 	DefaultAgentLogPath   string      = "/var/log/mongodb-mms-automation"
 )
+
+type AutomationConfig struct {
+	Version     int          `json:"version"`
+	Processes   []Process    `json:"processes"`
+	ReplicaSets []ReplicaSet `json:"replicaSets"`
+	Auth        Auth         `json:"auth"`
+	TLS         TLS          `json:"tls"`
+
+	Versions     []MongoDbVersionConfig `json:"mongoDbVersions"`
+	ToolsVersion ToolsVersion           `json:"mongoDbToolsVersion"`
+	Options      Options                `json:"options"`
+}
+
+type Process struct {
+	Name                        string      `json:"name"`
+	HostName                    string      `json:"hostname"`
+	Args26                      Args26      `json:"args2_6"`
+	FeatureCompatibilityVersion string      `json:"featureCompatibilityVersion"`
+	ProcessType                 ProcessType `json:"processType"`
+	Version                     string      `json:"version"`
+	AuthSchemaVersion           int         `json:"authSchemaVersion"`
+	SystemLog                   SystemLog   `json:"systemLog"`
+	WiredTiger                  WiredTiger  `json:"wiredTiger"`
+}
+
+func newProcess(name, hostName, version, replSetName string, opts ...func(process *Process)) Process {
+	p := Process{
+		Name:                        name,
+		HostName:                    hostName,
+		FeatureCompatibilityVersion: "4.0",
+		ProcessType:                 Mongod,
+		Version:                     version,
+		SystemLog: SystemLog{
+			Destination: "file",
+			Path:        path.Join(DefaultAgentLogPath, "/mongodb.log"),
+		},
+		AuthSchemaVersion: 5,
+		Args26: Args26{
+			Net: Net{
+				Port: 27017,
+				TLS: MongoDBTLS{
+					Mode: TLSModeDisabled,
+				},
+			},
+			Storage: Storage{
+				DBPath: DefaultMongoDBDataDir,
+			},
+			Replication: Replication{ReplicaSetName: replSetName},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&p)
+	}
+
+	return p
+}
+
+type Args26 struct {
+	Net         Net         `json:"net"`
+	Security    Security    `json:"security"`
+	Storage     Storage     `json:"storage"`
+	Replication Replication `json:"replication"`
+}
+
+type Net struct {
+	Port int        `json:"port"`
+	TLS  MongoDBTLS `json:"tls"`
+}
+
+type TLSMode string
+
+const (
+	TLSModeDisabled  TLSMode = "disabled"
+	TLSModeAllowed   TLSMode = "allowTLS"
+	TLSModePreferred TLSMode = "preferTLS"
+	TLSModeRequired  TLSMode = "requireTLS"
+)
+
+type MongoDBTLS struct {
+	Mode                               TLSMode `json:"mode"`
+	PEMKeyFile                         string  `json:"certificateKeyFile,omitempty"`
+	CAFile                             string  `json:"CAFile,omitempty"`
+	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
+}
+
+type Security struct {
+	ClusterAuthMode string `json:"clusterAuthMode,omitempty"`
+}
+
+type Storage struct {
+	DBPath string `json:"dbPath"`
+}
+
+type Replication struct {
+	ReplicaSetName string `json:"replSetName"`
+}
+
+type ProcessType string
+
+type SystemLog struct {
+	Destination string `json:"destination"`
+	Path        string `json:"path"`
+}
+
+type WiredTiger struct {
+	EngineConfig EngineConfig `json:"engineConfig"`
+}
+
+type EngineConfig struct {
+	CacheSizeGB float32 `json:"cacheSizeGB"`
+}
+
+type ReplicaSet struct {
+	Id              string             `json:"_id"`
+	Members         []ReplicaSetMember `json:"members"`
+	ProtocolVersion string             `json:"protocolVersion"`
+}
+
+type ReplicaSetMember struct {
+	Id          int    `json:"_id"`
+	Host        string `json:"host"`
+	Priority    int    `json:"priority"`
+	ArbiterOnly bool   `json:"arbiterOnly"`
+	Votes       int    `json:"votes"`
+}
+
+func newReplicaSetMember(p Process, id int) ReplicaSetMember {
+	return ReplicaSetMember{
+		Id:          id,
+		Host:        p.Name,
+		Priority:    1,
+		ArbiterOnly: false,
+		Votes:       1,
+	}
+}
 
 type Auth struct {
 	// Users is a list which contains the desired users at the project level.
@@ -51,133 +183,6 @@ func disabledAuth() Auth {
 type MongoDBUser struct {
 }
 
-type Process struct {
-	Name                        string      `json:"name"`
-	HostName                    string      `json:"hostname"`
-	Args26                      Args26      `json:"args2_6"`
-	FeatureCompatibilityVersion string      `json:"featureCompatibilityVersion"`
-	ProcessType                 ProcessType `json:"processType"`
-	Version                     string      `json:"version"`
-	AuthSchemaVersion           int         `json:"authSchemaVersion"`
-	SystemLog                   SystemLog   `json:"systemLog"`
-	WiredTiger                  WiredTiger  `json:"wiredTiger"`
-}
-
-type SystemLog struct {
-	Destination string `json:"destination"`
-	Path        string `json:"path"`
-}
-
-func newProcess(name, hostName, version, replSetName string, opts ...func(process *Process)) Process {
-	p := Process{
-		Name:                        name,
-		HostName:                    hostName,
-		FeatureCompatibilityVersion: "4.0",
-		ProcessType:                 Mongod,
-		Version:                     version,
-		SystemLog: SystemLog{
-			Destination: "file",
-			Path:        path.Join(DefaultAgentLogPath, "/mongodb.log"),
-		},
-		AuthSchemaVersion: 5,
-		Args26: Args26{
-			Net: Net{
-				Port: 27017,
-				TLS: MongoDBTLS{
-					Mode: TLSModeDisabled,
-				},
-			},
-			Storage: Storage{
-				DBPath: DefaultMongoDBDataDir,
-			},
-			Replication: Replication{ReplicaSetName: replSetName},
-		},
-	}
-
-	for _, opt := range opts {
-		opt(&p)
-	}
-
-	return p
-}
-
-type Replication struct {
-	ReplicaSetName string `json:"replSetName"`
-}
-
-type Storage struct {
-	DBPath string `json:"dbPath"`
-}
-
-type WiredTiger struct {
-	EngineConfig EngineConfig `json:"engineConfig"`
-}
-
-type EngineConfig struct {
-	CacheSizeGB float32 `json:"cacheSizeGB"`
-}
-
-type LogRotate struct {
-	SizeThresholdMB  int `json:"sizeThresholdMB"`
-	TimeThresholdHrs int `json:"timeThresholdHrs"`
-}
-
-type Args26 struct {
-	Net         Net         `json:"net"`
-	Security    Security    `json:"security"`
-	Storage     Storage     `json:"storage"`
-	Replication Replication `json:"replication"`
-}
-
-type Net struct {
-	Port int        `json:"port"`
-	TLS  MongoDBTLS `json:"tls"`
-}
-
-type TLSMode string
-
-const (
-	TLSModeDisabled  TLSMode = "disabled"
-	TLSModeAllowed   TLSMode = "allowTLS"
-	TLSModePreferred TLSMode = "preferTLS"
-	TLSModeRequired  TLSMode = "requireTLS"
-)
-
-type MongoDBTLS struct {
-	Mode                               TLSMode `json:"mode"`
-	PEMKeyFile                         string  `json:"certificateKeyFile,omitempty"`
-	CAFile                             string  `json:"CAFile,omitempty"`
-	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
-}
-
-type Security struct {
-	ClusterAuthMode string `json:"clusterAuthMode,omitempty"`
-}
-
-type ReplicaSet struct {
-	Id              string             `json:"_id"`
-	Members         []ReplicaSetMember `json:"members"`
-	ProtocolVersion string             `json:"protocolVersion"`
-}
-
-type ReplicaSetMember struct {
-	Id          int    `json:"_id"`
-	Host        string `json:"host"`
-	Priority    int    `json:"priority"`
-	ArbiterOnly bool   `json:"arbiterOnly"`
-	Votes       int    `json:"votes"`
-}
-
-func newReplicaSetMember(p Process, id int) ReplicaSetMember {
-	return ReplicaSetMember{
-		Id:          id,
-		Host:        p.Name,
-		Priority:    1,
-		ArbiterOnly: false,
-		Votes:       1,
-	}
-}
-
 type ClientCertificateMode string
 
 const (
@@ -185,26 +190,23 @@ const (
 	ClientCertificateModeRequired ClientCertificateMode = "REQUIRED"
 )
 
-type AutomationConfig struct {
-	Version     int          `json:"version"`
-	Processes   []Process    `json:"processes"`
-	ReplicaSets []ReplicaSet `json:"replicaSets"`
-	Auth        Auth         `json:"auth"`
-	TLS         TLS          `json:"tls"`
-
-	Versions     []MongoDbVersionConfig `json:"mongoDbVersions"`
-	ToolsVersion ToolsVersion           `json:"mongoDbToolsVersion"`
-	Options      Options                `json:"options"`
-}
-
 type TLS struct {
 	CAFilePath            string                `json:"CAFilePath"`
 	ClientCertificateMode ClientCertificateMode `json:"clientCertificateMode"`
 }
 
+type LogRotate struct {
+	SizeThresholdMB  int `json:"sizeThresholdMB"`
+	TimeThresholdHrs int `json:"timeThresholdHrs"`
+}
+
 type ToolsVersion struct {
 	Version string                       `json:"version"`
 	URLs    map[string]map[string]string `json:"urls"`
+}
+
+type Options struct {
+	DownloadBase string `json:"downloadBase"`
 }
 
 type VersionManifest struct {
@@ -227,10 +229,6 @@ func (v VersionManifest) BuildsForVersion(version string) MongoDbVersionConfig {
 		Name:   version,
 		Builds: builds,
 	}
-}
-
-type Options struct {
-	DownloadBase string `json:"downloadBase"`
 }
 
 type BuildConfig struct {

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -228,3 +228,19 @@ func TestTLSIsEnabled(t *testing.T) {
 		SetTLS("/path", "/path", TLSModeRequired)
 	assert.True(t, builder.isTLSEnabled())
 }
+
+func TestModifications(t *testing.T) {
+	incrementVersion := func(config *AutomationConfig) {
+		config.Version += 1
+	}
+
+	ac, err := NewBuilder().
+		AddModification(incrementVersion).
+		AddModification(incrementVersion).
+		AddModification(incrementVersion).
+		AddModification(NOOP()).
+		Build()
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, ac.Version)
+}

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -341,7 +341,7 @@ func (r ReplicaSetReconciler) ensureAutomationConfig(mdb mdbv1.MongoDB) error {
 	return configmap.CreateOrUpdate(r.client, cm)
 }
 
-func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.MongoDbVersionConfig, currentAc automationconfig.AutomationConfig, enabler automationconfig.AuthEnabler) (automationconfig.AutomationConfig, error) {
+func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.MongoDbVersionConfig, currentAc automationconfig.AutomationConfig, enabler automationconfig.AuthEnabler, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
 	domain := getDomain(mdb.ServiceName(), mdb.Namespace, "")
 
 	builder := automationconfig.NewBuilder().
@@ -354,24 +354,8 @@ func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.
 		SetFCV(mdb.GetFCV()).
 		AddVersion(mdbVersionConfig).
 		SetAuthEnabler(enabler).
+		AddModifications(modifications...).
 		SetToolsVersion(dummyToolsVersionConfig())
-
-	// Enable TLS in the automation config after the certs and keys have been rolled out to all pods.
-	// The agent needs these to be in place before the config is updated.
-	// The agents will handle the gradual enabling of TLS as recommended in: https://docs.mongodb.com/manual/tutorial/upgrade-cluster-to-ssl/
-	if mdb.Spec.Security.TLS.Enabled && hasRolledOutTLS(mdb) {
-		mode := automationconfig.TLSModeRequired
-		if mdb.Spec.Security.TLS.Optional {
-			// TLSModePreferred requires server-server connections to use TLS but makes it optional for clients.
-			mode = automationconfig.TLSModePreferred
-		}
-
-		builder.SetTLS(
-			tlsCAMountPath+tlsCACertName,
-			tlsServerMountPath+tlsServerFileName,
-			mode,
-		)
-	}
 
 	newAc, err := builder.Build()
 	if err != nil {
@@ -455,12 +439,14 @@ func (r ReplicaSetReconciler) buildAutomationConfigConfigMap(mdb mdbv1.MongoDB) 
 		return corev1.ConfigMap{}, err
 	}
 
+	tlsModification := tlsAutomationConfigModification(mdb)
+
 	currentAC, err := getCurrentAutomationConfig(r.client, mdb)
 	if err != nil {
 		return corev1.ConfigMap{}, err
 	}
 
-	ac, err := buildAutomationConfig(mdb, manifest.BuildsForVersion(mdb.Spec.Version), currentAC, enabler)
+	ac, err := buildAutomationConfig(mdb, manifest.BuildsForVersion(mdb.Spec.Version), currentAC, enabler, tlsModification)
 	if err != nil {
 		return corev1.ConfigMap{}, err
 	}

--- a/pkg/controller/mongodb/mongodb_controller.go
+++ b/pkg/controller/mongodb/mongodb_controller.go
@@ -439,7 +439,7 @@ func (r ReplicaSetReconciler) buildAutomationConfigConfigMap(mdb mdbv1.MongoDB) 
 		return corev1.ConfigMap{}, err
 	}
 
-	tlsModification := tlsAutomationConfigModification(mdb)
+	tlsModification := getTLSConfigModification(mdb)
 
 	currentAC, err := getCurrentAutomationConfig(r.client, mdb)
 	if err != nil {

--- a/pkg/controller/mongodb/mongodb_tls.go
+++ b/pkg/controller/mongodb/mongodb_tls.go
@@ -72,11 +72,11 @@ func (r *ReplicaSetReconciler) validateTLSConfig(mdb mdbv1.MongoDB) (bool, error
 	return true, nil
 }
 
-// tlsAutomationConfigModification creates a modification function which enables TLS in the automation config.
+// getTLSConfigModification creates a modification function which enables TLS in the automation config.
 // THe config is only updated after the certs and keys have been rolled out to all pods.
 // The agent needs these to be in place before the config is updated.
 // Once the config is updated, the agents will gradually enable TLS in accordance with: https://docs.mongodb.com/manual/tutorial/upgrade-cluster-to-ssl/
-func tlsAutomationConfigModification(mdb mdbv1.MongoDB) automationconfig.Modification {
+func getTLSConfigModification(mdb mdbv1.MongoDB) automationconfig.Modification {
 	if !(mdb.Spec.Security.TLS.Enabled && hasRolledOutTLS(mdb)) {
 		return automationconfig.NOOP()
 	}

--- a/pkg/controller/mongodb/mongodb_tls.go
+++ b/pkg/controller/mongodb/mongodb_tls.go
@@ -73,7 +73,7 @@ func (r *ReplicaSetReconciler) validateTLSConfig(mdb mdbv1.MongoDB) (bool, error
 }
 
 // getTLSConfigModification creates a modification function which enables TLS in the automation config.
-// THe config is only updated after the certs and keys have been rolled out to all pods.
+// The config is only updated after the certs and keys have been rolled out to all pods.
 // The agent needs these to be in place before the config is updated.
 // Once the config is updated, the agents will gradually enable TLS in accordance with: https://docs.mongodb.com/manual/tutorial/upgrade-cluster-to-ssl/
 func getTLSConfigModification(mdb mdbv1.MongoDB) automationconfig.Modification {

--- a/pkg/controller/mongodb/mongodb_tls.go
+++ b/pkg/controller/mongodb/mongodb_tls.go
@@ -3,6 +3,8 @@ package mongodb
 import (
 	"fmt"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
+
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/secret"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/configmap"
@@ -68,6 +70,39 @@ func (r *ReplicaSetReconciler) validateTLSConfig(mdb mdbv1.MongoDB) (bool, error
 	}
 
 	return true, nil
+}
+
+// tlsAutomationConfigModification creates a modification function which enables TLS in the automation config.
+// THe config is only updated after the certs and keys have been rolled out to all pods.
+// The agent needs these to be in place before the config is updated.
+// Once the config is updated, the agents will gradually enable TLS in accordance with: https://docs.mongodb.com/manual/tutorial/upgrade-cluster-to-ssl/
+func tlsAutomationConfigModification(mdb mdbv1.MongoDB) automationconfig.Modification {
+	if !(mdb.Spec.Security.TLS.Enabled && hasRolledOutTLS(mdb)) {
+		return automationconfig.NOOP()
+	}
+
+	caCertificatePath := tlsCAMountPath + tlsCACertName
+	certificateKeyPath := tlsServerMountPath + tlsServerFileName
+
+	mode := automationconfig.TLSModeRequired
+	if mdb.Spec.Security.TLS.Optional {
+		// TLSModePreferred requires server-server connections to use TLS but makes it optional for clients.
+		mode = automationconfig.TLSModePreferred
+	}
+
+	return func(config *automationconfig.AutomationConfig) {
+		// Configure CA certificate for agent
+		config.TLS.CAFilePath = caCertificatePath
+
+		for i, _ := range config.Processes {
+			config.Processes[i].Args26.Net.TLS = automationconfig.MongoDBTLS{
+				Mode:                               mode,
+				CAFile:                             caCertificatePath,
+				PEMKeyFile:                         certificateKeyPath,
+				AllowConnectionsWithoutCertificate: true,
+			}
+		}
+	}
 }
 
 // hasRolledOutTLS determines if the TLS key and certs have been mounted to all pods.

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -459,8 +459,7 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 			mdb,
 			versionConfig,
 			automationconfig.AutomationConfig{},
-			noOpAuthEnabler{},
-			tlsAutomationConfigModification(mdb),
+			getTLSConfigModification(mdb),
 		)
 		assert.NoError(t, err)
 		return ac

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -455,7 +455,13 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		assert.NoError(t, err)
 		versionConfig := manifest.BuildsForVersion(mdb.Spec.Version)
 
-		ac, err := buildAutomationConfig(mdb, versionConfig, automationconfig.AutomationConfig{}, noOpAuthEnabler{})
+		ac, err := buildAutomationConfig(
+			mdb,
+			versionConfig,
+			automationconfig.AutomationConfig{},
+			noOpAuthEnabler{},
+			tlsAutomationConfigModification(mdb),
+		)
 		assert.NoError(t, err)
 		return ac
 	}


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR refactors authentication (SCRAM-SHA) and TLS to use a unified way of setting up the automation config. We introduce a new `Modification` function for the automation config, similar to the functional builders used for Kubernetes objects. The builder is changed to accept these generic modification functions instead of having special fields for TLS and authentication. This way we reduce the operators knowledge about authentication and TLS and make the automation config simpler to extend.

With this PR we also re-arrange `automation_config.go` as the current order of types and functions is inconsistent and not top-down. There have been no other changes to that file.