### PR TITLE
State that `spec.users.name` must comply with DNS-1123 subdomain

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -34,7 +34,7 @@ You cannot disable SCRAM authentication.
    | Key | Type | Description | Required? |
    |----|----|----|----|
    | `spec.users` | array of objects | Configures database users for this deployment. | Yes |
-   | `spec.users.name` | string | Username of the database user. | Yes |
+   | `spec.users.name` | string | Username of the database user. <em> NOTE: make sure the name complies with [DNS-1123 subdomain](https://tools.ietf.org/html/rfc1123). Regex for validating name is ''[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'')' </em>| Yes |
    | `spec.users.db` | string | Database that the user authenticates against. Defaults to `admin`. | No |
    | `spec.users.passwordSecretRef.name` | string | Name of the secret that contains the user's plain text password. | Yes|
    | `spec.users.passwordSecretRef.key` | string| Key in the secret that corresponds to the value of the user's password. Defaults to `password`. | No |


### PR DESCRIPTION
`spec.users.name` is used to create SCRAM credential secret object with naming format
as : `<mdbname>-<spec.users.name>-scram-credentials`. Creation of secret object will error out
if the `spec.users.name` doesn't comply with `DNS-1123` subdomain convention. We should document this behavior.
Related issue: https://github.com/mongodb/mongodb-kubernetes-operator/issues/218

### All Submissions:

* [ n/a] Have you opened an Issue before filing this PR?
* [ n/a] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ n/a] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ n/a] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
