### PR TITLE
CLOUDP-74820: change in scram credential secret name generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ tags
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 *mypy_cache
+venv/
+local-config.json
 .idea
 vendor
 __pycache__

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -166,6 +166,7 @@ spec:
                 - name
                 - passwordSecretRef
                 - roles
+                - scramCredentialsSecretName
                 type: object
               type: array
             version:

--- a/deploy/crds/mongodb.com_mongodb_crd.yaml
+++ b/deploy/crds/mongodb.com_mongodb_crd.yaml
@@ -157,6 +157,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  scramCredentialsSecretName:
+                    description: ScramCredentialsSecretName appended by string "scram-credentials" is the name of the secret object
+                      created by the mongoDB operator for storing SCRAM credentials
+                    type: string
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 required:
                 - name
                 - passwordSecretRef

--- a/deploy/crds/mongodb.com_v1_mongodb_cr.yaml
+++ b/deploy/crds/mongodb.com_v1_mongodb_cr.yaml
@@ -19,3 +19,4 @@ spec:
           db: admin
         - name: userAdminAnyDatabase
           db: admin
+      scramCredentialsSecretName: my-scram

--- a/deploy/crds/mongodb.com_v1_mongodb_openshift_cr.yaml
+++ b/deploy/crds/mongodb.com_v1_mongodb_openshift_cr.yaml
@@ -19,6 +19,7 @@ spec:
           db: admin
         - name: userAdminAnyDatabase
           db: admin
+      scramCredentialsSecretName: my-scram
   statefulSet:
     spec:
       template:

--- a/deploy/crds/mongodb.com_v1_mongodb_scram_cr.yaml
+++ b/deploy/crds/mongodb.com_v1_mongodb_scram_cr.yaml
@@ -20,6 +20,7 @@ spec:
           db: admin
         - name: userAdminAnyDatabase
           db: admin
+      scramCredentialsSecretName: my-scram
 
 # the user credentials will be generated from this secret
 # once the credentials are generated, this secret is no longer required

--- a/deploy/crds/mongodb.com_v1_mongodb_tls_cr.yaml
+++ b/deploy/crds/mongodb.com_v1_mongodb_tls_cr.yaml
@@ -25,3 +25,4 @@ spec:
           db: admin
         - name: userAdminAnyDatabase
           db: admin
+      scramCredentialsSecretName: my-scram

--- a/docs/users.md
+++ b/docs/users.md
@@ -38,6 +38,7 @@ You cannot disable SCRAM authentication.
    | `spec.users.db` | string | Database that the user authenticates against. Defaults to `admin`. | No |
    | `spec.users.passwordSecretRef.name` | string | Name of the secret that contains the user's plain text password. | Yes|
    | `spec.users.passwordSecretRef.key` | string| Key in the secret that corresponds to the value of the user's password. Defaults to `password`. | No |
+   | `spec.users.scramCredentialsSecretName` | string| ScramCredentialsSecretName appended by string "scram-credentials" is the name of the secret object created by the operator for storing SCRAM credentials for the user. The name should comply with [DNS1123 subdomain](https://tools.ietf.org/html/rfc1123). Also, please make sure the name is unique among `users`.  | Yes |
    | `spec.users.roles` | array of objects | Configures roles assigned to the user. | Yes |
    | `spec.users.roles.role.name` | string | Name of the role. Valid values are [built-in roles](https://docs.mongodb.com/manual/reference/built-in-roles/#built-in-roles). | Yes |
    | `spec.users.roles.role.db` | string | Database that the role applies to. | Yes |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-kubernetes-operator
 
-go 1.15
+go 1.14
 
 require (
 	github.com/Azure/go-autorest v14.0.1+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-kubernetes-operator
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Azure/go-autorest v14.0.1+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/klauspost/compress v1.9.8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/operator-framework/operator-sdk v0.17.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/procfs v0.0.11 // indirect
 	github.com/rogpeppe/go-internal v1.5.2 // indirect
 	github.com/spf13/cobra v0.0.7 // indirect

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -120,6 +120,7 @@ type MongoDBUser struct {
 	Roles []Role `json:"roles"`
 
 	// ScramCredentialsSecretName appended by string "scram-credentials" is the name of the secret object created by the mongoDB operator for storing SCRAM credentials
+	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	ScramCredentialsSecretName string `json:"scramCredentialsSecretName"`
 }
 
@@ -138,7 +139,7 @@ func (m MongoDBUser) GetUserName() string {
 	return m.Name
 }
 
-// Get the final SCRAM credentials secret-name by appending the user provided
+// GetScramCredentialsSecretName gets the final SCRAM credentials secret-name by appending the user provided
 // scramsCredentialSecretName with "scram-credentials"
 func (m MongoDBUser) GetScramCredentialsSecretName() string {
 	return fmt.Sprintf("%s-%s", m.ScramCredentialsSecretName, "scram-credentials")

--- a/pkg/apis/mongodb/v1/mongodb_types.go
+++ b/pkg/apis/mongodb/v1/mongodb_types.go
@@ -118,6 +118,9 @@ type MongoDBUser struct {
 
 	// Roles is an array of roles assigned to this user
 	Roles []Role `json:"roles"`
+
+	// ScramCredentialsSecretName appended by string "scram-credentials" is the name of the secret object created by the mongoDB operator for storing SCRAM credentials
+	ScramCredentialsSecretName string `json:"scramCredentialsSecretName"`
 }
 
 func (m MongoDBUser) GetPasswordSecretKey() string {
@@ -133,6 +136,12 @@ func (m MongoDBUser) GetPasswordSecretName() string {
 
 func (m MongoDBUser) GetUserName() string {
 	return m.Name
+}
+
+// Get the final SCRAM credentials secret-name by appending the user provided
+// scramsCredentialSecretName with "scram-credentials"
+func (m MongoDBUser) GetScramCredentialsSecretName() string {
+	return fmt.Sprintf("%s-%s", m.ScramCredentialsSecretName, "scram-credentials")
 }
 
 // SecretKeyReference is a reference to the secret containing the user's password

--- a/pkg/apis/mongodb/v1/mongodb_types_test.go
+++ b/pkg/apis/mongodb/v1/mongodb_types_test.go
@@ -92,7 +92,7 @@ func TestGetScramCredentialsSecretName(t *testing.T) {
 	}
 
 	for _, tt := range testusers {
-		assert.Equal(t, tt.in.GetScramCredentialsSecretName(), tt.exp)
+		assert.Equal(t, tt.exp, tt.in.GetScramCredentialsSecretName())
 	}
 
 }

--- a/pkg/apis/mongodb/v1/mongodb_types_test.go
+++ b/pkg/apis/mongodb/v1/mongodb_types_test.go
@@ -28,6 +28,75 @@ func TestGetFCV(t *testing.T) {
 	assert.Equal(t, "4.2", mdb.GetFCV())
 }
 
+func TestGetScramCredentialsSecretName(t *testing.T) {
+	testusers := []struct {
+		in  MongoDBUser
+		exp string
+	}{
+		{
+			MongoDBUser{
+				Name: "mdb-0",
+				DB:   "admin",
+				Roles: []Role{
+					// roles on testing db for general connectivity
+					{
+						DB:   "testing",
+						Name: "readWrite",
+					},
+					{
+						DB:   "testing",
+						Name: "clusterAdmin",
+					},
+					// admin roles for reading FCV
+					{
+						DB:   "admin",
+						Name: "readWrite",
+					},
+					{
+						DB:   "admin",
+						Name: "clusterAdmin",
+					},
+				},
+				ScramCredentialsSecretName: "scram-credential-secret-name-0",
+			},
+			"scram-credential-secret-name-0-scram-credentials",
+		},
+		{
+			MongoDBUser{
+				Name: "mdb-1",
+				DB:   "admin",
+				Roles: []Role{
+					// roles on testing db for general connectivity
+					{
+						DB:   "testing",
+						Name: "readWrite",
+					},
+					{
+						DB:   "testing",
+						Name: "clusterAdmin",
+					},
+					// admin roles for reading FCV
+					{
+						DB:   "admin",
+						Name: "readWrite",
+					},
+					{
+						DB:   "admin",
+						Name: "clusterAdmin",
+					},
+				},
+				ScramCredentialsSecretName: "scram-credential-secret-name-1",
+			},
+			"scram-credential-secret-name-1-scram-credentials",
+		},
+	}
+
+	for _, tt := range testusers {
+		assert.Equal(t, tt.in.GetScramCredentialsSecretName(), tt.exp)
+	}
+
+}
+
 func newReplicaSet(members int, name, namespace string) MongoDB {
 	return MongoDB{
 		TypeMeta: metav1.TypeMeta{},

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -174,6 +174,7 @@ func NewTestMongoDB(name string) (mdbv1.MongoDB, mdbv1.MongoDBUser) {
 							Name: "clusterAdmin",
 						},
 					},
+					ScramCredentialsSecretName: fmt.Sprintf("%s-my-scram", name),
 				},
 			},
 		},


### PR DESCRIPTION
This PR changes the logic for SCRAM credential secret name generation for MongoDB users (to accommodate for non DNS1123 complying user name). For a more detailed discussion please refer to the corresponding JIRA ticket.

Note: This change breaks backward compatibility
### All Submissions:

* [n/a ] Have you opened an Issue before filing this PR?
* [n/a] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [n/a] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [n/a] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
