### PR TITLE
Add WithContainerFrom

### DIFF
--- a/pkg/kube/podtemplatespec/podspec_template.go
+++ b/pkg/kube/podtemplatespec/podspec_template.go
@@ -48,8 +48,9 @@ func WithContainer(name string, containerfunc func(*corev1.Container)) Modificat
 	}
 }
 
-// WithContainerFrom copies the container with name `name` and applies the modifications to it
-// if no container with that name exists, it returns NOOP
+// WithContainerFrom copies the container with name `name` into a new one named `newContainerName`
+// and applies the modifications to it, then adds it to the containers.
+// If no container with that name exists, it returns NOOP
 func WithContainerFrom(name string, newContainerName string, funcs ...func(container *corev1.Container)) Modification {
 	return func(podTemplateSpec *corev1.PodTemplateSpec) {
 		from := FindContainerByName(name, podTemplateSpec)

--- a/pkg/kube/podtemplatespec/podspec_template_test.go
+++ b/pkg/kube/podtemplatespec/podspec_template_test.go
@@ -356,7 +356,7 @@ func TestWithContainerFrom(t *testing.T) {
 	// Test that first container remains as it was
 	assert.Equal(t, defaultPodSpec.Spec.Containers[0], getDefaultContainer(), "First container should have not been changed")
 
-	// Test the new contaienr to be identical to the first one except the image and the name
+	// Test the new container to be identical to the first one except the image and the name
 	oldContainer := defaultPodSpec.Spec.Containers[0]
 	newContainer := defaultPodSpec.Spec.Containers[1]
 	assert.Equal(t, "container-1", newContainer.Name)

--- a/pkg/kube/podtemplatespec/podspec_template_test.go
+++ b/pkg/kube/podtemplatespec/podspec_template_test.go
@@ -341,6 +341,30 @@ func TestMergeVolumes_DoesNotAddDuplicatesWithSameName(t *testing.T) {
 	assert.Equal(t, "new-volume-3", mergedPodSpecTemplate.Spec.Volumes[2].Name)
 }
 
+func TestWithContainerFrom(t *testing.T) {
+	defaultPodSpec := getDefaultPodSpec()
+
+	Apply(
+		WithContainerFrom("container-0",
+			"container-1",
+			container.WithImage("image-1"),
+		),
+	)(&defaultPodSpec)
+
+	assert.Len(t, defaultPodSpec.Spec.Containers, 2, "Should have added a new container")
+
+	// Test that first container remains as it was
+	assert.Equal(t, defaultPodSpec.Spec.Containers[0], getDefaultContainer(), "First container should have not been changed")
+
+	// Test the new contaienr to be identical to the first one except the image and the name
+	oldContainer := defaultPodSpec.Spec.Containers[0]
+	newContainer := defaultPodSpec.Spec.Containers[1]
+	assert.Equal(t, "container-1", newContainer.Name)
+	assert.Equal(t, "image-1", newContainer.Image)
+	assert.Equal(t, oldContainer.ReadinessProbe, newContainer.ReadinessProbe)
+	assert.Equal(t, oldContainer.VolumeMounts, newContainer.VolumeMounts)
+}
+
 func int64Ref(i int64) *int64 {
 	return &i
 }


### PR DESCRIPTION
This PR adds a new function to the podtemplatespec package to add a container by starting from an existing one and modifying it.
This allows us to add new containers without having to redefine each of their element.

This is particularly useful for the AppDB project, where we add the monitoring container as a copy, with modifications, of the automation one.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
