### PR TITLE
Fixed merging of host aliases

### DIFF
--- a/pkg/util/merge/merge_podtemplate_spec.go
+++ b/pkg/util/merge/merge_podtemplate_spec.go
@@ -1,6 +1,8 @@
 package merge
 
 import (
+	"sort"
+
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/contains"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -207,6 +209,10 @@ func HostAliases(originalAliases, overrideAliases []corev1.HostAlias) []corev1.H
 	for _, v := range m {
 		mergedHostAliases = append(mergedHostAliases, v)
 	}
+
+	sort.SliceStable(mergedHostAliases, func(i, j int) bool {
+		return mergedHostAliases[i].IP < mergedHostAliases[j].IP
+	})
 
 	return mergedHostAliases
 }


### PR DESCRIPTION
We weren't sorting hostaliases when merging, so the order was not predictable as ranging over a map has no guarantees on the order. This caused a flaky unit test.

I've ran this test locally around 10 times with no failures.


### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
