### PR TITLE
CLOUDP-83838: Fix logging configuration and add volume for logs

### DIFF
--- a/controllers/build_statefulset_test.go
+++ b/controllers/build_statefulset_test.go
@@ -58,13 +58,13 @@ func assertStatefulSetIsBuiltCorrectly(t *testing.T, mdb mdbv1.MongoDBCommunity,
 	assert.True(t, reflect.DeepEqual(probes.New(defaultReadiness()), *probe))
 	assert.Equal(t, probes.New(defaultReadiness()).FailureThreshold, probe.FailureThreshold)
 	assert.Equal(t, int32(5), probe.InitialDelaySeconds)
-	assert.Len(t, agentContainer.VolumeMounts, 5)
+	assert.Len(t, agentContainer.VolumeMounts, 6)
 
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "agent-scripts")
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "automation-config")
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "data-volume")
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "healthstatus")
-	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "my-rs-agent-scram-credentials")
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "my-rs-keyfile")
 
 	mongodContainer := sts.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "repo/mongo:4.2.2", mongodContainer.Image)
@@ -75,7 +75,7 @@ func assertStatefulSetIsBuiltCorrectly(t *testing.T, mdb mdbv1.MongoDBCommunity,
 	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "healthstatus")
 	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "hooks")
 	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "logs-volume")
-	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "my-rs-agent-scram-credentials")
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "my-rs-keyfile")
 
 	initContainer := sts.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, versionUpgradeHookName, initContainer.Name)

--- a/controllers/build_statefulset_test.go
+++ b/controllers/build_statefulset_test.go
@@ -64,7 +64,7 @@ func assertStatefulSetIsBuiltCorrectly(t *testing.T, mdb mdbv1.MongoDBCommunity,
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "automation-config")
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "data-volume")
 	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "healthstatus")
-	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "keyfile-volume")
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "my-rs-agent-scram-credentials")
 
 	mongodContainer := sts.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "repo/mongo:4.2.2", mongodContainer.Image)
@@ -75,7 +75,7 @@ func assertStatefulSetIsBuiltCorrectly(t *testing.T, mdb mdbv1.MongoDBCommunity,
 	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "healthstatus")
 	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "hooks")
 	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "logs-volume")
-	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "keyfile-volume")
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "my-rs-agent-scram-credentials")
 
 	initContainer := sts.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, versionUpgradeHookName, initContainer.Name)

--- a/controllers/build_statefulset_test.go
+++ b/controllers/build_statefulset_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/probes"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
@@ -58,13 +60,36 @@ func assertStatefulSetIsBuiltCorrectly(t *testing.T, mdb mdbv1.MongoDBCommunity,
 	assert.Equal(t, int32(5), probe.InitialDelaySeconds)
 	assert.Len(t, agentContainer.VolumeMounts, 5)
 
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "agent-scripts")
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "automation-config")
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "data-volume")
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "healthstatus")
+	assertContainsVolumeMountWithName(t, agentContainer.VolumeMounts, "keyfile-volume")
+
 	mongodContainer := sts.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "repo/mongo:4.2.2", mongodContainer.Image)
 	assert.NotNil(t, sts.Spec.Template.Spec.Containers[1].ReadinessProbe)
-	assert.Len(t, mongodContainer.VolumeMounts, 4)
+	assert.Len(t, mongodContainer.VolumeMounts, 5)
+
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "data-volume")
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "healthstatus")
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "hooks")
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "logs-volume")
+	assertContainsVolumeMountWithName(t, mongodContainer.VolumeMounts, "keyfile-volume")
 
 	initContainer := sts.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, versionUpgradeHookName, initContainer.Name)
 	assert.Equal(t, "version-upgrade-hook-image", initContainer.Image)
 	assert.Len(t, initContainer.VolumeMounts, 1)
+}
+
+func assertContainsVolumeMountWithName(t *testing.T, mounts []corev1.VolumeMount, name string) {
+	found := false
+	for _, m := range mounts {
+		if m.Name == name {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Mounts should have contained a mount with name %s, but didn't. Actual mounts: %v", name, mounts)
 }

--- a/controllers/mongodb_authentication.go
+++ b/controllers/mongodb_authentication.go
@@ -1,16 +1,17 @@
 package controllers
 
 import (
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/statefulset"
 )
 
 // buildScramPodSpecModification will add the keyfile volume to the podTemplateSpec
 // the keyfile is owned by the agent, and is required to have 0600 permissions.
-func buildScramPodSpecModification() podtemplatespec.Modification {
+func buildScramPodSpecModification(mdb mdbv1.MongoDBCommunity) podtemplatespec.Modification {
 	mode := int32(0600)
-	keyfileVolumeName := "keyfile-volume"
-	keyFileVolume := statefulset.CreateVolumeFromSecret(keyfileVolumeName, keyfileVolumeName, statefulset.WithSecretDefaultMode(&mode))
+	scramSecretNsName := mdb.GetAgentScramCredentialsNamespacedName()
+	keyFileVolume := statefulset.CreateVolumeFromSecret(scramSecretNsName.Name, scramSecretNsName.Name, statefulset.WithSecretDefaultMode(&mode))
 	keyFileVolumeVolumeMount := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
 	keyFileVolumeVolumeMountMongod := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
 

--- a/controllers/mongodb_authentication.go
+++ b/controllers/mongodb_authentication.go
@@ -10,8 +10,8 @@ import (
 // the keyfile is owned by the agent, and is required to have 0600 permissions.
 func buildScramPodSpecModification(mdb mdbv1.MongoDBCommunity) podtemplatespec.Modification {
 	mode := int32(0600)
-	scramSecretNsName := mdb.GetAgentScramCredentialsNamespacedName()
-	keyFileVolume := statefulset.CreateVolumeFromSecret(scramSecretNsName.Name, scramSecretNsName.Name, statefulset.WithSecretDefaultMode(&mode))
+	keyfileVolumeName := "keyfile-volume"
+	keyFileVolume := statefulset.CreateVolumeFromSecret(keyfileVolumeName, keyfileVolumeName, statefulset.WithSecretDefaultMode(&mode))
 	keyFileVolumeVolumeMount := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
 	keyFileVolumeVolumeMountMongod := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
 

--- a/controllers/mongodb_authentication.go
+++ b/controllers/mongodb_authentication.go
@@ -1,14 +1,13 @@
 package controllers
 
 import (
-	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/podtemplatespec"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/statefulset"
 )
 
 // buildScramPodSpecModification will add the keyfile volume to the podTemplateSpec
 // the keyfile is owned by the agent, and is required to have 0600 permissions.
-func buildScramPodSpecModification(mdb mdbv1.MongoDBCommunity) podtemplatespec.Modification {
+func buildScramPodSpecModification() podtemplatespec.Modification {
 	mode := int32(0600)
 	keyfileVolumeName := "keyfile-volume"
 	keyFileVolume := statefulset.CreateVolumeFromSecret(keyfileVolumeName, keyfileVolumeName, statefulset.WithSecretDefaultMode(&mode))

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -748,7 +748,7 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 				podtemplatespec.WithVolume(automationConfigVolume),
 				podtemplatespec.WithVolume(scriptsVolume),
 				podtemplatespec.WithServiceAccount(operatorServiceAccountName),
-				podtemplatespec.WithContainer(agentName, mongodbAgentContainer(mdb.AutomationConfigSecretName(), []corev1.VolumeMount{agentHealthStatusVolumeMount, automationConfigVolumeMount, dataVolumeMount, scriptsVolumeMount})),
+				podtemplatespec.WithContainer(agentName, mongodbAgentContainer(mdb.AutomationConfigSecretName(), []corev1.VolumeMount{agentHealthStatusVolumeMount, automationConfigVolumeMount, dataVolumeMount, scriptsVolumeMount, logVolumeMount})),
 				podtemplatespec.WithContainer(mongodbName, mongodbContainer(mdb.Spec.Version, []corev1.VolumeMount{mongodHealthStatusVolumeMount, dataVolumeMount, hooksVolumeMount, logVolumeMount})),
 				podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount})),
 				podtemplatespec.WithInitContainer(readinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount})),

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -753,7 +753,7 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 				podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount})),
 				podtemplatespec.WithInitContainer(readinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount})),
 				buildTLSPodSpecModification(mdb),
-				buildScramPodSpecModification(mdb),
+				buildScramPodSpecModification(),
 			),
 		),
 		statefulset.WithCustomSpecs(mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec),

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -72,6 +72,7 @@ const (
 	versionUpgradeHookName         = "mongod-posthook"
 	readinessProbeContainerName    = "mongodb-agent-readinessprobe"
 	dataVolumeName                 = "data-volume"
+	logVolumeName                  = "logs-volume"
 	readinessProbePath             = "/opt/scripts/readinessprobe"
 	clusterFilePath                = "/var/lib/automation/config/cluster-config.json"
 	operatorServiceAccountName     = "mongodb-kubernetes-operator"
@@ -725,7 +726,8 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 	automationConfigVolume := statefulset.CreateVolumeFromSecret("automation-config", mdb.AutomationConfigSecretName())
 	automationConfigVolumeMount := statefulset.CreateVolumeMount(automationConfigVolume.Name, "/var/lib/automation/config", statefulset.WithReadOnly(true))
 
-	dataVolume := statefulset.CreateVolumeMount(dataVolumeName, "/data")
+	dataVolumeMount := statefulset.CreateVolumeMount(dataVolumeName, "/data")
+	logVolumeMount := statefulset.CreateVolumeMount(logVolumeName, automationconfig.DefaultAgentLogPath)
 
 	return statefulset.Apply(
 		statefulset.WithName(mdb.Name),
@@ -736,7 +738,8 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 		statefulset.WithOwnerReference([]metav1.OwnerReference{getOwnerReference(mdb)}),
 		statefulset.WithReplicas(mdb.StatefulSetReplicasThisReconciliation()),
 		statefulset.WithUpdateStrategyType(getUpdateStrategyType(mdb)),
-		statefulset.WithVolumeClaim(dataVolumeName, defaultPvc()),
+		statefulset.WithVolumeClaim(dataVolumeName, dataPvc()),
+		statefulset.WithVolumeClaim(logVolumeName, logsPvc()),
 		statefulset.WithPodSpecTemplate(
 			podtemplatespec.Apply(
 				podtemplatespec.WithPodLabels(labels),
@@ -745,8 +748,8 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 				podtemplatespec.WithVolume(automationConfigVolume),
 				podtemplatespec.WithVolume(scriptsVolume),
 				podtemplatespec.WithServiceAccount(operatorServiceAccountName),
-				podtemplatespec.WithContainer(agentName, mongodbAgentContainer(mdb.AutomationConfigSecretName(), []corev1.VolumeMount{agentHealthStatusVolumeMount, automationConfigVolumeMount, dataVolume, scriptsVolumeMount})),
-				podtemplatespec.WithContainer(mongodbName, mongodbContainer(mdb.Spec.Version, []corev1.VolumeMount{mongodHealthStatusVolumeMount, dataVolume, hooksVolumeMount})),
+				podtemplatespec.WithContainer(agentName, mongodbAgentContainer(mdb.AutomationConfigSecretName(), []corev1.VolumeMount{agentHealthStatusVolumeMount, automationConfigVolumeMount, dataVolumeMount, scriptsVolumeMount})),
+				podtemplatespec.WithContainer(mongodbName, mongodbContainer(mdb.Spec.Version, []corev1.VolumeMount{mongodHealthStatusVolumeMount, dataVolumeMount, hooksVolumeMount, logVolumeMount})),
 				podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount})),
 				podtemplatespec.WithInitContainer(readinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount})),
 				buildTLSPodSpecModification(mdb),
@@ -780,10 +783,18 @@ func defaultReadiness() probes.Modification {
 	)
 }
 
-func defaultPvc() persistentvolumeclaim.Modification {
+func dataPvc() persistentvolumeclaim.Modification {
 	return persistentvolumeclaim.Apply(
 		persistentvolumeclaim.WithName(dataVolumeName),
 		persistentvolumeclaim.WithAccessModes(corev1.ReadWriteOnce),
 		persistentvolumeclaim.WithResourceRequests(resourcerequirements.BuildDefaultStorageRequirements()),
+	)
+}
+
+func logsPvc() persistentvolumeclaim.Modification {
+	return persistentvolumeclaim.Apply(
+		persistentvolumeclaim.WithName(logVolumeName),
+		persistentvolumeclaim.WithAccessModes(corev1.ReadWriteOnce),
+		persistentvolumeclaim.WithResourceRequests(resourcerequirements.BuildStorageRequirements("2G")),
 	)
 }

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -753,7 +753,7 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 				podtemplatespec.WithInitContainer(versionUpgradeHookName, versionUpgradeHookInit([]corev1.VolumeMount{hooksVolumeMount})),
 				podtemplatespec.WithInitContainer(readinessProbeContainerName, readinessProbeInit([]corev1.VolumeMount{scriptsVolumeMount})),
 				buildTLSPodSpecModification(mdb),
-				buildScramPodSpecModification(),
+				buildScramPodSpecModification(mdb),
 			),
 		),
 		statefulset.WithCustomSpecs(mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec),

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -511,9 +511,9 @@ func TestOpenshift_Configuration(t *testing.T) {
 func TestVolumeClaimTemplates_Configuration(t *testing.T) {
 	sts := performReconciliationAndGetStatefulSet(t, "volume_claim_templates_mdb.yaml")
 
-	assert.Len(t, sts.Spec.VolumeClaimTemplates, 2)
+	assert.Len(t, sts.Spec.VolumeClaimTemplates, 3)
 
-	pvcSpec := sts.Spec.VolumeClaimTemplates[1].Spec
+	pvcSpec := sts.Spec.VolumeClaimTemplates[2].Spec
 
 	storage := pvcSpec.Resources.Requests[corev1.ResourceStorage]
 	storageRef := &storage
@@ -525,7 +525,7 @@ func TestVolumeClaimTemplates_Configuration(t *testing.T) {
 
 func TestChangeDataVolume_Configuration(t *testing.T) {
 	sts := performReconciliationAndGetStatefulSet(t, "change_data_volume.yaml")
-	assert.Len(t, sts.Spec.VolumeClaimTemplates, 1)
+	assert.Len(t, sts.Spec.VolumeClaimTemplates, 2)
 
 	dataVolume := sts.Spec.VolumeClaimTemplates[0]
 

--- a/controllers/testdata/change_data_volume.yaml
+++ b/controllers/testdata/change_data_volume.yaml
@@ -1,5 +1,5 @@
 apiVersion: mongodb.com/v1
-kind: MongoDB
+kind: MongoDBCommunity
 metadata:
   name: change-data-volume-mdb
 spec:

--- a/controllers/testdata/custom_storage_class.yaml
+++ b/controllers/testdata/custom_storage_class.yaml
@@ -1,5 +1,5 @@
 apiVersion: mongodb.com/v1
-kind: MongoDB
+kind: MongoDBCommunity
 metadata:
   name: custom-storage-class-mdb
 spec:

--- a/controllers/testdata/openshift_mdb.yaml
+++ b/controllers/testdata/openshift_mdb.yaml
@@ -1,5 +1,5 @@
 apiVersion: mongodb.com/v1
-kind: MongoDB
+kind: MongoDBCommunity
 metadata:
   name: example-openshift-mongodb
 spec:

--- a/controllers/testdata/tolerations_example.yaml
+++ b/controllers/testdata/tolerations_example.yaml
@@ -1,5 +1,5 @@
 apiVersion: mongodb.com/v1
-kind: MongoDB
+kind: MongoDBCommunity
 metadata:
   name: tolerations-mdb
 spec:

--- a/controllers/testdata/volume_claim_templates_mdb.yaml
+++ b/controllers/testdata/volume_claim_templates_mdb.yaml
@@ -1,5 +1,5 @@
 apiVersion: mongodb.com/v1
-kind: MongoDB
+kind: MongoDBCommunity
 metadata:
   name: volume-claim-templates-mdb
 spec:

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -80,7 +80,7 @@ func (p *Process) SetSystemLog(systemLog SystemLog) *Process {
 }
 
 // SetArgs26Field should be used whenever any args26 field needs to be set. It ensures
-// that the args26 map is non nil and assingns the given value.
+// that the args26 map is non nil and assigns the given value.
 func (p *Process) SetArgs26Field(fieldName string, value interface{}) *Process {
 	p.ensureArgs26()
 	p.Args26.Set(fieldName, value)

--- a/pkg/kube/resourcerequirements/resource_requirements.go
+++ b/pkg/kube/resourcerequirements/resource_requirements.go
@@ -63,3 +63,10 @@ func BuildDefaultStorageRequirements() corev1.ResourceList {
 	res[corev1.ResourceStorage] = g10
 	return res
 }
+
+func BuildStorageRequirements(amount string) corev1.ResourceList {
+	g10, _ := resource.ParseQuantity(amount)
+	res := corev1.ResourceList{}
+	res[corev1.ResourceStorage] = g10
+	return res
+}


### PR DESCRIPTION
### All Submissions:

* [N/A] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

We previously had not had a log volume set, so logs were being lost with pod restarts. The logging settings were also being misconfigured.

they were set at process[.].systemLog rather than the correct process[n].args2_6.systemLog, the previous settings were being ignored by the agent as the field was not being recognized. 