### PR TITLE
Added IsTransient function to check if an error is transient or not

### DIFF
--- a/pkg/controller/mongodb/mongodb_status_options.go
+++ b/pkg/controller/mongodb/mongodb_status_options.go
@@ -1,7 +1,10 @@
 package mongodb
 
 import (
+	"errors"
+
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/pkg/apis/mongodb/v1"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/apierrors"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/result"
 	"go.uber.org/zap"
 
@@ -112,6 +115,10 @@ func (o *optionBuilder) withStatefulSetReplicas(members int) *optionBuilder {
 }
 
 func (o *optionBuilder) withMessage(severityLevel severity, msg string) *optionBuilder {
+	if apierrors.IsTransient(errors.New(msg)) {
+		severityLevel = Debug
+		msg = ""
+	}
 	o.options = append(o.options, messageOption{
 		message: message{
 			messageString: msg,

--- a/pkg/controller/mongodb/mongodb_status_options.go
+++ b/pkg/controller/mongodb/mongodb_status_options.go
@@ -1,8 +1,6 @@
 package mongodb
 
 import (
-	"errors"
-
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/pkg/apis/mongodb/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/apierrors"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/result"
@@ -115,7 +113,7 @@ func (o *optionBuilder) withStatefulSetReplicas(members int) *optionBuilder {
 }
 
 func (o *optionBuilder) withMessage(severityLevel severity, msg string) *optionBuilder {
-	if apierrors.IsTransient(errors.New(msg)) {
+	if apierrors.IsTransientMessage(msg) {
 		severityLevel = Debug
 		msg = ""
 	}

--- a/pkg/util/apierrors/apierrors.go
+++ b/pkg/util/apierrors/apierrors.go
@@ -3,10 +3,15 @@ package apierrors
 import "strings"
 
 // objectModifiedText is an error indicating that we are trying to update a resource that has since been updated.
-// in this we just want to retry but not log it as an error.
+// in this case we just want to retry but not log it as an error.
 var objectModifiedText = "the object has been modified; please apply your changes to the latest version and try again"
 
-// IsTransient returns a boolean indicating if a given error is transient.
-func IsTransient(err error) bool {
-	return strings.Contains(strings.ToLower(err.Error()), objectModifiedText)
+// IsTransientError returns a boolean indicating if a given error is transient.
+func IsTransientError(err error) bool {
+	return IsTransientMessage(err.Error())
+}
+
+// IsTransientMessage returns a boolean indicating if a given error message is transient.
+func IsTransientMessage(msg string) bool {
+	return strings.Contains(strings.ToLower(msg), objectModifiedText)
 }

--- a/pkg/util/apierrors/apierrors.go
+++ b/pkg/util/apierrors/apierrors.go
@@ -1,0 +1,12 @@
+package apierrors
+
+import "strings"
+
+// objectModifiedText is an error indicating that we are trying to update a resource that has since been updated.
+// in this we just want to retry but not log it as an error.
+var objectModifiedText = "the object has been modified; please apply your changes to the latest version and try again"
+
+// IsTransient returns a boolean indicating if a given error is transient.
+func IsTransient(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), objectModifiedText)
+}

--- a/pkg/util/apierrors/apierrors_test.go
+++ b/pkg/util/apierrors/apierrors_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestIsTransient(t *testing.T) {
+func TestIsTransientError(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -22,15 +22,15 @@ func TestIsTransient(t *testing.T) {
 			true,
 		},
 		{
-			"Test Not Transient Errir",
+			"Test Not Transient Error",
 			fmt.Errorf(" error found deployments.extensions \"default\" not found"),
 			false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsTransient(tt.err); got != tt.want {
-				t.Errorf("IsTransient() = %v, want %v", got, tt.want)
+			if got := IsTransientError(tt.err); got != tt.want {
+				t.Errorf("IsTransientError() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/apierrors/apierrors_test.go
+++ b/pkg/util/apierrors/apierrors_test.go
@@ -1,0 +1,37 @@
+package apierrors
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			"Test Transient capitalised error",
+			fmt.Errorf("Error updating the status of the MongoDB resource: Operation cannot be fulfilled on mongodbcommunity.mongodb.com \"mdb0\": The object has been modified; please apply your changes to the latest version and try again"),
+			true,
+		},
+		{
+			"Test Transient lower case error",
+			fmt.Errorf("error updating the status of the MongoDB resource: Operation cannot be fulfilled on mongodbcommunity.mongodb.com \"mdb0\": the object has been modified; please apply your changes to the latest version and try again"),
+			true,
+		},
+		{
+			"Test Not Transient Errir",
+			fmt.Errorf(" error found deployments.extensions \"default\" not found"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransient(tt.err); got != tt.want {
+				t.Errorf("IsTransient() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### All Submissions:


* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

This PR lowers the severity of the transient `the object has been modified; please apply your changes to the latest version and try again` error