### PR TITLE
Add support for split horizon in replica set.

### DIFF
--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -49,6 +49,17 @@ spec:
             members:
               description: Members is the number of members in the replica set
               type: integer
+            replicaSetHorizons:
+              description: Add this parameter and values if you need your database
+                to be accessed outside of Kubernetes. This setting allows you to
+                provide different DNS settings within the Kubernetes cluster and
+                to the Kubernetes cluster. The Kubernetes Operator uses split horizon
+                DNS for replica set members. This feature allows communication both
+                within the Kubernetes cluster and from outside Kubernetes.
+              items:
+                properties: {}
+                type: object
+              type: array
             security:
               description: Security configures security features, such as TLS, and
                 authentication settings for a deployment

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/scale"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,6 +51,11 @@ type MongoDBSpec struct {
 	// +optional
 	FeatureCompatibilityVersion string `json:"featureCompatibilityVersion,omitempty"`
 
+	// ReplicaSetHorizons allows providing different DNS settings within the
+	// Kubernetes cluster and to the Kubernetes cluster.
+	// +optional
+	ReplicaSetHorizons ReplicaSetHorizonConfiguration `json:"replicaSetHorizons,omitempty"`
+
 	// Security configures security features, such as TLS, and authentication settings for a deployment
 	// +required
 	Security Security `json:"security"`
@@ -67,6 +73,10 @@ type MongoDBSpec struct {
 	// +kubebuilder:validation:Type=object
 	AdditionalMongodConfig MongodConfiguration `json:"additionalMongodConfig,omitempty"`
 }
+
+// ReplicaSetHorizonConfiguration holds the split horizon DNS settings for
+// replica set members.
+type ReplicaSetHorizonConfiguration []automationconfig.ReplicaSetHorizons
 
 // StatefulSetConfiguration holds the optional custom StatefulSet
 // that should be merged into the operator created one.

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -99,7 +99,7 @@ type ReplicaSetMember struct {
 	Priority    int                `json:"priority"`
 	ArbiterOnly bool               `json:"arbiterOnly"`
 	Votes       int                `json:"votes"`
-	Horizons    ReplicaSetHorizons `json:"horizons"`
+	Horizons    ReplicaSetHorizons `json:"horizons,omitempty"`
 }
 
 type ReplicaSetHorizons map[string]string

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -94,20 +94,24 @@ type ReplicaSet struct {
 }
 
 type ReplicaSetMember struct {
-	Id          int    `json:"_id"`
-	Host        string `json:"host"`
-	Priority    int    `json:"priority"`
-	ArbiterOnly bool   `json:"arbiterOnly"`
-	Votes       int    `json:"votes"`
+	Id          int                `json:"_id"`
+	Host        string             `json:"host"`
+	Priority    int                `json:"priority"`
+	ArbiterOnly bool               `json:"arbiterOnly"`
+	Votes       int                `json:"votes"`
+	Horizons    ReplicaSetHorizons `json:"horizons"`
 }
 
-func newReplicaSetMember(p Process, id int) ReplicaSetMember {
+type ReplicaSetHorizons map[string]string
+
+func newReplicaSetMember(p Process, id int, horizons ReplicaSetHorizons) ReplicaSetMember {
 	return ReplicaSetMember{
 		Id:          id,
 		Host:        p.Name,
 		Priority:    1,
 		ArbiterOnly: false,
 		Votes:       1,
+		Horizons:    horizons,
 	}
 }
 

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -24,16 +24,17 @@ func NOOP() Modification {
 }
 
 type Builder struct {
-	enabler        AuthEnabler
-	processes      []Process
-	replicaSets    []ReplicaSet
-	members        int
-	domain         string
-	name           string
-	fcv            string
-	topology       Topology
-	mongodbVersion string
-	previousAC     AutomationConfig
+	enabler            AuthEnabler
+	processes          []Process
+	replicaSets        []ReplicaSet
+	replicaSetHorizons []ReplicaSetHorizons
+	members            int
+	domain             string
+	name               string
+	fcv                string
+	topology           Topology
+	mongodbVersion     string
+	previousAC         AutomationConfig
 	// MongoDB installable versions
 	versions      []MongoDbVersionConfig
 	toolsVersion  ToolsVersion
@@ -56,6 +57,11 @@ func (b *Builder) SetAuthEnabler(enabler AuthEnabler) *Builder {
 
 func (b *Builder) SetTopology(topology Topology) *Builder {
 	b.topology = topology
+	return b
+}
+
+func (b *Builder) SetReplicaSetHorizons(horizons []ReplicaSetHorizons) *Builder {
+	b.replicaSetHorizons = horizons
 	return b
 }
 
@@ -124,7 +130,12 @@ func (b *Builder) Build() (AutomationConfig, error) {
 
 		process := newProcess(toHostName(b.name, i), h, b.mongodbVersion, b.name, opts...)
 		processes[i] = process
-		members[i] = newReplicaSetMember(process, i)
+
+		if b.replicaSetHorizons != nil {
+			members[i] = newReplicaSetMember(process, i, b.replicaSetHorizons[i])
+		} else {
+			members[i] = newReplicaSetMember(process, i, nil)
+		}
 	}
 
 	auth := disabledAuth()

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -62,6 +62,28 @@ func TestBuildAutomationConfig(t *testing.T) {
 	}
 }
 
+func TestReplicaSetHorizons(t *testing.T) {
+	ac, err := NewBuilder().
+		SetName("my-rs").
+		SetDomain("my-ns.svc.cluster.local").
+		SetMongoDBVersion("4.2.0").
+		SetMembers(3).
+		SetReplicaSetHorizons([]ReplicaSetHorizons{
+			{"horizon": "test-horizon-0"},
+			{"horizon": "test-horizon-1"},
+			{"horizon": "test-horizon-2"},
+		}).
+		Build()
+
+	assert.NoError(t, err)
+
+	for i, member := range ac.ReplicaSets[0].Members {
+		assert.NotEmpty(t, member.Horizons)
+		assert.Contains(t, member.Horizons, "horizon")
+		assert.Equal(t, fmt.Sprintf("test-horizon-%d", i), member.Horizons["horizon"])
+	}
+}
+
 func TestMongoDbVersions(t *testing.T) {
 	ac, err := NewBuilder().
 		SetName("my-rs").

--- a/pkg/controller/mongodb/replica_set_controller.go
+++ b/pkg/controller/mongodb/replica_set_controller.go
@@ -470,6 +470,7 @@ func buildAutomationConfig(mdb mdbv1.MongoDB, mdbVersionConfig automationconfig.
 		SetName(mdb.Name).
 		SetDomain(domain).
 		SetMembers(mdb.AutomationConfigMembersThisReconciliation()).
+		SetReplicaSetHorizons(mdb.Spec.ReplicaSetHorizons).
 		SetPreviousAutomationConfig(currentAc).
 		SetMongoDBVersion(mdb.Spec.Version).
 		SetFCV(mdb.GetFCV()).


### PR DESCRIPTION
When running MongoDB on Kubernetes, members of the replica set discover each other using the cluster-internal DNS name. When exposing this replica set through a NodePort, clients such as Mongoose are unable to connect, because the replica set document references the cluster-internal DNS name.

MongoDB has a currently undocumented feature where the replica set can respond to "isMaster" requests with different hostnames and ports, if contacted via alternate names using TLS. See https://jira.mongodb.org/browse/SERVER-40156 for more details. This implementation makes use of that.

Note, no validation is currently performed; it is currently possible to mis-configure by having different `members` from the number of array elements in the `horizons` field.

Example configuration:

```yaml
apiVersion: mongodb.com/v1
kind: MongoDB
metadata:
  name: production
  namespace: mongodb-operator
spec:
  members: 3
  replicaSetHorizons:
  - horizon: production-0.mongodb-operator.example.com:31181
  - horizon: production-1.mongodb-operator.example.com:31182
  - horizon: production-2.mongodb-operator.example.com:31183
  # ...
```

See related issue, possibly closes #127.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
