### PR TITLE
CLOUDP-73217: fix volumes merging

### DIFF
--- a/pkg/kube/podtemplatespec/podspec_template.go
+++ b/pkg/kube/podtemplatespec/podspec_template.go
@@ -292,7 +292,7 @@ func mergeKeyToPathItems(defaultItems []corev1.KeyToPath, overrideItems []corev1
 	// Merge Items array by KeyToPath.Key entry
 	defaultItemsMap := createKeyToPathMap(defaultItems)
 	overrideItemsMap := createKeyToPathMap(overrideItems)
-	mergedItems := []corev1.KeyToPath{}
+	var mergedItems []corev1.KeyToPath
 	for _, defaultItem := range defaultItemsMap {
 		mergedKey := defaultItem
 		if overrideItem, ok := overrideItemsMap[defaultItem.Key]; ok {
@@ -337,9 +337,7 @@ func mergeVolume(defaultVolume corev1.Volume, overrideVolume corev1.Volume) core
 		if overrideSource.Secret.SecretName != "" {
 			mergedVolume.Secret.SecretName = overrideSource.Secret.SecretName
 		}
-		if len(overrideSource.Secret.Items) > 0 {
-			mergedVolume.Secret.Items = mergeKeyToPathItems(defaultSource.Secret.Items, overrideSource.Secret.Items)
-		}
+		mergedVolume.Secret.Items = mergeKeyToPathItems(defaultSource.Secret.Items, overrideSource.Secret.Items)
 		if overrideSource.Secret.DefaultMode != nil {
 			mergedVolume.Secret.DefaultMode = overrideSource.Secret.DefaultMode
 		}
@@ -350,9 +348,7 @@ func mergeVolume(defaultVolume corev1.Volume, overrideVolume corev1.Volume) core
 		if overrideSource.ConfigMap.LocalObjectReference.Name != "" {
 			mergedVolume.ConfigMap.LocalObjectReference.Name = overrideSource.ConfigMap.LocalObjectReference.Name
 		}
-		if len(overrideSource.ConfigMap.Items) > 0 {
-			mergedVolume.ConfigMap.Items = mergeKeyToPathItems(defaultSource.ConfigMap.Items, overrideSource.ConfigMap.Items)
-		}
+		mergedVolume.ConfigMap.Items = mergeKeyToPathItems(defaultSource.ConfigMap.Items, overrideSource.ConfigMap.Items)
 		if overrideSource.ConfigMap.DefaultMode != nil {
 			mergedVolume.ConfigMap.DefaultMode = overrideSource.ConfigMap.DefaultMode
 		}

--- a/pkg/kube/podtemplatespec/podspec_template.go
+++ b/pkg/kube/podtemplatespec/podspec_template.go
@@ -265,19 +265,140 @@ func MergePodTemplateSpecs(defaultTemplate, overrideTemplate corev1.PodTemplateS
 	return mergedPodTemplateSpec, nil
 }
 
+func createKeyToPathMap(items []corev1.KeyToPath) map[string]corev1.KeyToPath {
+	itemsMap := make(map[string]corev1.KeyToPath)
+	for _, v := range items {
+		itemsMap[v.Key] = v
+	}
+	return itemsMap
+}
+
+func mergeKeyToPath(defaultKey corev1.KeyToPath, overrideKey corev1.KeyToPath) corev1.KeyToPath {
+	if defaultKey.Key != overrideKey.Key {
+		// This should not happen as we always merge by Key.
+		// If it does, we return the default as something's wrong
+		return defaultKey
+	}
+	if overrideKey.Path != "" {
+		defaultKey.Path = overrideKey.Path
+	}
+	if overrideKey.Mode != nil {
+		defaultKey.Mode = overrideKey.Mode
+	}
+	return defaultKey
+}
+
+func mergeKeyToPathItems(defaultItems []corev1.KeyToPath, overrideItems []corev1.KeyToPath) []corev1.KeyToPath {
+	// Merge Items array by KeyToPath.Key entry
+	defaultItemsMap := createKeyToPathMap(defaultItems)
+	overrideItemsMap := createKeyToPathMap(overrideItems)
+	mergedItems := []corev1.KeyToPath{}
+	for _, defaultItem := range defaultItemsMap {
+		mergedKey := defaultItem
+		if overrideItem, ok := overrideItemsMap[defaultItem.Key]; ok {
+			// Need to merge
+			mergedKey = mergeKeyToPath(defaultItem, overrideItem)
+		}
+		mergedItems = append(mergedItems, mergedKey)
+	}
+	for _, overrideItem := range overrideItemsMap {
+		if _, ok := defaultItemsMap[overrideItem.Key]; ok {
+			// Already merged
+			continue
+		}
+		mergedItems = append(mergedItems, overrideItem)
+
+	}
+	return mergedItems
+}
+
+func mergeVolume(defaultVolume corev1.Volume, overrideVolume corev1.Volume) corev1.Volume {
+	// Volume contains only Name and VolumeSource
+
+	// Merge VolumeSource
+	overrideSource := overrideVolume.VolumeSource
+	defaultSource := defaultVolume.VolumeSource
+	mergedVolume := defaultVolume
+
+	// Only one field must be non-nil.
+	// We merge if it is one of the ones we fill from the operator side:
+	// - EmptyDir
+	if overrideSource.EmptyDir != nil && defaultSource.EmptyDir != nil {
+		if overrideSource.EmptyDir.Medium != "" {
+			mergedVolume.EmptyDir.Medium = overrideSource.EmptyDir.Medium
+		}
+		if overrideSource.EmptyDir.SizeLimit != nil {
+			mergedVolume.EmptyDir.SizeLimit = overrideSource.EmptyDir.SizeLimit
+		}
+		return mergedVolume
+	}
+	// - Secret
+	if overrideSource.Secret != nil && defaultSource.Secret != nil {
+		if overrideSource.Secret.SecretName != "" {
+			mergedVolume.Secret.SecretName = overrideSource.Secret.SecretName
+		}
+		if len(overrideSource.Secret.Items) > 0 {
+			mergedVolume.Secret.Items = mergeKeyToPathItems(defaultSource.Secret.Items, overrideSource.Secret.Items)
+		}
+		if overrideSource.Secret.DefaultMode != nil {
+			mergedVolume.Secret.DefaultMode = overrideSource.Secret.DefaultMode
+		}
+		return mergedVolume
+	}
+	// - ConfigMap
+	if overrideSource.ConfigMap != nil && defaultSource.ConfigMap != nil {
+		if overrideSource.ConfigMap.LocalObjectReference.Name != "" {
+			mergedVolume.ConfigMap.LocalObjectReference.Name = overrideSource.ConfigMap.LocalObjectReference.Name
+		}
+		if len(overrideSource.ConfigMap.Items) > 0 {
+			mergedVolume.ConfigMap.Items = mergeKeyToPathItems(defaultSource.ConfigMap.Items, overrideSource.ConfigMap.Items)
+		}
+		if overrideSource.ConfigMap.DefaultMode != nil {
+			mergedVolume.ConfigMap.DefaultMode = overrideSource.ConfigMap.DefaultMode
+		}
+		if overrideSource.ConfigMap.Optional != nil {
+			mergedVolume.ConfigMap.Optional = overrideSource.ConfigMap.Optional
+		}
+		return mergedVolume
+	}
+
+	// Otherwise we assume that the user provides every field
+	// and we just assign it and nil every other field
+	// We also do that in the case the user provides one of the three listed above
+	// but our volume has a different non-nil entry.
+
+	// this is effectively the same as just returning the overrideSource
+	mergedVolume.VolumeSource = overrideSource
+	return mergedVolume
+}
+
+func createVolumesMap(volumes []corev1.Volume) map[string]corev1.Volume {
+	volumesMap := make(map[string]corev1.Volume)
+	for _, v := range volumes {
+		volumesMap[v.Name] = v
+	}
+	return volumesMap
+}
+
 func mergeVolumes(defaultVolumes []corev1.Volume, overrideVolumes []corev1.Volume) []corev1.Volume {
-	mergedVolumeMap := make(map[string]corev1.Volume)
+	defaultVolumesMap := createVolumesMap(defaultVolumes)
+	overrideVolumesMap := createVolumesMap(overrideVolumes)
 	mergedVolumes := []corev1.Volume{}
-	for _, v := range defaultVolumes {
-		mergedVolumeMap[v.Name] = v
+
+	for _, defaultVolume := range defaultVolumes {
+		mergedVolume := defaultVolume
+		if overrideVolume, ok := overrideVolumesMap[defaultVolume.Name]; ok {
+			mergedVolume = mergeVolume(defaultVolume, overrideVolume)
+		}
+		mergedVolumes = append(mergedVolumes, mergedVolume)
 	}
 
-	for _, v := range overrideVolumes {
-		mergedVolumeMap[v.Name] = v
-	}
-
-	for _, v := range mergedVolumeMap {
-		mergedVolumes = append(mergedVolumes, v)
+	for _, overrideVolume := range overrideVolumes {
+		if _, ok := defaultVolumesMap[overrideVolume.Name]; ok {
+			// Already Merged
+			continue
+		}
+		mergedVolumes = append(mergedVolumes, overrideVolume)
 	}
 
 	sort.SliceStable(mergedVolumes, func(i, j int) bool {


### PR DESCRIPTION
This PR fixes the volume merging by manually merging by name volumes and volumesources

As discussed with @chatton, for now we focus on merging the values of VolumeSource for which the operator fills default values (Secret, ConfigMap, EmptyDir) and we overwrite the volume if a different one is provided.

A few new unit tests are introduced as well.
More comments to come inline

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
