### PR TITLE
Fix incorrect arg parse field

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import sys
-from typing import Dict, Optional, Union, Callable, Text
+from typing import Dict, Optional
 
 from sonar.sonar import process_image
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import sys
-from typing import Dict, Optional
+from typing import Dict, Optional, Union, Callable, Text
 
 from sonar.sonar import process_image
 
@@ -113,7 +113,7 @@ def sonar_build_image(
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--image-name", type=str)
-    parser.add_argument("--release", type=bool)
+    parser.add_argument("--release", type=lambda x: x.lower() == "true")
     return parser.parse_args()
 
 


### PR DESCRIPTION
### All Submissions:

The release flag was being triggered with every task. A value of true was returned if the field was specified at all, it does not account for the value of the bool.

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

