### PR TITLE
CLOUD-84084 Added - mongodbcommunity/finalizers to role. Fixes the StatefulSet creation on OpenShift 4.5

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,7 @@ rules:
   - mongodbcommunity
   - mongodbcommunity/status
   - mongodbcommunity/spec
+  - mongodbcommunity/finalizers
   verbs:
   - create
   - delete

--- a/deploy/e2e/role.yaml
+++ b/deploy/e2e/role.yaml
@@ -74,6 +74,7 @@ rules:
   - mongodbcommunity
   - mongodbcommunity/status
   - mongodbcommunity/spec
+  - mongodbcommunity/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
Added - mongodbcommunity/finalizers to the mongodbcommunity.mongodb.com ApiGroup in role.yaml. 
Fixes the StatefulSet creation on OpenShift 4.5. closes #367

### All Submissions:

* [X] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
