### PR TITLE
Read Automation Config from Secret instead of ConfigMap

### DIFF
--- a/scripts/dev/k8s_request_data.py
+++ b/scripts/dev/k8s_request_data.py
@@ -57,6 +57,16 @@ def get_configmap_namespaced(namespace: str, name: str) -> Optional[Dict]:
     return config_map.to_dict()
 
 
+def get_secret_namespaced(namespace: str, name: str) -> Optional[Dict]:
+    corev1 = client.CoreV1Api()
+    try:
+        secret = corev1.read_namespaced_secret(name, namespace, pretty="true")
+    except ApiException as e:
+        print("Exception when calling read_namespaced_secret: %s\n" % e)
+        return None
+    return secret.to_dict()
+
+
 def get_pods_namespaced(namespace: str) -> Optional[List]:
     corev1 = client.CoreV1Api()
     try:


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

We are now storing the Automation Config in a secret, so we need to read the configs from secrets instead.

EVG: https://evergreen.mongodb.com/version/5f182ca7562343139d5d49b0