### PR TITLE
CLOUDP-83615: Fix flakey upgrade tls test

### DIFF
--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -188,6 +188,14 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 		)
 	}
 
+	if err := r.ensureTLSResources(mdb); err != nil {
+		return status.Update(r.client.Status(), &mdb,
+			statusOptions().
+				withMessage(Error, fmt.Sprintf("Error ensuring TLS resources: %s", err)).
+				withFailedPhase(),
+		)
+	}
+
 	ready, err := r.deployMongoDBReplicaSet(mdb)
 	if err != nil {
 		return status.Update(r.client.Status(), &mdb,
@@ -248,6 +256,23 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	r.log.Infow("Successfully finished reconciliation", "MongoDB.Spec:", mdb.Spec, "MongoDB.Status:", mdb.Status)
 	return res, err
+}
+
+// ensureTLSResources creates any required TLS resources that the MongoDBCommunity
+// requires for TLS configuration.
+func (r *ReplicaSetReconciler) ensureTLSResources(mdb mdbv1.MongoDBCommunity) error {
+	if !mdb.Spec.Security.TLS.Enabled {
+		return nil
+	}
+	// the TLS secret needs to be created beforehand, as both the StatefulSet and AutomationConfig
+	// require the contents.
+	if mdb.Spec.Security.TLS.Enabled {
+		r.log.Infof("TLS is enabled, creating/updating TLS secret")
+		if err := ensureTLSSecret(r.client, mdb); err != nil {
+			return errors.Errorf("could not ensure TLS secret: %s", err)
+		}
+	}
+	return nil
 }
 
 // deployStatefulSet deploys the backing StatefulSet of the MongoDBCommunity resource.

--- a/pkg/kube/client/mocked_manager.go
+++ b/pkg/kube/client/mocked_manager.go
@@ -30,6 +30,10 @@ func NewManager(obj k8sClient.Object) *MockedManager {
 	return &MockedManager{Client: NewClient(c)}
 }
 
+func NewManagerWithClient(c k8sClient.Client) *MockedManager {
+	return &MockedManager{Client: NewClient(c)}
+}
+
 func (m *MockedManager) Add(_ manager.Runnable) error {
 	return nil
 }

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -95,6 +95,14 @@ func WaitForStatefulSetToBeReady(t *testing.T, mdb *mdbv1.MongoDBCommunity, retr
 	})
 }
 
+// waitForStatefulSetCondition waits until all replicas of the StatefulSet with the given name
+// is not ready.
+func WaitForStatefulSetToBeUnready(t *testing.T, mdb *mdbv1.MongoDBCommunity, retryInterval, timeout time.Duration) error {
+	return waitForStatefulSetCondition(t, mdb, retryInterval, timeout, func(sts appsv1.StatefulSet) bool {
+		return !statefulset.IsReady(sts, mdb.Spec.Members)
+	})
+}
+
 // WaitForStatefulSetToBeReadyAfterScaleDown waits for just the ready replicas to be correct
 // and does not account for the updated replicas
 func WaitForStatefulSetToBeReadyAfterScaleDown(t *testing.T, mdb *mdbv1.MongoDBCommunity, retryInterval, timeout time.Duration) error {

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -52,7 +52,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while version is upgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 	})
 
 	t.Run("Test Basic Connectivity after upgrade has completed", tester.ConnectivitySucceeds())
@@ -62,7 +62,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while version is downgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 	})
 
 	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", tester.HasFCV("4.0", 3))

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -59,7 +59,7 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("Test Basic Connectivity after upgrade has completed", tester.ConnectivitySucceeds())
 	})
 
@@ -72,7 +72,7 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 			})
 			assert.NoError(t, err)
 		})
-		t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 	})
 	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", tester.HasFCV("4.2", 3))

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -30,6 +30,10 @@ func StatefulSetIsReady(mdb *mdbv1.MongoDBCommunity) func(t *testing.T) {
 	return statefulSetIsReady(mdb, time.Second*15, time.Minute*12)
 }
 
+func StatefulSetBecomesUnready(mdb *mdbv1.MongoDBCommunity) func(t *testing.T) {
+	return statefulSetIsNotReady(mdb, time.Second*15, time.Minute*12)
+}
+
 // StatefulSetIsReadyAfterScaleDown ensures that a replica set is scaled down correctly
 // note: scaling down takes considerably longer than scaling up due the readiness probe
 // failure threshold being high
@@ -52,6 +56,18 @@ func statefulSetIsReady(mdb *mdbv1.MongoDBCommunity, interval time.Duration, tim
 			t.Fatal(err)
 		}
 		t.Logf("StatefulSet %s/%s is ready!", mdb.Namespace, mdb.Name)
+	}
+}
+
+// StatefulSetIsReady ensures that the underlying stateful set
+// reaches the running state
+func statefulSetIsNotReady(mdb *mdbv1.MongoDBCommunity, interval time.Duration, timeout time.Duration) func(t *testing.T) {
+	return func(t *testing.T) {
+		err := e2eutil.WaitForStatefulSetToBeUnready(t, mdb, interval, timeout)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("StatefulSet %s/%s is not ready!", mdb.Namespace, mdb.Name)
 	}
 }
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -24,12 +24,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// StatefulSetIsReady ensures that the underlying stateful set
-// reaches the running state
-func StatefulSetIsReady(mdb *mdbv1.MongoDBCommunity) func(t *testing.T) {
+// StatefulSetBecomesReady ensures that the underlying stateful set
+// reaches the running state.
+func StatefulSetBecomesReady(mdb *mdbv1.MongoDBCommunity) func(t *testing.T) {
 	return statefulSetIsReady(mdb, time.Second*15, time.Minute*12)
 }
 
+// StatefulSetBecomesUnready ensures the underlying stateful set reaches
+// the unready state.
 func StatefulSetBecomesUnready(mdb *mdbv1.MongoDBCommunity) func(t *testing.T) {
 	return statefulSetIsNotReady(mdb, time.Second*15, time.Minute*12)
 }
@@ -59,8 +61,7 @@ func statefulSetIsReady(mdb *mdbv1.MongoDBCommunity, interval time.Duration, tim
 	}
 }
 
-// StatefulSetIsReady ensures that the underlying stateful set
-// reaches the running state
+// statefulSetIsNotReady ensures that the underlying stateful set reaches the unready state.
 func statefulSetIsNotReady(mdb *mdbv1.MongoDBCommunity, interval time.Duration, timeout time.Duration) func(t *testing.T) {
 	return func(t *testing.T) {
 		err := e2eutil.WaitForStatefulSetToBeUnready(t, mdb, interval, timeout)
@@ -176,7 +177,7 @@ func CreateMongoDBResource(mdb *mdbv1.MongoDBCommunity, ctx *e2eutil.Context) fu
 func BasicFunctionality(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("Secret Was Correctly Created", AutomationConfigSecretExists(mdb))
-		t.Run("Stateful Set Reaches Ready State", StatefulSetIsReady(mdb))
+		t.Run("Stateful Set Reaches Ready State", StatefulSetBecomesReady(mdb))
 		t.Run("MongoDB Reaches Running Phase", MongoDBReachesRunningPhase(mdb))
 		t.Run("Stateful Set has OwnerReference", StatefulSetHasOwnerReference(mdb,
 			*metav1.NewControllerRef(mdb, schema.GroupVersionKind{

--- a/test/e2e/replica_set_change_version/replica_set_test.go
+++ b/test/e2e/replica_set_change_version/replica_set_test.go
@@ -55,7 +55,7 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.4.1"))
 		t.Run("StatefulSet has OnDelete update strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.OnDeleteStatefulSetStrategyType))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 2))
 	})
 
@@ -66,7 +66,7 @@ func TestReplicaSetUpgradeVersion(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.4.0"))
 		t.Run("StatefulSet has OnDelete restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.OnDeleteStatefulSetStrategyType))
-		t.Run("Stateful Set Reaches Ready State, after downgrading", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after downgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))
 	})
 	t.Run("StatefulSet has RollingUpgrade restart strategy", mongodbtests.StatefulSetHasUpdateStrategy(&mdb, appsv1.RollingUpdateStatefulSetStrategyType))

--- a/test/e2e/replica_set_multiple/replica_set_multiple_test.go
+++ b/test/e2e/replica_set_multiple/replica_set_multiple_test.go
@@ -72,7 +72,7 @@ func TestReplicaSetMultiple(t *testing.T) {
 	t.Run("MongoDB is reachable while being scaled up", func(t *testing.T) {
 		defer tester0.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Scale MongoDB Resource Up", mongodbtests.Scale(&mdb0, 5))
-		t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetIsReady(&mdb0))
+		t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb0))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb0))
 		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb0, 3))
 		t.Run("Test Status Was Updated", mongodbtests.Status(&mdb0,

--- a/test/e2e/replica_set_readiness_probe/replica_set_readiness_probe_test.go
+++ b/test/e2e/replica_set_readiness_probe/replica_set_readiness_probe_test.go
@@ -55,7 +55,7 @@ func TestReplicaSetReadinessProbeScaling(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Run("Delete Random Pod", mongodbtests.DeletePod(&mdb, int(n.Int64())))
-		t.Run("Test Replica Set Recovers", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Test Replica Set Recovers", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 		t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
 			mdbv1.MongoDBCommunityStatus{

--- a/test/e2e/replica_set_scale/replica_set_scaling_test.go
+++ b/test/e2e/replica_set_scale/replica_set_scaling_test.go
@@ -49,7 +49,7 @@ func TestReplicaSetScaleUp(t *testing.T) {
 	t.Run("MongoDB is reachable", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Scale MongoDB Resource Up", mongodbtests.Scale(&mdb, 5))
-		t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 		t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))
 		t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,

--- a/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
+++ b/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
@@ -53,7 +53,7 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable while TLS is being enabled", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithoutTls())()
 		t.Run("Upgrade to TLS", tlstests.EnableTLS(&mdb, true))
-		t.Run("Stateful Set Reaches Ready State, after enabling TLS", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after setting TLS to preferSSL", mongodbtests.StatefulSetIsReady(&mdb))
 		t.Run("Wait for TLS to be enabled", tester.HasTlsMode("preferSSL", 60, WithoutTls()))
 	})
 
@@ -66,6 +66,7 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable over TLS while making TLS required", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithTls())()
 		t.Run("Make TLS required", tlstests.EnableTLS(&mdb, false))
+		t.Run("Stateful Set Reaches Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetIsReady(&mdb))
 		t.Run("Wait for TLS to be required", tester.HasTlsMode("requireSSL", 120, WithTls()))
 	})
 

--- a/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
+++ b/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
@@ -53,6 +53,7 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable while TLS is being enabled", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithoutTls())()
 		t.Run("Upgrade to TLS", tlstests.EnableTLS(&mdb, true))
+		t.Run("Stateful Set Leaves Ready State, after setting TLS to preferSSL", mongodbtests.StatefulSetBecomesUnready(&mdb))
 		t.Run("Stateful Set Reaches Ready State, after setting TLS to preferSSL", mongodbtests.StatefulSetIsReady(&mdb))
 		t.Run("Wait for TLS to be enabled", tester.HasTlsMode("preferSSL", 60, WithoutTls()))
 	})
@@ -66,6 +67,7 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable over TLS while making TLS required", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithTls())()
 		t.Run("Make TLS required", tlstests.EnableTLS(&mdb, false))
+		t.Run("Stateful Set Leaves Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetBecomesUnready(&mdb))
 		t.Run("Stateful Set Reaches Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetIsReady(&mdb))
 		t.Run("Wait for TLS to be required", tester.HasTlsMode("requireSSL", 120, WithTls()))
 	})

--- a/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
+++ b/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
@@ -54,7 +54,7 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithoutTls())()
 		t.Run("Upgrade to TLS", tlstests.EnableTLS(&mdb, true))
 		t.Run("Stateful Set Leaves Ready State, after setting TLS to preferSSL", mongodbtests.StatefulSetBecomesUnready(&mdb))
-		t.Run("Stateful Set Reaches Ready State, after setting TLS to preferSSL", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after setting TLS to preferSSL", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("Wait for TLS to be enabled", tester.HasTlsMode("preferSSL", 60, WithoutTls()))
 	})
 
@@ -67,7 +67,7 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable over TLS while making TLS required", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithTls())()
 		t.Run("Make TLS required", tlstests.EnableTLS(&mdb, false))
-		t.Run("Stateful Set Reaches Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetIsReady(&mdb))
+		t.Run("Stateful Set Reaches Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("Wait for TLS to be required", tester.HasTlsMode("requireSSL", 120, WithTls()))
 	})
 

--- a/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
+++ b/test/e2e/replica_set_tls_upgrade/replica_set_tls_upgrade_test.go
@@ -67,7 +67,6 @@ func TestReplicaSetTLSUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable over TLS while making TLS required", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10, WithTls())()
 		t.Run("Make TLS required", tlstests.EnableTLS(&mdb, false))
-		t.Run("Stateful Set Leaves Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetBecomesUnready(&mdb))
 		t.Run("Stateful Set Reaches Ready State, after setting TLS to requireSSL", mongodbtests.StatefulSetIsReady(&mdb))
 		t.Run("Wait for TLS to be required", tester.HasTlsMode("requireSSL", 120, WithTls()))
 	})


### PR DESCRIPTION
### All Submissions:

* [n/a] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


This PR fixes the flakey tls upgrade test. The issue was that we were continuing the test without waiting for the agents to reach goal state.

