### PR TITLE
CLOUDP-85272: remove persistence method from interface

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -502,10 +502,6 @@ func (m MongoDBCommunity) GetMongoDBVersionForAnnotation() string {
 	return m.GetMongoDBVersion()
 }
 
-func (m MongoDBCommunity) Persistent() bool {
-	return true
-}
-
 func (m *MongoDBCommunity) StatefulSetReplicasThisReconciliation() int {
 	return scale.ReplicasThisReconciliation(m)
 }


### PR DESCRIPTION
This method was added to support the AppDB project. 
However, there is no need (and it's actually harmful) to allow customers to specify persistence=false in the AppDB, and we never supported that here in Community.

This PR completely removes the method from the interface and an analogous PR on Enterprise will remove it from the AppDB

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
