### PR TITLE
Removed log call in goroutine

### DIFF
--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -284,7 +284,6 @@ func IsReachableDuringWithConnection(mdb *mdbv1.MongoDB, interval time.Duration,
 			for {
 				select {
 				case <-ctx.Done():
-					t.Log("context cancelled, no longer checking connectivity") //nolint
 					return
 				case <-time.After(interval):
 					if err := connectFunc(); err != nil {
@@ -352,7 +351,7 @@ func getCommandLineOptions(mdb *mdbv1.MongoDB, username string, password string)
 	var result bson.M
 	err = client.
 		Database("admin").
-		RunCommand(ctx, bson.D{{"getCmdLineOpts", 1}}).
+		RunCommand(ctx, bson.D{primitive.E{Key: "getCmdLineOpts", Value: 1}}).
 		Decode(&result)
 
 	return result, err


### PR DESCRIPTION
We still have some failures from time to time in our `e2e_readiness_probe`: https://evergreen.mongodb.com/task/mongodb_kubernetes_operator_e2e_tests_e2e_test_replica_set_readiness_probe_3b8ea122eb9953a12326d0285c03b2869bbbdd94_20_08_26_12_28_25/0

`[2020/08/26 12:40:09.830] panic: Log in goroutine after TestReplicaSetReadinessProbeScaling/MongoDB_is_reachable has completed`

calling `t.Log` inside a goroutine is considered wrong and we added a `nolint` in the past for the exact reason. Since the log isn't fundamental for our testing, I would just remove it. 

Note that all the test have actually passed when we reach the line that causes that error

There's also a change in another line due to the linter complaining 

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
