### PR TITLE
Added CLUSTER_DNS_NAME env variable to customise headless service 

### DIFF
--- a/pkg/controller/mongodb/replica_set_controller.go
+++ b/pkg/controller/mongodb/replica_set_controller.go
@@ -54,6 +54,7 @@ import (
 
 const (
 	agentImageEnv                = "AGENT_IMAGE"
+	clusterDNSName               = "CLUSTER_DNS_NAME"
 	versionUpgradeHookImageEnv   = "VERSION_UPGRADE_HOOK_IMAGE"
 	agentHealthStatusFilePathEnv = "AGENT_STATUS_FILEPATH"
 	mongodbToolsVersionEnv       = "MONGODB_TOOLS_VERSION"
@@ -369,7 +370,7 @@ func (r ReplicaSetReconciler) ensureAutomationConfig(mdb mdbv1.MongoDB) error {
 }
 
 func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.MongoDbVersionConfig, currentAc automationconfig.AutomationConfig, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
-	domain := getDomain(mdb.ServiceName(), mdb.Namespace, "")
+	domain := getDomain(mdb.ServiceName(), mdb.Namespace, os.Getenv(clusterDNSName))
 
 	builder := automationconfig.NewBuilder().
 		SetTopology(automationconfig.ReplicaSetTopology).


### PR DESCRIPTION
### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

This PR introduces a mechanism to customise headless service according to cluster dns name.
New Additions - 
- `CLUSTER_DNS_NAME` env var in operator deployment

closes #180 