### PR TITLE
Fix use of incorrect crd plural in role.yaml

### DIFF
--- a/deploy/clusterwide/role.yaml
+++ b/deploy/clusterwide/role.yaml
@@ -69,8 +69,9 @@ rules:
 - apiGroups:
   - mongodb.com
   resources:
-  - '*'
-  - mongodbs
+  - mongodbcommunity
+  - mongodbcommunity/status
+  - mongodbcommunity/spec
   verbs:
   - create
   - delete

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -69,8 +69,9 @@ rules:
 - apiGroups:
   - mongodb.com
   resources:
-  - '*'
-  - mongodbs
+  - mongodbcommunity
+  - mongodbcommunity/status
+  - mongodbcommunity/spec
   verbs:
   - create
   - delete


### PR DESCRIPTION
### All Submissions:

* [X] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Fixes use of old/incorrect resource plural in role.yaml and removes need for '*' permission.