### PR TITLE
add WithAgentFlags function

### DIFF
--- a/pkg/agent/agentflags.go
+++ b/pkg/agent/agentflags.go
@@ -7,9 +7,9 @@ type StartupParameter struct {
 	Value string `json:"value"`
 }
 
-// WithAgentFlags takes a slice of envVars corresponding to
-// pairs of key-value agent startup flags and concatenates them
-// into a single string that is then passed as env variable AGENT_FLAGS
+// StartupParametersToAgentFlag takes a slice of StartupParameters
+// and concatenates them into a single string that is then
+// returned as env variable AGENT_FLAGS
 func StartupParametersToAgentFlag(parameters ...StartupParameter) corev1.EnvVar {
 	agentParams := ""
 	for _, param := range parameters {

--- a/pkg/agent/agentflags.go
+++ b/pkg/agent/agentflags.go
@@ -1,0 +1,19 @@
+package agent
+
+import corev1 "k8s.io/api/core/v1"
+
+type StartupParameter struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// WithAgentFlags takes a slice of envVars corresponding to
+// pairs of key-value agent startup flags and concatenates them
+// into a single string that is then passed as env variable AGENT_FLAGS
+func StartupParametersToAgentFlag(parameters ...StartupParameter) corev1.EnvVar {
+	agentParams := ""
+	for _, param := range parameters {
+		agentParams += " -" + param.Key + " " + param.Value
+	}
+	return corev1.EnvVar{Name: "AGENT_FLAGS", Value: agentParams}
+}

--- a/pkg/agent/agentflags_test.go
+++ b/pkg/agent/agentflags_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentFlagIsCorrectlyCreated(t *testing.T) {
+	parameters := []StartupParameter{
+		{
+			Key:   "Key1",
+			Value: "Value1",
+		},
+		{
+			Key:   "Key2",
+			Value: "Value2",
+		},
+	}
+
+	envVar := StartupParametersToAgentFlag(parameters...)
+	assert.Equal(t, "AGENT_FLAGS", envVar.Name)
+	assert.Equal(t, " -Key1 Value1 -Key2 Value2", envVar.Value)
+
+}
+
+func TestAgentFlagEmptyParameters(t *testing.T) {
+	parameters := []StartupParameter{}
+
+	envVar := StartupParametersToAgentFlag(parameters...)
+	assert.Equal(t, "AGENT_FLAGS", envVar.Name)
+	assert.Equal(t, "", envVar.Value)
+
+}

--- a/pkg/agent/agenthealth.go
+++ b/pkg/agent/agenthealth.go
@@ -1,4 +1,4 @@
-package agenthealth
+package agent
 
 import (
 	"time"

--- a/pkg/kube/container/containers.go
+++ b/pkg/kube/container/containers.go
@@ -152,3 +152,16 @@ func WithSecurityContext(context corev1.SecurityContext) Modification {
 		container.SecurityContext = &context
 	}
 }
+
+// WithAgentFlags takes a slice of envVars corresponding to
+// pairs of key-value agent startup flags and concatenates them
+// into a single string that is then passed as env variable AGENT_FLAGS
+func WithAgentFlags(envs ...corev1.EnvVar) Modification {
+	return func(container *corev1.Container) {
+		agentParams := ""
+		for _, variable := range envs {
+			agentParams += " -" + variable.Name + " " + variable.Value
+		}
+		container.Env = envvar.MergeWithOverride(container.Env, []corev1.EnvVar{{Name: "AGENT_FLAGS", Value: agentParams}})
+	}
+}

--- a/pkg/kube/container/containers.go
+++ b/pkg/kube/container/containers.go
@@ -152,16 +152,3 @@ func WithSecurityContext(context corev1.SecurityContext) Modification {
 		container.SecurityContext = &context
 	}
 }
-
-// WithAgentFlags takes a slice of envVars corresponding to
-// pairs of key-value agent startup flags and concatenates them
-// into a single string that is then passed as env variable AGENT_FLAGS
-func WithAgentFlags(envs ...corev1.EnvVar) Modification {
-	return func(container *corev1.Container) {
-		agentParams := ""
-		for _, variable := range envs {
-			agentParams += " -" + variable.Name + " " + variable.Value
-		}
-		container.Env = envvar.MergeWithOverride(container.Env, []corev1.EnvVar{{Name: "AGENT_FLAGS", Value: agentParams}})
-	}
-}


### PR DESCRIPTION
This PR adds a `WithAgentFlags` function that sets up the `AGENT_FLAGS` environment variable from a slice of env var representing single agent startup flags. 

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?