### PR TITLE
CLOUDP-80411: Change math/rand to crypto/rand in test

### DIFF
--- a/test/e2e/replica_set_readiness_probe/replica_set_readiness_probe_test.go
+++ b/test/e2e/replica_set_readiness_probe/replica_set_readiness_probe_test.go
@@ -1,7 +1,8 @@
 package replica_set_readiness_probe
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"testing"
 	"time"
 
@@ -19,9 +20,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestReplicaSetReadinessProbeScaling(t *testing.T) {
-
-	rand.Seed(time.Now().Unix())
-
 	ctx, shouldCleanup := setup.InitTest(t)
 
 	if shouldCleanup {
@@ -47,7 +45,11 @@ func TestReplicaSetReadinessProbeScaling(t *testing.T) {
 
 	t.Run("MongoDB is reachable", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
-		t.Run("Delete Random Pod", mongodbtests.DeletePod(&mdb, rand.Intn(mdb.Spec.Members))) //nolint
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(mdb.Spec.Members)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Run("Delete Random Pod", mongodbtests.DeletePod(&mdb, int(n.Int64())))
 		t.Run("Test Replica Set Recovers", mongodbtests.StatefulSetIsReady(&mdb))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 		t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,


### PR DESCRIPTION
### All Submissions:

* [X] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

This fixes a linting issue found (and ignored) in #279. golangci-lint compains about the use of the `math/rand` package in this test, so this change switches to using the `crypto/rand` package.
Link to ticket: https://jira.mongodb.org/browse/CLOUDP-80411