### PR TITLE
Added progress bar to dev tooling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jinja2==2.11.2
 PyYAML==5.3.1
 black==19.10b0
 mypy==0.782
+tqdm==v4.49.0


### PR DESCRIPTION
### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This PR updates our tooling to display a progress bar in the form of.

```bash

Pushing image: 268558157000.dkr.ecr.us-east-1.amazonaws.com/chatton/test-runner:latest
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:15<00:00,  6.50it/s]
Building image: 268558157000.dkr.ecr.us-east-1.amazonaws.com/chatton/e2e:latest
Successfully built image!
Pushing image: 268558157000.dkr.ecr.us-east-1.amazonaws.com/chatton/e2e:latest
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:01<00:00,  9.67it/s]
```