### PR TITLE
Make docker file S3 bucket configurable

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -1,7 +1,5 @@
 vars:
   registry: <registry>
-  s3_bucket_http: https://enterprise-operator-dockerfiles.s3.amazonaws.com/dockerfiles/mongodb-agent
-  s3_bucket: s3://enterprise-operator-dockerfiles/dockerfiles/mongodb-agent
 
 images:
   - name: agent-ubuntu
@@ -62,9 +60,10 @@ images:
 
         inputs:
           - release_version
+          - s3_bucket
 
         output:
-          - dockerfile: $(inputs.params.s3_bucket)/Dockerfile.ubuntu-$(inputs.params.release_version)
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-agent/Dockerfile.ubuntu-$(inputs.params.release_version)
 
       - name: agent-context-ubuntu-release
         task_type: tag_image
@@ -150,7 +149,7 @@ images:
           - release_version
 
         output:
-          - dockerfile: $(inputs.params.s3_bucket)/Dockerfile.ubi-$(inputs.params.release_version)
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-agent/Dockerfile.ubi-$(inputs.params.release_version)
 
       - name: agent-context-ubi-release
         task_type: tag_image

--- a/pipeline.py
+++ b/pipeline.py
@@ -33,6 +33,7 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
         "release_version": release["agent"]["version"],
         "tools_version": release["agent"]["tools_version"],
         "registry": config.repo_url,
+        "s3_bucket": "{}/{}".format(config.s3_bucket, "mongodb-agent"),
     }
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -33,7 +33,7 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
         "release_version": release["agent"]["version"],
         "tools_version": release["agent"]["tools_version"],
         "registry": config.repo_url,
-        "s3_bucket": "{}/{}".format(config.s3_bucket, "mongodb-agent"),
+        "s3_bucket": config.s3_bucket,
     }
 
 

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -1,10 +1,11 @@
 {
-    "namespace": "default",
-    "repo_url": "quay.io/mongodb",
-    "operator_image": "community-operator-dev",
-    "e2e_image": "community-operator-e2e",
-    "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook",
-    "testrunner_image": "community-operator-testrunner",
-    "agent_image_ubuntu": "mongodb-agent-dev",
-    "agent_image_ubi": "mongodb-agent-ubi-dev"
+  "namespace": "default",
+  "repo_url": "quay.io/mongodb",
+  "operator_image": "community-operator-dev",
+  "e2e_image": "community-operator-e2e",
+  "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook",
+  "testrunner_image": "community-operator-testrunner",
+  "agent_image_ubuntu": "mongodb-agent-dev",
+  "agent_image_ubi": "mongodb-agent-ubi-dev",
+  "s3_bucket": "s3://enterprise-operator-dockerfiles/dockerfiles"
 }

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -51,6 +51,10 @@ class DevConfig:
         return self._config["repo_url"]
 
     @property
+    def s3_bucket(self) -> str:
+        return self._config["s3_bucket"]
+
+    @property
     def expire_after(self) -> str:
         return self._config.get("expire_after", "never")
 


### PR DESCRIPTION
This PR makes the S3 bucket configurable. This allows the s3 dockerfile publishing to be run against dev s3 buckets. The evergreen config file points at the one we release to as part of the release task.