### PR TITLE
Adds replicationStatusUndefined.

### DIFF
--- a/pkg/readiness/health/health.go
+++ b/pkg/readiness/health/health.go
@@ -8,8 +8,17 @@ import (
 type replicationStatus int
 
 const (
-	replicationStatusPrimary   replicationStatus = 1
-	replicationStatusSecondary replicationStatus = 2
+	replicationStatusStartup    replicationStatus = 0
+	replicationStatusPrimary    replicationStatus = 1
+	replicationStatusSecondary  replicationStatus = 2
+	replicationStatusRecovering replicationStatus = 3
+	replicationStatusStartup2   replicationStatus = 5
+	replicationStatusUnknown    replicationStatus = 6
+	replicationStatusArbiter    replicationStatus = 7
+	replicationStatusDown       replicationStatus = 8
+	replicationStatusRollback   replicationStatus = 9
+	replicationStatusRemoved    replicationStatus = 10
+	replicationStatusUndefined  replicationStatus = -1
 )
 
 type Status struct {
@@ -55,7 +64,12 @@ type StepStatus struct {
 // isReadyState will return true, meaning a *ready state* in the sense that this Process can
 // accept read operations. There are no other states in which the MongoDB server could that
 // would mean a Ready State.
+// It returns true if the managed process is mongos or standalone (replicationStatusUndefined).
 func (h processHealth) IsReadyState() bool {
-	return *h.ReplicaStatus == replicationStatusPrimary ||
-		*h.ReplicaStatus == replicationStatusSecondary
+	status := *h.ReplicaStatus
+	if status == replicationStatusUndefined {
+		return true
+	}
+
+	return status == replicationStatusPrimary || status == replicationStatusSecondary
 }

--- a/pkg/readiness/health/health_test.go
+++ b/pkg/readiness/health/health_test.go
@@ -1,0 +1,32 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsReadyState checks that Primary, Secondary and Undefined always result
+// in Ready State.
+func TestIsReadyStateNotPrimaryNorSecondary(t *testing.T) {
+	status := []replicationStatus{replicationStatusUndefined, replicationStatusPrimary, replicationStatusSecondary}
+
+	for _, st := range status {
+		h := processHealth{ReplicaStatus: &st}
+		assert.True(t, h.IsReadyState())
+	}
+}
+
+// TestIsNotReady any of these states will result on a Database not being ready.
+func TestIsNotReady(t *testing.T) {
+	status := []replicationStatus{
+		replicationStatusStartup, replicationStatusRecovering, replicationStatusStartup2,
+		replicationStatusUnknown, replicationStatusArbiter, replicationStatusDown,
+		replicationStatusRollback, replicationStatusRemoved,
+	}
+
+	for _, st := range status {
+		h := processHealth{ReplicaStatus: &st}
+		assert.False(t, h.IsReadyState())
+	}
+}


### PR DESCRIPTION
Checks for `replicationStatusUndefined` for standalones and sharded clusters.

I also added tests for all of the possible states, to make it clear as to what is checked by the readiness probe.

Please note that `readiness-probe:1.0.2` was built with these changes, but I forgot to add them to the previous PR.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
