### PR TITLE
Fix warning message in Stale action 

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -22,3 +22,4 @@ jobs:
           days-before-pr-close: -1 # never close PRs
 
           exempt-issue-labels: 'bug,feature-request'
+          ascending: true


### PR DESCRIPTION
The stale action was exiting prematurely with the message:

`Warning: Reached max number of operations to process. Exiting.`

(see https://github.com/mongodb/mongodb-kubernetes-operator/runs/2434307103?check_suite_focus=true)

This is reported here: https://github.com/actions/stale/issues/95

and fixed here: https://github.com/actions/stale/pull/97

This way we will start with older issues first and then move to newer ones. We will still exit prematurely but missing only new issues.

We could increase `operations-per-run`(https://github.com/marketplace/actions/close-stale-issues#operations-per-run) but I wanted to try with a safer approach

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
