### PR TITLE
Removed dependency on version manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/mongodb/mongodb-kubernetes-operator:0.5.0 # replace with localhost:5000/mongodb-kubernetes-operator locally
+IMG ?= <operator-registry>/mongodb-kubernetes-operator
 DOCKERFILE ?= operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=true,crdVersions=v1beta1"

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -qq update \
         && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p agent \
-    && curl --fail --retry 3 --silent https://s3.amazonaws.com/mciuploads/mms-automation/mongodb-mms-build-agent/builds/automation-agent/prod/mongodb-mms-automation-agent-${agent_version}.rhel7_x86_64.tar.gz -o agent/mongodb-agent.tar.gz \
+    && curl --fail --retry 3 --silent https://mciuploads.s3.amazonaws.com/mms-automation/mongodb-mms-build-agent/builds/automation-agent/prod/mongodb-mms-automation-agent-${agent_version}.rhel7_x86_64.tar.gz -o agent/mongodb-agent.tar.gz \
     && tar xfz agent/mongodb-agent.tar.gz \
     && mv mongodb-mms-automation-agent-*/mongodb-mms-automation-agent agent/mongodb-agent \
     && chmod +x agent/mongodb-agent \

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -96,7 +96,7 @@ func main() {
 	}
 
 	// Setup Controller.
-	if err = controllers.NewReconciler(mgr, nil).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewReconciler(mgr).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller")
 		os.Exit(1)
 	}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
             - name: OPERATOR_NAME
               value: "mongodb-kubernetes-operator"
             - name: AGENT_IMAGE # The MongoDB Agent the operator will deploy to manage MongoDB deployments
-              value: quay.io/mongodb/mongodb-agent:10.19.0.6562-1
+              value: quay.io/mongodb/mongodb-agent:10.27.0.6772-1
             - name: VERSION_UPGRADE_HOOK_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2
             - name: MONGODB_IMAGE

--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -26,7 +26,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 	err := createTLSSecretAndConfigMap(mgr.GetClient(), mdb)
 	assert.NoError(t, err)
 
-	r := NewReconciler(mgr, mockManifestProvider(mdb.Spec.Version))
+	r := NewReconciler(mgr)
 	res, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
 	assertReconciliationSuccessful(t, res, err)
 
@@ -85,14 +85,10 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		err := createTLSSecretAndConfigMap(client, mdb)
 		assert.NoError(t, err)
 
-		manifest, err := mockManifestProvider(mdb.Spec.Version)()
-		assert.NoError(t, err)
-		versionConfig := manifest.BuildsForVersion(mdb.Spec.Version)
-
 		tlsModification, err := getTLSConfigModification(client, mdb)
 		assert.NoError(t, err)
 
-		ac, err := buildAutomationConfig(mdb, versionConfig, automationconfig.AutomationConfig{}, tlsModification)
+		ac, err := buildAutomationConfig(mdb, automationconfig.AutomationConfig{}, tlsModification)
 		assert.NoError(t, err)
 
 		return ac

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -69,7 +68,6 @@ const (
 	mongodbName                    = "mongod"
 	versionUpgradeHookName         = "mongod-posthook"
 	dataVolumeName                 = "data-volume"
-	versionManifestFilePath        = "/usr/local/version_manifest.json"
 	readinessProbePath             = "/var/lib/mongodb-mms-automation/probes/readinessprobe"
 	clusterFilePath                = "/var/lib/automation/config/cluster-config.json"
 	operatorServiceAccountName     = "mongodb-kubernetes-operator"
@@ -94,25 +92,15 @@ func init() {
 	zap.ReplaceGlobals(logger)
 }
 
-// ManifestProvider is a function which returns the VersionManifest which
-// contains the list of all available MongoDB versions
-type ManifestProvider func() (automationconfig.VersionManifest, error)
-
-func NewReconciler(mgr manager.Manager, manifestProvider ManifestProvider) *ReplicaSetReconciler {
+func NewReconciler(mgr manager.Manager) *ReplicaSetReconciler {
 	mgrClient := mgr.GetClient()
 	secretWatcher := watch.New()
 
-	mp := manifestProvider
-	if mp == nil {
-		mp = readVersionManifestFromDisk
-	}
-
 	return &ReplicaSetReconciler{
-		client:           kubernetesClient.NewClient(mgrClient),
-		scheme:           mgr.GetScheme(),
-		manifestProvider: mp,
-		log:              zap.S(),
-		secretWatcher:    &secretWatcher,
+		client:        kubernetesClient.NewClient(mgrClient),
+		scheme:        mgr.GetScheme(),
+		log:           zap.S(),
+		secretWatcher: &secretWatcher,
 	}
 }
 
@@ -129,11 +117,10 @@ func (r *ReplicaSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 type ReplicaSetReconciler struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client           kubernetesClient.Client
-	scheme           *runtime.Scheme
-	manifestProvider func() (automationconfig.VersionManifest, error)
-	log              *zap.SugaredLogger
-	secretWatcher    *watch.ResourceWatcher
+	client        kubernetesClient.Client
+	scheme        *runtime.Scheme
+	log           *zap.SugaredLogger
+	secretWatcher *watch.ResourceWatcher
 }
 
 // +kubebuilder:rbac:groups=mongodbcommunity.mongodb.com,resources=mongodbcommunity,verbs=get;list;watch;create;update;patch;delete
@@ -446,7 +433,7 @@ func (r ReplicaSetReconciler) ensureAutomationConfig(mdb mdbv1.MongoDBCommunity)
 	return secret.CreateOrUpdate(r.client, s)
 }
 
-func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, mdbVersionConfig automationconfig.MongoDbVersionConfig, currentAc automationconfig.AutomationConfig, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
+func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, currentAc automationconfig.AutomationConfig, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
 	domain := getDomain(mdb.ServiceName(), mdb.Namespace, os.Getenv(clusterDNSName))
 	zap.S().Debugw("AutomationConfigMembersThisReconciliation", "mdb.AutomationConfigMembersThisReconciliation()", mdb.AutomationConfigMembersThisReconciliation())
 
@@ -459,7 +446,6 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, mdbVersionConfig automati
 		SetPreviousAutomationConfig(currentAc).
 		SetMongoDBVersion(mdb.Spec.Version).
 		SetFCV(mdb.GetFCV()).
-		AddVersion(mdbVersionConfig).
 		AddModifications(getMongodConfigModification(mdb)).
 		AddModifications(modifications...)
 	newAc, err := builder.Build()
@@ -468,22 +454,6 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, mdbVersionConfig automati
 	}
 
 	return newAc, nil
-}
-
-func readVersionManifestFromDisk() (automationconfig.VersionManifest, error) {
-	versionManifestBytes, err := ioutil.ReadFile(versionManifestFilePath)
-	if err != nil {
-		return automationconfig.VersionManifest{}, err
-	}
-	return versionManifestFromBytes(versionManifestBytes)
-}
-
-func versionManifestFromBytes(bytes []byte) (automationconfig.VersionManifest, error) {
-	versionManifest := automationconfig.VersionManifest{}
-	if err := json.Unmarshal(bytes, &versionManifest); err != nil {
-		return automationconfig.VersionManifest{}, err
-	}
-	return versionManifest, nil
 }
 
 // buildService creates a Service that will be used for the Replica Set StatefulSet
@@ -550,12 +520,6 @@ func getCustomRolesModification(mdb mdbv1.MongoDBCommunity) (automationconfig.Mo
 }
 
 func (r ReplicaSetReconciler) buildAutomationConfigSecret(mdb mdbv1.MongoDBCommunity) (corev1.Secret, error) {
-
-	manifest, err := r.manifestProvider()
-	if err != nil {
-		return corev1.Secret{}, errors.Errorf("could not read version manifest from disk: %s", err)
-	}
-
 	authModification, err := scram.EnsureScram(r.client, mdb.ScramCredentialsNamespacedName(), mdb)
 	if err != nil {
 		return corev1.Secret{}, errors.Errorf("could not ensure scram credentials: %s", err)
@@ -578,7 +542,6 @@ func (r ReplicaSetReconciler) buildAutomationConfigSecret(mdb mdbv1.MongoDBCommu
 
 	ac, err := buildAutomationConfig(
 		mdb,
-		manifest.BuildsForVersion(mdb.Spec.Version),
 		currentAC,
 		authModification,
 		tlsModification,

--- a/deploy/openshift/operator_openshift.yaml
+++ b/deploy/openshift/operator_openshift.yaml
@@ -33,6 +33,6 @@ spec:
             - name: OPERATOR_NAME
               value: "mongodb-kubernetes-operator"
             - name: AGENT_IMAGE # The MongoDB Agent the operator will deploy to manage MongoDB deployments
-              value: quay.io/mongodb/mongodb-agent:10.19.0.6562-1
+              value: quay.io/mongodb/mongodb-agent:10.27.0.6772-1
             - name: VERSION_UPGRADE_HOOK_IMAGE
               value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -224,23 +224,6 @@ type VersionManifest struct {
 	Versions []MongoDbVersionConfig `json:"versions"`
 }
 
-// BuildsForVersion returns the MongoDbVersionConfig containing all of the version informatioon
-// for the given mongodb version provided
-func (v VersionManifest) BuildsForVersion(version string) MongoDbVersionConfig {
-	var builds []BuildConfig
-	for _, versionConfig := range v.Versions {
-		if versionConfig.Name != version {
-			continue
-		}
-		builds = versionConfig.Builds
-		break
-	}
-	return MongoDbVersionConfig{
-		Name:   version,
-		Builds: builds,
-	}
-}
-
 type BuildConfig struct {
 	Platform     string   `json:"platform"`
 	Url          string   `json:"url"`

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -138,7 +138,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 	}
 
 	if len(b.versions) == 0 {
-		b.versions = append(b.versions, buildDummyGenericMongoDbVersionConfig(b.mongodbVersion))
+		b.versions = append(b.versions, buildDummyMongoDbVersionConfig(b.mongodbVersion))
 	}
 
 	currentAc := AutomationConfig{
@@ -196,10 +196,10 @@ func withFCV(fcv string) func(*Process) {
 	}
 }
 
-// buildDummyGenericMongoDbVersionConfig create a MongoDbVersionConfig which
+// buildDummyMongoDbVersionConfig create a MongoDbVersionConfig which
 // will be valid for any version of MongoDB. This is used as a default if no
 // versions are manually specified.
-func buildDummyGenericMongoDbVersionConfig(version string) MongoDbVersionConfig {
+func buildDummyMongoDbVersionConfig(version string) MongoDbVersionConfig {
 	return MongoDbVersionConfig{
 		Name: version,
 		Builds: []BuildConfig{

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -137,6 +137,10 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		auth = b.enabler.EnableAuth(auth)
 	}
 
+	if len(b.versions) == 0 {
+		b.versions = append(b.versions, buildDummyGenericMongoDbVersionConfig(b.mongodbVersion))
+	}
+
 	currentAc := AutomationConfig{
 		Version:   b.previousAC.Version,
 		Processes: processes,
@@ -189,5 +193,28 @@ func toHostName(name string, index int) string {
 func withFCV(fcv string) func(*Process) {
 	return func(process *Process) {
 		process.FeatureCompatibilityVersion = fcv
+	}
+}
+
+// buildDummyGenericMongoDbVersionConfig create a MongoDbVersionConfig which
+// will be valid for any version of MongoDB. This is used as a default if no
+// versions are manually specified.
+func buildDummyGenericMongoDbVersionConfig(version string) MongoDbVersionConfig {
+	return MongoDbVersionConfig{
+		Name: version,
+		Builds: []BuildConfig{
+			{
+				Platform:     "linux",
+				Architecture: "amd64",
+				Flavor:       "rhel",
+				Modules:      []string{},
+			},
+			{
+				Platform:     "linux",
+				Architecture: "amd64",
+				Flavor:       "ubuntu",
+				Modules:      []string{},
+			},
+		},
 	}
 }

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -184,3 +184,52 @@ func TestModifications(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 4, ac.Version)
 }
+
+func TestMongoDBVersionsConfig(t *testing.T) {
+
+	t.Run("Dummy Config is used when no versions are set", func(t *testing.T) {
+		ac, err := NewBuilder().SetMongoDBVersion("4.4.2").Build()
+		assert.NoError(t, err)
+
+		versions := ac.Versions
+		assert.Len(t, versions, 1)
+		v := versions[0]
+		dummyConfig := buildDummyMongoDbVersionConfig("4.4.2")
+		assert.Equal(t, v, dummyConfig)
+	})
+
+	t.Run("Dummy Config is not used when versions are set", func(t *testing.T) {
+		ac, err := NewBuilder().SetMongoDBVersion("4.4.2").AddVersion(MongoDbVersionConfig{
+			Name: "4.4.2",
+			Builds: []BuildConfig{
+				{
+					Platform:     "linux",
+					Url:          "url",
+					GitVersion:   "gitVersion",
+					Architecture: "arch",
+					Flavor:       "flavor",
+					MinOsVersion: "minOs",
+					MaxOsVersion: "maxOs",
+				},
+			},
+		}).Build()
+
+		assert.NoError(t, err)
+
+		versions := ac.Versions
+		assert.Len(t, versions, 1)
+		v := versions[0]
+		dummyConfig := buildDummyMongoDbVersionConfig("4.4.2")
+		assert.NotEqual(t, v, dummyConfig)
+
+		b := versions[0].Builds[0]
+		assert.Equal(t, "linux", b.Platform)
+		assert.Equal(t, "url", b.Url)
+		assert.Equal(t, "gitVersion", b.GitVersion)
+		assert.Equal(t, "arch", b.Architecture)
+		assert.Equal(t, "minOs", b.MinOsVersion)
+		assert.Equal(t, "maxOs", b.MaxOsVersion)
+
+	})
+
+}

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -171,32 +171,6 @@ func TestProcessHasPortSetToDefault(t *testing.T) {
 	}
 }
 
-func TestVersionManifest_BuildsForVersion(t *testing.T) {
-	vm := VersionManifest{
-		Updated: 0,
-		Versions: []MongoDbVersionConfig{
-			defaultMongoDbVersion("4.2.0"),
-			defaultMongoDbVersion("4.2.3"),
-			defaultMongoDbVersion("4.2.4"),
-		},
-	}
-
-	version := vm.BuildsForVersion("4.2.0")
-	assert.Len(t, version.Builds, 1)
-	assert.Equal(t, defaultMongoDbVersion("4.2.0"), version)
-
-	version = vm.BuildsForVersion("4.2.3")
-	assert.Len(t, version.Builds, 1)
-	assert.Equal(t, defaultMongoDbVersion("4.2.3"), version)
-
-	version = vm.BuildsForVersion("4.2.4")
-	assert.Len(t, version.Builds, 1)
-	assert.Equal(t, defaultMongoDbVersion("4.2.4"), version)
-
-	version = vm.BuildsForVersion("4.2.1")
-	assert.Empty(t, version.Builds)
-}
-
 func TestModifications(t *testing.T) {
 	incrementVersion := func(config *AutomationConfig) {
 		config.Version += 1

--- a/release.json
+++ b/release.json
@@ -1,4 +1,8 @@
 {
-    "mongodb-kubernetes-operator": "0.5.0",
-    "version-upgrade-hook": "1.0.2"
+  "mongodb-kubernetes-operator": "0.5.0",
+  "version-upgrade-hook": "1.0.2",
+  "agent": {
+    "version": "10.27.0.6772-1",
+    "tools_version": "100.2.0"
+  }
 }

--- a/scripts/dev/templates/Dockerfile.operator
+++ b/scripts/dev/templates/Dockerfile.operator
@@ -12,10 +12,6 @@ COPY build/bin/ build/bin/
 # Build the operator
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager cmd/manager/main.go
 
-ENV manifest_version=4.4
-RUN mkdir -p /content/ \
-        && chmod -R +r /content/ \
-        && curl --fail --retry 3 -o /content/version_manifest.json "https://opsmanager.mongodb.com/static/version_manifest/${manifest_version}.json"
 {% endblock -%}
 
 {% block build_second_stage -%}
@@ -29,7 +25,6 @@ ENV OPERATOR=manager \
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/build/bin /usr/local/bin
-COPY --from=builder /content/version_manifest.json /usr/local/version_manifest.json
 
 RUN  /usr/local/bin/user_setup
 


### PR DESCRIPTION
### All Submissions:

* [N/A] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


This PR upgrades the agent version to a version which supports allowing versions of MongoDB which are not present in the version manifest.

* The version manifest has been removed from the operator image.
* A dummy version config is being used in the automation config.
* The agent version has been upgraded.

closes #255