### PR TITLE
Add Delete Function for ConfigMap

### DIFF
--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -26,7 +26,7 @@ type Client interface {
 	k8sClient.Client
 	// TODO: remove this function, add mongodb package which has GetAndUpdate function
 	GetAndUpdate(nsName types.NamespacedName, obj runtime.Object, updateFunc func()) error
-	configmap.GetUpdateCreator
+	configmap.GetUpdateCreateDeleter
 	service.GetUpdateCreator
 	secret.GetUpdateCreateDeleter
 	statefulset.GetUpdateCreateDeleter
@@ -66,6 +66,17 @@ func (c client) UpdateConfigMap(cm corev1.ConfigMap) error {
 // CreateConfigMap provides a thin wrapper and client.Client to create corev1.ConfigMap types
 func (c client) CreateConfigMap(cm corev1.ConfigMap) error {
 	return c.Create(context.TODO(), &cm)
+}
+
+// DeleteConfigMap deletes the configmap of the given object key
+func (c client) DeleteConfigMap(key k8sClient.ObjectKey) error {
+	cm := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+	}
+	return c.Delete(context.TODO(), &cm)
 }
 
 // GetSecret provides a thin wrapper and client.Client to access corev1.Secret types

--- a/pkg/kube/client/client_test.go
+++ b/pkg/kube/client/client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/configmap"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -61,4 +63,22 @@ func TestAddingDataField_ModifiesExistingObject(t *testing.T) {
 
 	assert.Contains(t, cm.Data, "new-field")
 	assert.Equal(t, cm.Data["new-field"], "value")
+}
+
+func TestDeleteConfigMap(t *testing.T) {
+	cm := configmap.Builder().
+		SetName("config-map").
+		SetNamespace("default").
+		Build()
+
+	client := NewClient(NewMockedClient())
+	err := client.CreateConfigMap(cm)
+	assert.NoError(t, err)
+
+	err = client.DeleteConfigMap(types.NamespacedName{Name: "config-map", Namespace: "default"})
+	assert.NoError(t, err)
+
+	_, err = client.GetConfigMap(types.NamespacedName{Name: "config-map", Namespace: "default"})
+	assert.Error(t, err)
+	assert.Equal(t, err, notFoundError())
 }

--- a/pkg/kube/client/client_test.go
+++ b/pkg/kube/client/client_test.go
@@ -79,6 +79,5 @@ func TestDeleteConfigMap(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = client.GetConfigMap(types.NamespacedName{Name: "config-map", Namespace: "default"})
-	assert.Error(t, err)
 	assert.Equal(t, err, notFoundError())
 }

--- a/pkg/kube/client/mocked_client.go
+++ b/pkg/kube/client/mocked_client.go
@@ -76,7 +76,13 @@ func (m *mockedClient) List(_ context.Context, _ runtime.Object, _ ...k8sClient.
 	return nil
 }
 
-func (m *mockedClient) Delete(_ context.Context, _ runtime.Object, _ ...k8sClient.DeleteOption) error {
+func (m *mockedClient) Delete(_ context.Context, obj runtime.Object, _ ...k8sClient.DeleteOption) error {
+	relevantMap := m.ensureMapFor(obj)
+	objKey, err := k8sClient.ObjectKeyFromObject(obj)
+	if err != nil {
+		return err
+	}
+	delete(relevantMap, objKey)
 	return nil
 }
 

--- a/pkg/kube/configmap/configmap.go
+++ b/pkg/kube/configmap/configmap.go
@@ -21,6 +21,10 @@ type Creator interface {
 	CreateConfigMap(cm corev1.ConfigMap) error
 }
 
+type Deleter interface {
+	DeleteConfigMap(key client.ObjectKey) error
+}
+
 type GetUpdater interface {
 	Getter
 	Updater
@@ -30,6 +34,13 @@ type GetUpdateCreator interface {
 	Getter
 	Updater
 	Creator
+}
+
+type GetUpdateCreateDeleter interface {
+	Getter
+	Updater
+	Creator
+	Deleter
 }
 
 // ReadKey accepts a ConfigMap Getter, the object of the ConfigMap to get, and the key within


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR adds a simple function to delete ConfigMaps which is consistent with our current patterns.