### PR TITLE
CLOUDP-83820: Make additionalMongod config nullable

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -79,6 +79,7 @@ type MongoDBCommunitySpec struct {
 	// configuration file: https://docs.mongodb.com/manual/reference/configuration-options/
 	// +kubebuilder:validation:Type=object
 	// +optional
+	// +nullable
 	AdditionalMongodConfig MongodConfiguration `json:"additionalMongodConfig,omitempty"`
 }
 

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -51,6 +51,7 @@ spec:
               description: 'AdditionalMongodConfig is additional configuration that
                 can be passed to each data-bearing mongod at runtime. Uses the same
                 structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+              nullable: true
               type: object
             featureCompatibilityVersion:
               description: FeatureCompatibilityVersion configures the feature compatibility

--- a/config/samples/mongodb.com_v1_mongodbcommunity_specify_pod_resources.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_specify_pod_resources.yaml
@@ -44,7 +44,6 @@ spec:
                 requests:
                   cpu: "0.2"
                   memory: 200M
-  additionalMongodConfig: {}
 # the user credentials will be generated from this secret
 # once the credentials are generated, this secret is no longer required
 ---

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -17,6 +17,16 @@ function go_imports() {
 
 }
 
+function generate_crd(){
+  echo "Generating CRD"
+  make manifests
+  for file in $(git diff --cached --name-only --diff-filter=ACM | grep '\.yaml$')
+  do
+      goimports -w "${file}"
+      git add "$file"
+  done
+}
+
 function mypy_check()
 {
     local exit_status=0
@@ -67,8 +77,7 @@ function black_formatting()
     done
 }
 
-
-
+generate_crd
 go_imports
 black_formatting
 if ! mypy_check; then

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -20,11 +20,7 @@ function go_imports() {
 function generate_crd(){
   echo "Generating CRD"
   make manifests
-  for file in $(git diff --cached --name-only --diff-filter=ACM | grep '\.yaml$')
-  do
-      goimports -w "${file}"
-      git add "$file"
-  done
+  git add config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
 }
 
 function mypy_check()

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -162,9 +162,6 @@ func NewTestMongoDB(name string, namespace string) (mdbv1.MongoDBCommunity, mdbv
 					Modes: []mdbv1.AuthMode{"SCRAM"},
 				},
 			},
-			AdditionalMongodConfig: mdbv1.MongodConfiguration{
-				Object: map[string]interface{}{},
-			},
 			Users: []mdbv1.MongoDBUser{
 				{
 					Name: fmt.Sprintf("%s-user", name),


### PR DESCRIPTION
### All Submissions:

* [n/a] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

closes #312

This PR makes the additional mongod field nullable in order to prevent the presence of the field in all resource specifications.