### PR TITLE
CLOUDP-83929: Build agent image in evergreen & remove old readiness probe

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -101,6 +101,7 @@ functions:
           - quay_user_name
           - quay_password
           - expire_after
+          - image
         working_dir: mongodb-kubernetes-operator
         binary: scripts/ci/build_and_push_agent_image.sh
 

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -116,7 +116,7 @@ functions:
           - image_type
           - expire_after
         working_dir: mongodb-kubernetes-operator
-        binary: scripts/ci/build_and_push_image.sh
+        binary: scripts/ci/build_and_push_agent_image.sh
 
   release_docker_image:
     - command: subprocess.exec

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -116,7 +116,7 @@ functions:
           - image_type
           - expire_after
         working_dir: mongodb-kubernetes-operator
-        binary: scripts/ci/build_and_push_agent_image.sh
+        binary: scripts/ci/build_and_push_image.sh
 
   release_docker_image:
     - command: subprocess.exec
@@ -192,10 +192,9 @@ tasks:
     commands:
       - func: clone
       - func: setup_virtualenv
-      - func: build_and_push_image
+      - func: build_and_push_agent_image
         vars:
           image: quay.io/mongodb/mongodb-agent-dev:${version_id}
-          image_type: agent
           expire_after: 48h
 
   - name: build_prehook_image

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -91,6 +91,18 @@ functions:
           - clusterwide
         binary: scripts/ci/run_test.sh
 
+  # TODO: can be removed once the agent is included in the Dockerfile generator.
+  build_and_push_agent_image:
+    - command: subprocess.exec
+      type: setup
+      params:
+        include_expansions_in_env:
+          - version_id
+          - quay_user_name
+          - quay_password
+          - expire_after
+        working_dir: mongodb-kubernetes-operator
+        binary: scripts/ci/build_and_push_agent_image.sh
 
   build_and_push_image:
     - command: subprocess.exec
@@ -172,6 +184,18 @@ tasks:
         vars:
           image: quay.io/mongodb/community-operator-e2e:${version_id}
           image_type: e2e
+          expire_after: 48h
+
+  - name: build_agent_image
+    priority: 60
+    exec_timeout_secs: 600
+    commands:
+      - func: clone
+      - func: setup_virtualenv
+      - func: build_and_push_image
+        vars:
+          image: quay.io/mongodb/mongodb-agent-dev:${version_id}
+          image_type: agent
           expire_after: 48h
 
   - name: build_prehook_image
@@ -322,6 +346,8 @@ buildvariants:
         variant: init_test_run
       - name: build_prehook_image
         variant: init_test_run
+      - name: build_agent_image
+        variant: init_test_run
     tasks:
       - name: e2e_test_group
 
@@ -333,6 +359,7 @@ buildvariants:
       - name: build_operator_image
       - name: build_e2e_image
       - name: build_prehook_image
+      - name: build_agent_image
 
   - name: release_blocker
     display_name: release_blocker
@@ -349,6 +376,8 @@ buildvariants:
       - name: build_operator_image
         variant: init_test_run
       - name: build_prehook_image
+        variant: init_test_run
+      - name: build_agent_image
         variant: init_test_run
     run_on:
       - ubuntu1604-test

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -19,10 +19,8 @@ RUN mkdir -p agent \
     && chmod -R +r /var/lib/automation/config \
     && rm agent/mongodb-agent.tar.gz \
     && rm -r mongodb-mms-automation-agent-*
-RUN mkdir -p /var/lib/mongodb-mms-automation/probes/ \
-    && curl --retry 3 https://readinessprobe.s3-us-west-1.amazonaws.com/readiness -o /var/lib/mongodb-mms-automation/probes/readinessprobe \
-    && chmod +x /var/lib/mongodb-mms-automation/probes/readinessprobe \
-    && mkdir -p /var/log/mongodb-mms-automation/ \
+
+RUN mkdir -p /var/log/mongodb-mms-automation/ \
     && chmod -R +wr /var/log/mongodb-mms-automation/ \
     # ensure that the agent user can write the logs in OpenShift
     && touch /var/log/mongodb-mms-automation/readiness.log \

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -19,8 +19,8 @@ RUN mkdir -p agent \
     && chmod -R +r /var/lib/automation/config \
     && rm agent/mongodb-agent.tar.gz \
     && rm -r mongodb-mms-automation-agent-*
-
-RUN mkdir -p /var/log/mongodb-mms-automation/ \
+RUN mkdir -p /var/lib/mongodb-mms-automation \
+    && mkdir -p /var/log/mongodb-mms-automation/ \
     && chmod -R +wr /var/log/mongodb-mms-automation/ \
     # ensure that the agent user can write the logs in OpenShift
     && touch /var/log/mongodb-mms-automation/readiness.log \

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -52,7 +52,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !hasRequiredVariables(log, "AGENT_IMAGE") {
+	if !hasRequiredVariables(log, "AGENT_IMAGE", "VERSION_UPGRADE_HOOK_IMAGE", "READINESS_PROBE_IMAGE") {
 		os.Exit(1)
 	}
 

--- a/scripts/ci/build_and_push_agent_image.sh
+++ b/scripts/ci/build_and_push_agent_image.sh
@@ -7,5 +7,5 @@ echo "${quay_password:?}" | docker login "-u=${quay_user_name:?}" quay.io --pass
 
 
 # Providing the quay.expires-after configures quay to delete this image after the provided amount of time
-docker build . --label "quay.expires-after=${expire_after:-never}" -f agent/Dockerfile -t "${image:?}"
+docker build . --label "quay.expires-after=${expire_after:-never}" -f agent/Dockerfile -t "${image:?}" --build-arg tools_version="100.2.0" --build-arg agent_version="10.27.0.6772-1"
 docker push "${image:?}"

--- a/scripts/ci/build_and_push_agent_image.sh
+++ b/scripts/ci/build_and_push_agent_image.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+
+# shellcheck disable=SC1091
+. venv/bin/activate
+echo "${quay_password:?}" | docker login "-u=${quay_user_name:?}" quay.io --password-stdin
+
+
+# Providing the quay.expires-after configures quay to delete this image after the provided amount of time
+docker build . --label "quay.expires-after=${expire_after:-never}" -f agent/Dockerfile -t "${image:?}"
+docker push "${image:?}"

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -4,5 +4,6 @@
     "operator_image": "community-operator-dev",
     "e2e_image": "community-operator-e2e",
     "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook",
-    "testrunner_image": "community-operator-testrunner"
+    "testrunner_image": "community-operator-testrunner",
+    "agent_image": "mongodb-agent-dev"
 }

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -39,8 +39,8 @@ class DevConfig:
         return self._config["version_upgrade_hook_image"]
 
     @property
-    def testrunner_image(self) -> str:
-        return self._config["testrunner_image"]
+    def agent_image(self) -> str:
+        return self._config["agent_image"]
 
 
 def load_config(config_file_path: str = None) -> DevConfig:

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -147,6 +147,10 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                             "value": f"{dev_config.repo_url}/{dev_config.operator_image}:{args.tag}",
                         },
                         {
+                            "name": "AGENT_IMAGE",
+                            "value": f"{dev_config.repo_url}/{dev_config.agent_image}:{args.tag}",
+                        },
+                        {
                             "name": "TEST_NAMESPACE",
                             "value": dev_config.namespace,
                         },

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -145,6 +145,7 @@ func deployOperator() error {
 		withOperatorImage(testConfig.operatorImage),
 		withVersionUpgradeHookImage(testConfig.versionUpgradeHookImage),
 		withEnvVar("WATCH_NAMESPACE", watchNamespace),
+		withEnvVar("AGENT_IMAGE", testConfig.agentImage),
 	); err != nil {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}

--- a/test/e2e/setup/test_config.go
+++ b/test/e2e/setup/test_config.go
@@ -7,6 +7,7 @@ import (
 const (
 	testNamespaceEnvName      = "TEST_NAMESPACE"
 	operatorImageEnvName      = "OPERATOR_IMAGE"
+	agentImage                = "AGENT_IMAGE"
 	clusterWideEnvName        = "CLUSTER_WIDE"
 	versionUpgradeHookEnvName = "VERSION_UPGRADE_HOOK_IMAGE"
 	performCleanupEnvName     = "PERFORM_CLEANUP"
@@ -18,6 +19,7 @@ type testConfig struct {
 	versionUpgradeHookImage string
 	clusterWide             bool
 	performCleanup          bool
+	agentImage              string
 }
 
 func loadTestConfigFromEnv() testConfig {
@@ -25,6 +27,7 @@ func loadTestConfigFromEnv() testConfig {
 		namespace:               envvar.GetEnvOrDefault(testNamespaceEnvName, "default"),
 		operatorImage:           envvar.GetEnvOrDefault(operatorImageEnvName, "quay.io/mongodb/community-operator-dev:latest"),
 		versionUpgradeHookImage: envvar.GetEnvOrDefault(versionUpgradeHookEnvName, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
+		agentImage:              envvar.GetEnvOrDefault(agentImage, "quay.io/mongodb/mongodb-agent:10.27.0.6772-1"), // TODO: better way to decide default agent image.
 		clusterWide:             envvar.ReadBool(clusterWideEnvName),
 		performCleanup:          envvar.ReadBool(performCleanupEnvName),
 	}


### PR DESCRIPTION
### All Submissions:

* [n/a] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


This PR updates the agent Dockerfile to remove the old readiness probe which is no longer being used. (it has been replaced by the readiness probe copied from the init container)

In order to test this, I have also updated our ci to build the agent image for each evergreen run. And each of our tests will use the image built. There is a little duplication of our build & push scripts which will be addressed in a future PR.

