### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
 # Image URL to use all building/pushing image targets
-REPO_URL := $(shell cat ~/.community-operator-dev/config.json | jq -r .repo_url)
-OPERATOR_IMAGE := $(shell cat ~/.community-operator-dev/config.json | jq -r .operator_image)
+REPO_URL := $(shell jq -r .repo_url < ~/.community-operator-dev/config.json)
+OPERATOR_IMAGE := $(shell jq -r .operator_image < ~/.community-operator-dev/config.json)
 IMG := $(REPO_URL)/$(OPERATOR_IMAGE)
 DOCKERFILE ?= operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= <operator-registry>/mongodb-kubernetes-operator
+REPO_URL := $(shell cat ~/.community-operator-dev/config.json | jq -r .repo_url)
+OPERATOR_IMAGE := $(shell cat ~/.community-operator-dev/config.json | jq -r .operator_image)
+IMG := $(REPO_URL)/$(OPERATOR_IMAGE)
 DOCKERFILE ?= operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=true,crdVersions=v1beta1"
@@ -71,7 +73,7 @@ uninstall: manifests kustomize
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image quay.io/mongodb/mongodb-kubernetes-operator=$(IMG):latest
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config


### PR DESCRIPTION
This PR fixes the issues with the Makefile.

The following commands now substitute in the value located in your local dev config.

`make docker-build`, `make docker-push` and `make deploy`