### PR TITLE
Separate Keyfile & Password into separate secrets

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -358,6 +358,14 @@ type MongoDBCommunity struct {
 	Status MongoDBCommunityStatus `json:"status,omitempty"`
 }
 
+func (m MongoDBCommunity) GetAgentPasswordSecretNamespacedName() types.NamespacedName {
+	return types.NamespacedName{Name: m.Name + "-agent-password", Namespace: m.Namespace}
+}
+
+func (m MongoDBCommunity) GetAgentKeyfileSecretNamespacedName() types.NamespacedName {
+	return types.NamespacedName{Name: m.Name + "-keyfile", Namespace: m.Namespace}
+}
+
 // GetScramOptions returns a set of Options that are used to configure scram
 // authentication.
 func (m MongoDBCommunity) GetScramOptions() scram.Options {

--- a/controllers/mongodb_authentication.go
+++ b/controllers/mongodb_authentication.go
@@ -10,8 +10,8 @@ import (
 // the keyfile is owned by the agent, and is required to have 0600 permissions.
 func buildScramPodSpecModification(mdb mdbv1.MongoDBCommunity) podtemplatespec.Modification {
 	mode := int32(0600)
-	scramSecretNsName := mdb.GetAgentScramCredentialsNamespacedName()
-	keyFileVolume := statefulset.CreateVolumeFromSecret(scramSecretNsName.Name, scramSecretNsName.Name, statefulset.WithSecretDefaultMode(&mode))
+	keyFileNsName := mdb.GetAgentKeyfileSecretNamespacedName()
+	keyFileVolume := statefulset.CreateVolumeFromSecret(keyFileNsName.Name, keyFileNsName.Name, statefulset.WithSecretDefaultMode(&mode))
 	keyFileVolumeVolumeMount := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
 	keyFileVolumeVolumeMountMongod := statefulset.CreateVolumeMount(keyFileVolume.Name, "/var/lib/mongodb-mms-automation/authentication", statefulset.WithReadOnly(false))
 

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -341,13 +341,22 @@ func TestExistingPasswordAndKeyfile_AreUsedWhenTheSecretExists(t *testing.T) {
 
 	c := mgr.Client
 
-	scramNsName := mdb.GetAgentScramCredentialsNamespacedName()
+	keyFileNsName := mdb.GetAgentKeyfileSecretNamespacedName()
 	err := secret.CreateOrUpdate(c,
 		secret.Builder().
-			SetName(scramNsName.Name).
-			SetNamespace(scramNsName.Namespace).
-			SetField(scram.AgentPasswordKey, "my-pass").
+			SetName(keyFileNsName.Name).
+			SetNamespace(keyFileNsName.Namespace).
 			SetField(scram.AgentKeyfileKey, "my-keyfile").
+			Build(),
+	)
+	assert.NoError(t, err)
+
+	passwordNsName := mdb.GetAgentPasswordSecretNamespacedName()
+	err = secret.CreateOrUpdate(c,
+		secret.Builder().
+			SetName(passwordNsName.Name).
+			SetNamespace(passwordNsName.Namespace).
+			SetField(scram.AgentPasswordKey, "my-pass").
 			Build(),
 	)
 	assert.NoError(t, err)
@@ -479,12 +488,18 @@ func assertReplicaSetIsConfiguredWithScram(t *testing.T, mdb mdbv1.MongoDBCommun
 		assert.NotEmpty(t, currentAc.Auth.AutoPwd)
 		assert.False(t, currentAc.Auth.Disabled)
 	})
-	t.Run("Secret with credentials was created", func(t *testing.T) {
-		secretNsName := mdb.GetAgentScramCredentialsNamespacedName()
+	t.Run("Secret with password was created", func(t *testing.T) {
+		secretNsName := mdb.GetAgentPasswordSecretNamespacedName()
+		s, err := mgr.Client.GetSecret(secretNsName)
+		assert.NoError(t, err)
+		assert.Equal(t, s.Data[scram.AgentPasswordKey], []byte(currentAc.Auth.AutoPwd))
+	})
+
+	t.Run("Secret with keyfile was created", func(t *testing.T) {
+		secretNsName := mdb.GetAgentKeyfileSecretNamespacedName()
 		s, err := mgr.Client.GetSecret(secretNsName)
 		assert.NoError(t, err)
 		assert.Equal(t, s.Data[scram.AgentKeyfileKey], []byte(currentAc.Auth.Key))
-		assert.Equal(t, s.Data[scram.AgentPasswordKey], []byte(currentAc.Auth.AutoPwd))
 	})
 }
 

--- a/pkg/authentication/scram/mock_types_test.go
+++ b/pkg/authentication/scram/mock_types_test.go
@@ -38,8 +38,12 @@ type mockConfigurable struct {
 	nsName types.NamespacedName
 }
 
-func (m mockConfigurable) GetAgentScramCredentialsNamespacedName() types.NamespacedName {
-	return types.NamespacedName{Name: m.nsName.Name + "-scram-credentials", Namespace: m.nsName.Namespace}
+func (m mockConfigurable) GetAgentPasswordSecretNamespacedName() types.NamespacedName {
+	return types.NamespacedName{Name: m.nsName.Name + "-agent-password", Namespace: m.nsName.Namespace}
+}
+
+func (m mockConfigurable) GetAgentKeyfileSecretNamespacedName() types.NamespacedName {
+	return types.NamespacedName{Name: m.nsName.Name + "-keyfile", Namespace: m.nsName.Namespace}
 }
 
 func (m mockConfigurable) GetScramOptions() Options {

--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -109,3 +109,25 @@ func HasAllKeys(secret corev1.Secret, keys ...string) bool {
 	}
 	return true
 }
+
+// EnsureSecretWithKey makes sure the Secret with the given name has a key with the given value if the key is not already present.
+// if the key is present, it will return the existing value associated with this key.
+func EnsureSecretWithKey(secretGetUpdateCreateDeleter GetUpdateCreateDeleter, nsName types.NamespacedName, key, value string) (string, error) {
+	existingSecret, err0 := secretGetUpdateCreateDeleter.GetSecret(nsName)
+	if err0 != nil {
+		if apiErrors.IsNotFound(err0) {
+			s := Builder().
+				SetNamespace(nsName.Namespace).
+				SetName(nsName.Name).
+				SetField(key, value).
+				Build()
+
+			if err1 := secretGetUpdateCreateDeleter.CreateSecret(s); err1 != nil {
+				return "", err1
+			}
+			return value, nil
+		}
+		return "", err0
+	}
+	return string(existingSecret.Data[key]), nil
+}


### PR DESCRIPTION
### All Submissions:

* [N/A] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


We were including the agent password + keyfile in a single secret, but these are not required to be kept together, this PR separates them into separate secrets and renames the volume to a more meaningful name.