### PR TITLE
Added MANAGED_SECURITY_CONTEXT check and refactored env vars

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,7 +6,7 @@ import (
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/controllers"
-	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
+	"github.com/mongodb/mongodb-kubernetes-operator/controllers/construct"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -20,6 +20,10 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+)
+
+const (
+	WatchNamespaceEnv = "WATCH_NAMESPACE"
 )
 
 func init() {
@@ -53,12 +57,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !hasRequiredVariables(log, envvar.AgentImageEnv, envvar.VersionUpgradeHookImageEnv, envvar.ReadinessProbeImageEnv) {
+	if !hasRequiredVariables(log, construct.AgentImageEnv, construct.VersionUpgradeHookImageEnv, construct.ReadinessProbeImageEnv) {
 		os.Exit(1)
 	}
 
 	// Get watch namespace from environment variable.
-	namespace, nsSpecified := os.LookupEnv(envvar.WatchNamespaceEnv)
+	namespace, nsSpecified := os.LookupEnv(WatchNamespaceEnv)
 	if !nsSpecified {
 		os.Exit(1)
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,6 +6,7 @@ import (
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/controllers"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -52,12 +53,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !hasRequiredVariables(log, "AGENT_IMAGE", "VERSION_UPGRADE_HOOK_IMAGE", "READINESS_PROBE_IMAGE") {
+	if !hasRequiredVariables(log, envvar.AgentImageEnv, envvar.VersionUpgradeHookImageEnv, envvar.ReadinessProbeImageEnv) {
 		os.Exit(1)
 	}
 
 	// Get watch namespace from environment variable.
-	namespace, nsSpecified := os.LookupEnv("WATCH_NAMESPACE")
+	namespace, nsSpecified := os.LookupEnv(envvar.WatchNamespaceEnv)
 	if !nsSpecified {
 		os.Exit(1)
 	}

--- a/config/samples/mongodb.com_v1_mongodbcommunity_openshift_cr.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_openshift_cr.yaml
@@ -25,17 +25,6 @@ spec:
     spec:
       serviceName: example-openshift-mongodb-svc
       selector: {}
-      template:
-        spec:
-          containers:
-            - name: "mongodb-agent"
-              env:
-                - name: MANAGED_SECURITY_CONTEXT
-                  value: "true"
-            - name: "mongod"
-              env:
-                - name: MANAGED_SECURITY_CONTEXT
-                  value: "true"
 
 # the user credentials will be generated from this secret
 # once the credentials are generated, this secret is no longer required

--- a/controllers/construct/build_statefulset_test.go
+++ b/controllers/construct/build_statefulset_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	os.Setenv(versionUpgradeHookImageEnv, "version-upgrade-hook-image")
+	os.Setenv(VersionUpgradeHookImageEnv, "version-upgrade-hook-image")
 }
 
 func newTestReplicaSet() mdbv1.MongoDBCommunity {

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/authentication/scram"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/annotations"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/secret"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/controllers/construct"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/probes"
@@ -40,7 +41,7 @@ import (
 )
 
 func init() {
-	os.Setenv("AGENT_IMAGE", "agent-image")
+	os.Setenv(envvar.AgentImageEnv, "agent-image")
 }
 
 func newTestReplicaSet() mdbv1.MongoDBCommunity {
@@ -559,12 +560,6 @@ func TestReplicaSet_IsScaledUpToDesiredMembers_WhenFirstCreated(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 3, mdb.Status.CurrentMongoDBMembers)
-}
-
-func TestOpenshift_Configuration(t *testing.T) {
-	sts := performReconciliationAndGetStatefulSet(t, "openshift_mdb.yaml")
-	assert.Equal(t, "MANAGED_SECURITY_CONTEXT", sts.Spec.Template.Spec.Containers[1].Env[3].Name)
-	assert.Equal(t, "MANAGED_SECURITY_CONTEXT", sts.Spec.Template.Spec.Containers[0].Env[1].Name)
 }
 
 func TestVolumeClaimTemplates_Configuration(t *testing.T) {

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/authentication/scram"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/annotations"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/secret"
-	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/controllers/construct"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/probes"
@@ -41,7 +40,7 @@ import (
 )
 
 func init() {
-	os.Setenv(envvar.AgentImageEnv, "agent-image")
+	os.Setenv(construct.AgentImageEnv, "agent-image")
 }
 
 func newTestReplicaSet() mdbv1.MongoDBCommunity {

--- a/controllers/testdata/openshift_mdb.yaml
+++ b/controllers/testdata/openshift_mdb.yaml
@@ -19,16 +19,3 @@ spec:
           db: admin
         - name: userAdminAnyDatabase
           db: admin
-  statefulSet:
-    spec:
-      template:
-        spec:
-          containers:
-            - name: "mongodb-agent"
-              env:
-                - name: MANAGED_SECURITY_CONTEXT
-                  value: "true"
-            - name: "mongod"
-              env:
-                - name: MANAGED_SECURITY_CONTEXT
-                  value: "true"

--- a/docs/deploy-configure.md
+++ b/docs/deploy-configure.md
@@ -128,7 +128,7 @@ To upgrade this resource from `4.0.6` to `4.2.7`:
 
 ## Deploy Replica Sets on OpenShift
 
-To deploy the operator on OpenShift you will have to provide the environment variable `MANAGED_SECURITY_CONTEXT` set to `true` for both the `mongodb` and `mongodb-agent` containers, as well as the operator deployment.
+To deploy the operator on OpenShift you will have to provide the environment variable `MANAGED_SECURITY_CONTEXT` set to `true` for the operator deployment.
 
 See [here](/config/samples/mongodb.com_v1_mongodbcommunity_openshift_cr.yaml) for
 an example of how to provide the required configuration for a MongoDB

--- a/pkg/util/envvar/envvars.go
+++ b/pkg/util/envvar/envvars.go
@@ -8,6 +8,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	AgentImageEnv              = "AGENT_IMAGE"
+	MongodbImageEnv            = "MONGODB_IMAGE"
+	WatchNamespaceEnv          = "WATCH_NAMESPACE"
+	VersionUpgradeHookImageEnv = "VERSION_UPGRADE_HOOK_IMAGE"
+	ReadinessProbeImageEnv     = "READINESS_PROBE_IMAGE"
+	ManagedSecurityContextEnv  = "MANAGED_SECURITY_CONTEXT"
+)
+
 func MergeWithOverride(existing, desired []corev1.EnvVar) []corev1.EnvVar {
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range existing {

--- a/pkg/util/envvar/envvars.go
+++ b/pkg/util/envvar/envvars.go
@@ -8,15 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	AgentImageEnv              = "AGENT_IMAGE"
-	MongodbImageEnv            = "MONGODB_IMAGE"
-	WatchNamespaceEnv          = "WATCH_NAMESPACE"
-	VersionUpgradeHookImageEnv = "VERSION_UPGRADE_HOOK_IMAGE"
-	ReadinessProbeImageEnv     = "READINESS_PROBE_IMAGE"
-	ManagedSecurityContextEnv  = "MANAGED_SECURITY_CONTEXT"
-)
-
 func MergeWithOverride(existing, desired []corev1.EnvVar) []corev1.EnvVar {
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range existing {

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/generate"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -144,8 +145,8 @@ func deployOperator() error {
 		withNamespace(testConfig.namespace),
 		withOperatorImage(testConfig.operatorImage),
 		withVersionUpgradeHookImage(testConfig.versionUpgradeHookImage),
-		withEnvVar("WATCH_NAMESPACE", watchNamespace),
-		withEnvVar("AGENT_IMAGE", testConfig.agentImage),
+		withEnvVar(envvar.WatchNamespaceEnv, watchNamespace),
+		withEnvVar(envvar.AgentImageEnv, testConfig.agentImage),
 	); err != nil {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}
@@ -240,7 +241,7 @@ func withVersionUpgradeHookImage(image string) func(runtime.Object) {
 	return func(obj runtime.Object) {
 		if dep, ok := obj.(*appsv1.Deployment); ok {
 			versionUpgradeHookEnv := corev1.EnvVar{
-				Name:  "VERSION_UPGRADE_HOOK_IMAGE",
+				Name:  envvar.VersionUpgradeHookImageEnv,
 				Value: image,
 			}
 			found := false

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
+	"github.com/mongodb/mongodb-kubernetes-operator/controllers/construct"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/generate"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -145,8 +145,8 @@ func deployOperator() error {
 		withNamespace(testConfig.namespace),
 		withOperatorImage(testConfig.operatorImage),
 		withVersionUpgradeHookImage(testConfig.versionUpgradeHookImage),
-		withEnvVar(envvar.WatchNamespaceEnv, watchNamespace),
-		withEnvVar(envvar.AgentImageEnv, testConfig.agentImage),
+		withEnvVar("WATCH_NAMESPACE", watchNamespace),
+		withEnvVar(construct.AgentImageEnv, testConfig.agentImage),
 	); err != nil {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}
@@ -241,7 +241,7 @@ func withVersionUpgradeHookImage(image string) func(runtime.Object) {
 	return func(obj runtime.Object) {
 		if dep, ok := obj.(*appsv1.Deployment); ok {
 			versionUpgradeHookEnv := corev1.EnvVar{
-				Name:  envvar.VersionUpgradeHookImageEnv,
+				Name:  construct.VersionUpgradeHookImageEnv,
 				Value: image,
 			}
 			found := false

--- a/test/e2e/setup/test_config.go
+++ b/test/e2e/setup/test_config.go
@@ -5,12 +5,10 @@ import (
 )
 
 const (
-	testNamespaceEnvName      = "TEST_NAMESPACE"
-	operatorImageEnvName      = "OPERATOR_IMAGE"
-	agentImage                = "AGENT_IMAGE"
-	clusterWideEnvName        = "CLUSTER_WIDE"
-	versionUpgradeHookEnvName = "VERSION_UPGRADE_HOOK_IMAGE"
-	performCleanupEnvName     = "PERFORM_CLEANUP"
+	testNamespaceEnvName  = "TEST_NAMESPACE"
+	operatorImageEnvName  = "OPERATOR_IMAGE"
+	clusterWideEnvName    = "CLUSTER_WIDE"
+	performCleanupEnvName = "PERFORM_CLEANUP"
 )
 
 type testConfig struct {
@@ -26,8 +24,8 @@ func loadTestConfigFromEnv() testConfig {
 	return testConfig{
 		namespace:               envvar.GetEnvOrDefault(testNamespaceEnvName, "default"),
 		operatorImage:           envvar.GetEnvOrDefault(operatorImageEnvName, "quay.io/mongodb/community-operator-dev:latest"),
-		versionUpgradeHookImage: envvar.GetEnvOrDefault(versionUpgradeHookEnvName, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
-		agentImage:              envvar.GetEnvOrDefault(agentImage, "quay.io/mongodb/mongodb-agent:10.27.0.6772-1"), // TODO: better way to decide default agent image.
+		versionUpgradeHookImage: envvar.GetEnvOrDefault(envvar.VersionUpgradeHookImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
+		agentImage:              envvar.GetEnvOrDefault(envvar.AgentImageEnv, "quay.io/mongodb/mongodb-agent:10.27.0.6772-1"), // TODO: better way to decide default agent image.
 		clusterWide:             envvar.ReadBool(clusterWideEnvName),
 		performCleanup:          envvar.ReadBool(performCleanupEnvName),
 	}

--- a/test/e2e/setup/test_config.go
+++ b/test/e2e/setup/test_config.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"github.com/mongodb/mongodb-kubernetes-operator/controllers/construct"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 )
 
@@ -24,8 +25,8 @@ func loadTestConfigFromEnv() testConfig {
 	return testConfig{
 		namespace:               envvar.GetEnvOrDefault(testNamespaceEnvName, "default"),
 		operatorImage:           envvar.GetEnvOrDefault(operatorImageEnvName, "quay.io/mongodb/community-operator-dev:latest"),
-		versionUpgradeHookImage: envvar.GetEnvOrDefault(envvar.VersionUpgradeHookImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
-		agentImage:              envvar.GetEnvOrDefault(envvar.AgentImageEnv, "quay.io/mongodb/mongodb-agent:10.27.0.6772-1"), // TODO: better way to decide default agent image.
+		versionUpgradeHookImage: envvar.GetEnvOrDefault(construct.VersionUpgradeHookImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
+		agentImage:              envvar.GetEnvOrDefault(construct.AgentImageEnv, "quay.io/mongodb/mongodb-agent:10.27.0.6772-1"), // TODO: better way to decide default agent image.
 		clusterWide:             envvar.ReadBool(clusterWideEnvName),
 		performCleanup:          envvar.ReadBool(performCleanupEnvName),
 	}


### PR DESCRIPTION
We weren't correctly using the `MANAGED_SECURITY_CONTEXT` env var, which is needed only in the operator and not in MongoDB pods. 

This PR uses this env var when building the Statefulset, and it adds security context to the pods only when it is not set.

It also refactors usage of env vars, to avoid duplication

### All Submissions:

* [n/a] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
