### PR TITLE
Extract agent command common to monitoring and automation

### DIFF
--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -51,12 +51,10 @@ const (
 	automationAgentOptions = " -skipMongoStart -noDaemonize -useLocalMongoDbTools"
 
 	MongodbUserCommand = `current_uid=$(id -u)
-echo $current_uid
 declare -r current_uid
 if ! grep -q "${current_uid}" /etc/passwd ; then
 sed -e "s/^mongodb:/builder:/" /etc/passwd > /tmp/passwd
 echo "mongodb:x:$(id -u):$(id -g):,,,:/:/bin/bash" >> /tmp/passwd
-cat /tmp/passwd
 export NSS_WRAPPER_PASSWD=/tmp/passwd
 export LD_PRELOAD=libnss_wrapper.so
 export NSS_WRAPPER_GROUP=/etc/group

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -49,7 +49,7 @@ const (
 
 	automationAgentOptions = " -skipMongoStart -noDaemonize -useLocalMongoDbTools"
 
-	mongodbUserCommand = `current_uid=$(id -u)
+	MongodbUserCommand = `current_uid=$(id -u)
 echo $current_uid
 declare -r current_uid
 if ! grep -q "${current_uid}" /etc/passwd ; then
@@ -181,7 +181,7 @@ func mongodbAgentContainer(automationConfigSecretName string, volumeMounts []cor
 		container.WithResourceRequirements(resourcerequirements.Defaults()),
 		container.WithVolumeMounts(volumeMounts),
 		container.WithSecurityContext(container.DefaultSecurityContext()),
-		container.WithCommand([]string{"/bin/bash", "-c", mongodbUserCommand + BaseAgentCommand() + automationAgentOptions}),
+		container.WithCommand([]string{"/bin/bash", "-c", MongodbUserCommand + BaseAgentCommand() + automationAgentOptions}),
 		container.WithEnvs(
 			corev1.EnvVar{
 				Name:  headlessAgentEnv,


### PR DESCRIPTION
This PR separates the part of the agent command that is common between monitoring and automation to the one that only goes to automation. This way we can reuse the constants in enterprise to configure monitoring.

### All Submissions:

* [n/a] Have you opened an Issue before filing this PR?
* [n/a] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [n/a] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
