### PR TITLE
add dummy config if not present

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -534,6 +534,10 @@ func (m MongoDBCommunity) GetAnnotations() map[string]string {
 	return m.Annotations
 }
 
+func (m MongoDBCommunity) DataVolumeName() string {
+	return "data-volume"
+}
+
 type automationConfigReplicasScaler struct {
 	current, desired int
 }

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -112,6 +112,13 @@ func (b *Builder) SetCAFilePath(caFilePath string) *Builder {
 	return b
 }
 
+func (b *Builder) AddVersions(versions []MongoDbVersionConfig) *Builder {
+	for _, v := range versions {
+		b.AddVersion(v)
+	}
+	return b
+}
+
 func (b *Builder) AddVersion(version MongoDbVersionConfig) *Builder {
 	for idx := range version.Builds {
 		if version.Builds[idx].Modules == nil {

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -3,6 +3,7 @@ package automationconfig
 import (
 	"fmt"
 	"path"
+	"reflect"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -238,8 +239,9 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		b.auth = &disabled
 	}
 
-	if len(b.versions) == 0 {
-		b.versions = append(b.versions, buildDummyMongoDbVersionConfig(b.mongodbVersion))
+	dummyConfig := buildDummyMongoDbVersionConfig(b.mongodbVersion)
+	if !versionsContain(b.versions, dummyConfig) {
+		b.versions = append(b.versions, dummyConfig)
 	}
 
 	currentAc := AutomationConfig{
@@ -295,6 +297,15 @@ func (b *Builder) Build() (AutomationConfig, error) {
 
 func toProcessName(name string, index int) string {
 	return fmt.Sprintf("%s-%d", name, index)
+}
+
+func versionsContain(versions []MongoDbVersionConfig, version MongoDbVersionConfig) bool {
+	for _, v := range versions {
+		if reflect.DeepEqual(v, version) {
+			return true
+		}
+	}
+	return false
 }
 
 // buildDummyMongoDbVersionConfig create a MongoDbVersionConfig which


### PR DESCRIPTION
This PR refactors the construction of the Automation Config for the AppDB upgrade.

It also extracts the data volume name to an interface method because we want to maintain backward compatibility and in enterprise it's called `data` while here is `data-volume`

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
