### PR TITLE
Use generic map for "args2_6" in automation config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/rogpeppe/go-internal v1.5.2 // indirect
 	github.com/spf13/cobra v0.0.7 // indirect
+	github.com/stretchr/objx v0.3.0
 	github.com/stretchr/testify v1.4.0
+	github.com/xdg/stringprep v1.0.0
 	go.mongodb.org/mongo-driver v1.3.2
 	go.uber.org/zap v1.14.1
 	google.golang.org/appengine v1.6.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -994,6 +994,8 @@ github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -29,15 +29,15 @@ type Role struct {
 }
 
 type Process struct {
-	Name                        string      `json:"name"`
-	HostName                    string      `json:"hostname"`
-	Args26                      Args26      `json:"args2_6"`
-	FeatureCompatibilityVersion string      `json:"featureCompatibilityVersion"`
-	ProcessType                 ProcessType `json:"processType"`
-	Version                     string      `json:"version"`
-	AuthSchemaVersion           int         `json:"authSchemaVersion"`
-	SystemLog                   SystemLog   `json:"systemLog"`
-	WiredTiger                  WiredTiger  `json:"wiredTiger"`
+	Name                        string                 `json:"name"`
+	HostName                    string                 `json:"hostname"`
+	Args26                      map[string]interface{} `json:"args2_6"`
+	FeatureCompatibilityVersion string                 `json:"featureCompatibilityVersion"`
+	ProcessType                 ProcessType            `json:"processType"`
+	Version                     string                 `json:"version"`
+	AuthSchemaVersion           int                    `json:"authSchemaVersion"`
+	SystemLog                   SystemLog              `json:"systemLog"`
+	WiredTiger                  WiredTiger             `json:"wiredTiger"`
 }
 
 func newProcess(name, hostName, version, replSetName string, opts ...func(process *Process)) Process {
@@ -52,17 +52,16 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 			Path:        path.Join(DefaultAgentLogPath, "/mongodb.log"),
 		},
 		AuthSchemaVersion: 5,
-		Args26: Args26{
-			Net: Net{
-				Port: 27017,
-				TLS: MongoDBTLS{
-					Mode: TLSModeDisabled,
-				},
+		Args26: map[string]interface{}{
+			"net": map[string]interface{}{
+				"port": 27017,
 			},
-			Storage: Storage{
-				DBPath: DefaultMongoDBDataDir,
+			"storage": map[string]interface{}{
+				"dbPath": DefaultMongoDBDataDir,
 			},
-			Replication: Replication{ReplicaSetName: replSetName},
+			"replication": map[string]interface{}{
+				"replSetName": replSetName,
+			},
 		},
 	}
 
@@ -80,11 +79,6 @@ type Args26 struct {
 	Replication Replication `json:"replication"`
 }
 
-type Net struct {
-	Port int        `json:"port"`
-	TLS  MongoDBTLS `json:"tls"`
-}
-
 type TLSMode string
 
 const (
@@ -93,13 +87,6 @@ const (
 	TLSModePreferred TLSMode = "preferTLS"
 	TLSModeRequired  TLSMode = "requireTLS"
 )
-
-type MongoDBTLS struct {
-	Mode                               TLSMode `json:"mode"`
-	PEMKeyFile                         string  `json:"certificateKeyFile,omitempty"`
-	CAFile                             string  `json:"CAFile,omitempty"`
-	AllowConnectionsWithoutCertificate bool    `json:"allowConnectionsWithoutCertificates"`
-}
 
 type Security struct {
 	ClusterAuthMode string `json:"clusterAuthMode,omitempty"`

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -4,6 +4,7 @@ import (
 	"path"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/authentication/scramcredentials"
+	"github.com/stretchr/objx"
 )
 
 const (
@@ -29,18 +30,23 @@ type Role struct {
 }
 
 type Process struct {
-	Name                        string                 `json:"name"`
-	HostName                    string                 `json:"hostname"`
-	Args26                      map[string]interface{} `json:"args2_6"`
-	FeatureCompatibilityVersion string                 `json:"featureCompatibilityVersion"`
-	ProcessType                 ProcessType            `json:"processType"`
-	Version                     string                 `json:"version"`
-	AuthSchemaVersion           int                    `json:"authSchemaVersion"`
-	SystemLog                   SystemLog              `json:"systemLog"`
-	WiredTiger                  WiredTiger             `json:"wiredTiger"`
+	Name                        string      `json:"name"`
+	HostName                    string      `json:"hostname"`
+	Args26                      objx.Map    `json:"args2_6"`
+	FeatureCompatibilityVersion string      `json:"featureCompatibilityVersion"`
+	ProcessType                 ProcessType `json:"processType"`
+	Version                     string      `json:"version"`
+	AuthSchemaVersion           int         `json:"authSchemaVersion"`
+	SystemLog                   SystemLog   `json:"systemLog"`
+	WiredTiger                  WiredTiger  `json:"wiredTiger"`
 }
 
 func newProcess(name, hostName, version, replSetName string, opts ...func(process *Process)) Process {
+	args26 := objx.New(map[string]interface{}{})
+	args26.Set("net.port", 27017)
+	args26.Set("storage.dbPath", DefaultMongoDBDataDir)
+	args26.Set("replication.replSetName", replSetName)
+
 	p := Process{
 		Name:                        name,
 		HostName:                    hostName,
@@ -52,17 +58,7 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 			Path:        path.Join(DefaultAgentLogPath, "/mongodb.log"),
 		},
 		AuthSchemaVersion: 5,
-		Args26: map[string]interface{}{
-			"net": map[string]interface{}{
-				"port": 27017,
-			},
-			"storage": map[string]interface{}{
-				"dbPath": DefaultMongoDBDataDir,
-			},
-			"replication": map[string]interface{}{
-				"replSetName": replSetName,
-			},
-		},
+		Args26:            args26,
 	}
 
 	for _, opt := range opts {
@@ -70,13 +66,6 @@ func newProcess(name, hostName, version, replSetName string, opts ...func(proces
 	}
 
 	return p
-}
-
-type Args26 struct {
-	Net         Net         `json:"net"`
-	Security    Security    `json:"security"`
-	Storage     Storage     `json:"storage"`
-	Replication Replication `json:"replication"`
 }
 
 type TLSMode string
@@ -87,18 +76,6 @@ const (
 	TLSModePreferred TLSMode = "preferTLS"
 	TLSModeRequired  TLSMode = "requireTLS"
 )
-
-type Security struct {
-	ClusterAuthMode string `json:"clusterAuthMode,omitempty"`
-}
-
-type Storage struct {
-	DBPath string `json:"dbPath"`
-}
-
-type Replication struct {
-	ReplicaSetName string `json:"replSetName"`
-}
 
 type ProcessType string
 

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -40,12 +40,8 @@ func TestBuildAutomationConfig(t *testing.T) {
 	for i, p := range ac.Processes {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
-		assert.Equal(t, map[string]interface{}{
-			"dbPath": DefaultMongoDBDataDir,
-		}, p.Args26["storage"])
-		assert.Equal(t, map[string]interface{}{
-			"replSetName": "my-rs",
-		}, p.Args26["replication"], "replication should be configured based on the replica set name provided")
+		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Get("storage.dbPath").MustStr())
+		assert.Equal(t, "my-rs", p.Args26.Get("replication.replSetName").MustStr())
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
@@ -149,9 +145,7 @@ func TestProcessHasPortSetToDefault(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, ac.Processes, 3)
 	for _, process := range ac.Processes {
-		assert.Equal(t, map[string]interface{}{
-			"port": 27017,
-		}, process.Args26["net"])
+		assert.Equal(t, 27017, process.Args26.Get("net.port").MustInt())
 	}
 }
 

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -40,9 +40,12 @@ func TestBuildAutomationConfig(t *testing.T) {
 	for i, p := range ac.Processes {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
-		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Storage.DBPath)
-		assert.Equal(t, TLSModeDisabled, p.Args26.Net.TLS.Mode)
-		assert.Equal(t, "my-rs", p.Args26.Replication.ReplicaSetName, "replication should be configured based on the replica set name provided")
+		assert.Equal(t, map[string]interface{}{
+			"dbPath": DefaultMongoDBDataDir,
+		}, p.Args26["storage"])
+		assert.Equal(t, map[string]interface{}{
+			"replSetName": "my-rs",
+		}, p.Args26["replication"], "replication should be configured based on the replica set name provided")
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
@@ -145,9 +148,11 @@ func TestProcessHasPortSetToDefault(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, ac.Processes, 3)
-	assert.Equal(t, ac.Processes[0].Args26.Net.Port, 27017)
-	assert.Equal(t, ac.Processes[1].Args26.Net.Port, 27017)
-	assert.Equal(t, ac.Processes[2].Args26.Net.Port, 27017)
+	for _, process := range ac.Processes {
+		assert.Equal(t, map[string]interface{}{
+			"port": 27017,
+		}, process.Args26["net"])
+	}
 }
 
 func TestVersionManifest_BuildsForVersion(t *testing.T) {

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -40,8 +40,8 @@ func TestBuildAutomationConfig(t *testing.T) {
 	for i, p := range ac.Processes {
 		assert.Equal(t, Mongod, p.ProcessType)
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
-		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Get("storage.dbPath").MustStr())
-		assert.Equal(t, "my-rs", p.Args26.Get("replication.replSetName").MustStr())
+		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Get("storage.dbPath").Data())
+		assert.Equal(t, "my-rs", p.Args26.Get("replication.replSetName").Data())
 		assert.Equal(t, toHostName("my-rs", i), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
@@ -145,7 +145,7 @@ func TestProcessHasPortSetToDefault(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, ac.Processes, 3)
 	for _, process := range ac.Processes {
-		assert.Equal(t, 27017, process.Args26.Get("net.port").MustInt())
+		assert.Equal(t, 27017, process.Args26.Get("net.port").Data())
 	}
 }
 

--- a/pkg/controller/mongodb/mongodb_tls.go
+++ b/pkg/controller/mongodb/mongodb_tls.go
@@ -165,13 +165,12 @@ func tlsConfigModification(mdb mdbv1.MongoDB, cert, key string) automationconfig
 		config.TLS.CAFilePath = caCertificatePath
 
 		for i := range config.Processes {
-			net := config.Processes[i].Args26["net"].(map[string]interface{})
-			net["tls"] = map[string]interface{}{
-				"mode":                                mode,
-				"CAFile":                              caCertificatePath,
-				"certificateKeyFile":                  certificateKeyPath,
-				"allowConnectionsWithoutCertificates": true,
-			}
+			args := config.Processes[i].Args26
+
+			args.Set("net.tls.mode", mode)
+			args.Set("net.tls.CAFile", caCertificatePath)
+			args.Set("net.tls.certificateKeyFile", certificateKeyPath)
+			args.Set("net.tls.allowConnectionsWithoutCertificates", true)
 		}
 	}
 }

--- a/pkg/controller/mongodb/mongodb_tls.go
+++ b/pkg/controller/mongodb/mongodb_tls.go
@@ -165,11 +165,12 @@ func tlsConfigModification(mdb mdbv1.MongoDB, cert, key string) automationconfig
 		config.TLS.CAFilePath = caCertificatePath
 
 		for i := range config.Processes {
-			config.Processes[i].Args26.Net.TLS = automationconfig.MongoDBTLS{
-				Mode:                               mode,
-				CAFile:                             caCertificatePath,
-				PEMKeyFile:                         certificateKeyPath,
-				AllowConnectionsWithoutCertificate: true,
+			net := config.Processes[i].Args26["net"].(map[string]interface{})
+			net["tls"] = map[string]interface{}{
+				"mode":                                mode,
+				"CAFile":                              caCertificatePath,
+				"certificateKeyFile":                  certificateKeyPath,
+				"allowConnectionsWithoutCertificates": true,
 			}
 		}
 	}

--- a/pkg/controller/mongodb/mongodb_tls_test.go
+++ b/pkg/controller/mongodb/mongodb_tls_test.go
@@ -106,9 +106,10 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			assert.Equal(t, automationconfig.MongoDBTLS{
-				Mode: automationconfig.TLSModeDisabled,
-			}, process.Args26.Net.TLS)
+			net := process.Args26["net"].(map[string]interface{})
+			assert.Equal(t, map[string]interface{}{
+				"mode": automationconfig.TLSModeDisabled,
+			}, net["tls"])
 		}
 	})
 
@@ -122,9 +123,10 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			assert.Equal(t, automationconfig.MongoDBTLS{
-				Mode: automationconfig.TLSModeDisabled,
-			}, process.Args26.Net.TLS)
+			net := process.Args26["net"].(map[string]interface{})
+			assert.Equal(t, map[string]interface{}{
+				"mode": automationconfig.TLSModeDisabled,
+			}, net["tls"])
 		}
 	})
 
@@ -141,12 +143,13 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		for _, process := range ac.Processes {
 			operatorSecretFileName := tlsOperatorSecretFileName("CERT", "KEY")
 
-			assert.Equal(t, automationconfig.MongoDBTLS{
-				Mode:                               automationconfig.TLSModeRequired,
-				PEMKeyFile:                         tlsOperatorSecretMountPath + operatorSecretFileName,
-				CAFile:                             tlsCAMountPath + tlsCACertName,
-				AllowConnectionsWithoutCertificate: true,
-			}, process.Args26.Net.TLS)
+			net := process.Args26["net"].(map[string]interface{})
+			assert.Equal(t, map[string]interface{}{
+				"mode":                                automationconfig.TLSModeRequired,
+				"certificateKeyFile":                  tlsOperatorSecretMountPath + operatorSecretFileName,
+				"CAFile":                              tlsCAMountPath + tlsCACertName,
+				"allowConnectionsWithoutCertificates": true,
+			}, net["tls"])
 		}
 	})
 
@@ -164,12 +167,13 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		for _, process := range ac.Processes {
 			operatorSecretFileName := tlsOperatorSecretFileName("CERT", "KEY")
 
-			assert.Equal(t, automationconfig.MongoDBTLS{
-				Mode:                               automationconfig.TLSModePreferred,
-				PEMKeyFile:                         tlsOperatorSecretMountPath + operatorSecretFileName,
-				CAFile:                             tlsCAMountPath + tlsCACertName,
-				AllowConnectionsWithoutCertificate: true,
-			}, process.Args26.Net.TLS)
+			net := process.Args26["net"].(map[string]interface{})
+			assert.Equal(t, map[string]interface{}{
+				"mode":                                automationconfig.TLSModePreferred,
+				"certificateKeyFile":                  tlsOperatorSecretMountPath + operatorSecretFileName,
+				"CAFile":                              tlsCAMountPath + tlsCACertName,
+				"allowConnectionsWithoutCertificates": true,
+			}, net["tls"])
 		}
 	})
 }

--- a/pkg/controller/mongodb/mongodb_tls_test.go
+++ b/pkg/controller/mongodb/mongodb_tls_test.go
@@ -106,10 +106,7 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			net := process.Args26["net"].(map[string]interface{})
-			assert.Equal(t, map[string]interface{}{
-				"mode": automationconfig.TLSModeDisabled,
-			}, net["tls"])
+			assert.False(t, process.Args26.Has("net.tls"))
 		}
 	})
 
@@ -123,10 +120,7 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		}, ac.TLS)
 
 		for _, process := range ac.Processes {
-			net := process.Args26["net"].(map[string]interface{})
-			assert.Equal(t, map[string]interface{}{
-				"mode": automationconfig.TLSModeDisabled,
-			}, net["tls"])
+			assert.False(t, process.Args26.Has("net.tls"))
 		}
 	})
 
@@ -143,13 +137,10 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		for _, process := range ac.Processes {
 			operatorSecretFileName := tlsOperatorSecretFileName("CERT", "KEY")
 
-			net := process.Args26["net"].(map[string]interface{})
-			assert.Equal(t, map[string]interface{}{
-				"mode":                                automationconfig.TLSModeRequired,
-				"certificateKeyFile":                  tlsOperatorSecretMountPath + operatorSecretFileName,
-				"CAFile":                              tlsCAMountPath + tlsCACertName,
-				"allowConnectionsWithoutCertificates": true,
-			}, net["tls"])
+			assert.Equal(t, automationconfig.TLSModeRequired, process.Args26.Get("net.tls.mode").Data())
+			assert.Equal(t, tlsOperatorSecretMountPath+operatorSecretFileName, process.Args26.Get("net.tls.certificateKeyFile").Data())
+			assert.Equal(t, tlsCAMountPath+tlsCACertName, process.Args26.Get("net.tls.CAFile").Data())
+			assert.True(t, process.Args26.Get("net.tls.allowConnectionsWithoutCertificates").MustBool())
 		}
 	})
 
@@ -167,13 +158,10 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		for _, process := range ac.Processes {
 			operatorSecretFileName := tlsOperatorSecretFileName("CERT", "KEY")
 
-			net := process.Args26["net"].(map[string]interface{})
-			assert.Equal(t, map[string]interface{}{
-				"mode":                                automationconfig.TLSModePreferred,
-				"certificateKeyFile":                  tlsOperatorSecretMountPath + operatorSecretFileName,
-				"CAFile":                              tlsCAMountPath + tlsCACertName,
-				"allowConnectionsWithoutCertificates": true,
-			}, net["tls"])
+			assert.Equal(t, automationconfig.TLSModePreferred, process.Args26.Get("net.tls.mode").Data())
+			assert.Equal(t, tlsOperatorSecretMountPath+operatorSecretFileName, process.Args26.Get("net.tls.certificateKeyFile").Data())
+			assert.Equal(t, tlsCAMountPath+tlsCACertName, process.Args26.Get("net.tls.CAFile").Data())
+			assert.True(t, process.Args26.Get("net.tls.allowConnectionsWithoutCertificates").MustBool())
 		}
 	})
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR is in preparation for CLOUDP-58544 which adds support for arbitrary MongoDB configuration in the CRD. To support this change, we need to treat "args2_6" as a generic map, instead of a hard-coded struct.

To simplify interactions with the map, this PR uses the objx library: https://github.com/stretchr/objx. The library helps us write better code with less typecasting without having to write our helper functions. On top of that, it also includes support for merging maps which will be helpful for the next PR. Based on the following criteria I feel that the library is good enough to be included in our code base:

- Maturity: the library has been around for a while and is very well-tested. Most issues have been closed and no major features seem to be missing.
- Pulse: the library isn't seeing many changes but because of it's limited scope and current state there aren't many changes to be made.
- License: MIT