### PR TITLE
CLOUDP-58544: Add support for arbitrary mongod config in CRD

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -154,6 +154,7 @@ task_groups:
     - e2e_test_replica_set_tls_rotate
     - e2e_test_statefulset_arbitrary_config
     - e2e_test_statefulset_arbitrary_config_update
+    - e2e_test_replica_set_mongod_config
   teardown_task:
     - func: upload_e2e_logs
 
@@ -297,6 +298,12 @@ tasks:
       - func: run_e2e_test
         vars:
           test: statefulset_arbitrary_config_update
+
+  - name: e2e_test_replica_set_mongod_config
+    commands:
+      - func: run_e2e_test
+        vars:
+          test: e2e_test_replica_set_mongod_config
 
 buildvariants:
   - name: go_unit_tests

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -303,7 +303,7 @@ tasks:
     commands:
       - func: run_e2e_test
         vars:
-          test: e2e_test_replica_set_mongod_config
+          test: replica_set_mongod_config
 
 buildvariants:
   - name: go_unit_tests

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/imdario/mergo v0.3.9
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/klauspost/compress v1.9.8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect

--- a/pkg/controller/mongodb/replica_set_controller.go
+++ b/pkg/controller/mongodb/replica_set_controller.go
@@ -482,7 +482,7 @@ func (r ReplicaSetReconciler) buildAutomationConfigConfigMap(mdb mdbv1.MongoDB) 
 // into the configuration set up by the operator.
 func getMongodConfigModification(mdb mdbv1.MongoDB) automationconfig.Modification {
 	return func(ac *automationconfig.AutomationConfig) {
-		for i, _ := range ac.Processes {
+		for i := range ac.Processes {
 			// Mergo requires both objects to have the same type
 			mergo.Merge(&ac.Processes[i].Args26, objx.New(mdb.Spec.AdditionalMongodConfig.Object), mergo.WithOverride)
 		}

--- a/pkg/controller/mongodb/replica_set_controller.go
+++ b/pkg/controller/mongodb/replica_set_controller.go
@@ -360,6 +360,7 @@ func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.
 		SetMongoDBVersion(mdb.Spec.Version).
 		SetFCV(mdb.GetFCV()).
 		AddVersion(mdbVersionConfig).
+		AddModifications(getMongodConfigModification(mdb)).
 		AddModifications(modifications...).
 		SetToolsVersion(dummyToolsVersionConfig())
 
@@ -461,7 +462,6 @@ func (r ReplicaSetReconciler) buildAutomationConfigConfigMap(mdb mdbv1.MongoDB) 
 		currentAC,
 		authModification,
 		tlsModification,
-		getMongodConfigModification(mdb),
 	)
 	if err != nil {
 		return corev1.ConfigMap{}, err

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -308,6 +308,7 @@ func TestAutomationConfig_CustomMongodConfig(t *testing.T) {
 
 	mongodConfig := objx.New(map[string]interface{}{})
 	mongodConfig.Set("net.port", 1000)
+	mongodConfig.Set("storage.other", "value")
 	mongodConfig.Set("arbitrary.config.path", "value")
 	mdb.Spec.AdditionalMongodConfig.Object = mongodConfig
 
@@ -323,8 +324,9 @@ func TestAutomationConfig_CustomMongodConfig(t *testing.T) {
 		// Ensure port was overridden
 		assert.Equal(t, float64(1000), p.Args26.Get("net.port").Data())
 
-		// Ensure custom value was added
+		// Ensure custom values were added
 		assert.Equal(t, "value", p.Args26.Get("arbitrary.config.path").Data())
+		assert.Equal(t, "value", p.Args26.Get("storage.other").Data())
 
 		// Ensure default settings went unchanged
 		assert.Equal(t, automationconfig.DefaultMongoDBDataDir, p.Args26.Get("storage.dbPath").Data())

--- a/pkg/controller/mongodb/replicaset_controller_test.go
+++ b/pkg/controller/mongodb/replicaset_controller_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/objx"
+
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/authentication/scram"
@@ -299,6 +301,35 @@ func TestAutomationConfig_versionIsNotBumpedWithNoChanges(t *testing.T) {
 	currentAc, err = getCurrentAutomationConfig(client.NewClient(mgr.GetClient()), mdb)
 	assert.NoError(t, err)
 	assert.Equal(t, currentAc.Version, 1)
+}
+
+func TestAutomationConfig_CustomMongodConfig(t *testing.T) {
+	mdb := newTestReplicaSet()
+
+	mongodConfig := objx.New(map[string]interface{}{})
+	mongodConfig.Set("net.port", 1000)
+	mongodConfig.Set("arbitrary.config.path", "value")
+	mdb.Spec.AdditionalMongodConfig.Object = mongodConfig
+
+	mgr := client.NewManager(&mdb)
+	r := newReconciler(mgr, mockManifestProvider(mdb.Spec.Version))
+	res, err := r.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
+	assertReconciliationSuccessful(t, res, err)
+
+	currentAc, err := getCurrentAutomationConfig(client.NewClient(mgr.GetClient()), mdb)
+	assert.NoError(t, err)
+
+	for _, p := range currentAc.Processes {
+		// Ensure port was overridden
+		assert.Equal(t, float64(1000), p.Args26.Get("net.port").Data())
+
+		// Ensure custom value was added
+		assert.Equal(t, "value", p.Args26.Get("arbitrary.config.path").Data())
+
+		// Ensure default settings went unchanged
+		assert.Equal(t, automationconfig.DefaultMongoDBDataDir, p.Args26.Get("storage.dbPath").Data())
+		assert.Equal(t, mdb.Name, p.Args26.Get("replication.replSetName").Data())
+	}
 }
 
 func TestExistingPasswordAndKeyfile_AreUsedWhenTheSecretExists(t *testing.T) {

--- a/test/e2e/replica_set_mongod_config/replica_set_mongod_config_test.go
+++ b/test/e2e/replica_set_mongod_config/replica_set_mongod_config_test.go
@@ -1,0 +1,42 @@
+package replica_set_mongod_config
+
+import (
+	"testing"
+
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+	f "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/objx"
+)
+
+func TestMain(m *testing.M) {
+	f.MainEntry(m)
+}
+
+func TestReplicaSet(t *testing.T) {
+	ctx, shouldCleanup := setup.InitTest(t)
+
+	if shouldCleanup {
+		defer ctx.Cleanup()
+	}
+	mdb, user := e2eutil.NewTestMongoDB("mdb0")
+
+	_, err := setup.GeneratePasswordForUser(user, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Override the journal compressor setting
+	setting := "storage.wiredTiger.engineConfig.journalCompressor"
+	value := "zlib"
+	mongodConfig := objx.New(map[string]interface{}{})
+	mongodConfig.Set(setting, value)
+	mdb.Spec.AdditionalMongodConfig.Object = mongodConfig
+
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
+	t.Run("Test Basic Connectivity", mongodbtests.Connectivity(&mdb))
+	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
+	t.Run("Mongod config has been set", mongodbtests.EnsureMongodConfig(&mdb, setting, value))
+}


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR adds support for overriding mongod configuration in the CRD. Any settings will override the default ones without exception and the same settings must be used for all members.