### PR TITLE
CLOUDP-66666: Update Replica Set test to check for the clusterAuthMode admin setting

### DIFF
--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -124,7 +124,10 @@ func HasFeatureCompatibilityVersion(mdb *mdbv1.MongoDB, fcv string, tries int, u
 				continue
 			}
 
-			expected := primitive.M{"version": fcv}
+			expected := map[string]interface{}{
+				"version": fcv,
+			}
+
 			found = reflect.DeepEqual(expected, result["featureCompatibilityVersion"])
 			tries--
 		}

--- a/test/e2e/replica_set/replica_set_test.go
+++ b/test/e2e/replica_set/replica_set_test.go
@@ -28,6 +28,7 @@ func TestReplicaSet(t *testing.T) {
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
+	t.Run("Keyfile authentication is configured", mongodbtests.IsConfiguredWithKeyfileAuthentication(&mdb, 3, user.Name, password))
 	t.Run("Test Basic Connectivity", mongodbtests.Connectivity(&mdb, user.Name, password))
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR introduces a new function which gets any given admin parameter and updates the replica set test to check for cluster auth mode.

TODO: in future PRs
*  Update TLS tests to check for this also 
* Add this check as one that gets run on every test
