### PR TITLE
Fix release task

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -340,7 +340,7 @@ tasks:
         vars:
           old_image: quay.io/mongodb/community-operator-dev
           new_image: quay.io/mongodb/mongodb-kubernetes-operator
-          image_type: operator
+          image_type: mongodb-kubernetes-operator
 
   - name: release_version_upgrade_hook
     commands:
@@ -350,7 +350,7 @@ tasks:
         vars:
           old_image: quay.io/mongodb/community-operator-version-upgrade-post-start-hook
           new_image: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook
-          image_type: versionhook
+          image_type: version-upgrade-hook
 
 
 buildvariants:


### PR DESCRIPTION
This PR should fix the error encountered during the latest release:

https://evergreen.mongodb.com/task/mongodb_kubernetes_operator_release_images_quay_release_operator_patch_2957f6a75cb4e98fcf0aa7ec94b62ddb74898e15_5f4699083627e02af45eb038_20_08_26_17_16_57

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
