### PR TITLE
CLOUDP-83416: fix flakey TLS test

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -138,7 +138,7 @@ task_groups:
     - e2e_test_feature_compatibility_version
     - e2e_test_feature_compatibility_version_upgrade
     - e2e_test_replica_set_multiple
-#    - e2e_test_replica_set_tls # TODO: flaky test, fix and uncomment in CLOUDP-76190
+    - e2e_test_replica_set_tls
     - e2e_test_replica_set_tls_upgrade
     - e2e_test_replica_set_tls_rotate
     - e2e_test_statefulset_arbitrary_config

--- a/test/e2e/replica_set_tls/replica_set_tls_test.go
+++ b/test/e2e/replica_set_tls/replica_set_tls_test.go
@@ -45,7 +45,7 @@ func TestReplicaSetTLS(t *testing.T) {
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
-	t.Run("Wait for TLS to be enabled", tester.HasTlsMode("requireSSL", 60))
+	t.Run("Wait for TLS to be enabled", tester.HasTlsMode("requireSSL", 60, WithTls()))
 	t.Run("Test Basic TLS Connectivity", tester.ConnectivitySucceeds(WithTls()))
 	t.Run("Test TLS required", tester.ConnectivityFails(WithoutTls()))
 	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3, WithTls()))


### PR DESCRIPTION
This fixes the flakey TLS test. Just copies the existing statement from the green test (`replica_set_tls_rotate_test.go`)
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
