### PR TITLE
CLOUDP-89359: Ensure Mongod logs are sent to stdout upon restart

### DIFF
--- a/controllers/construct/build_statefulset_test.go
+++ b/controllers/construct/build_statefulset_test.go
@@ -5,6 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/container"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/resourcerequirements"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/probes"
@@ -54,6 +57,24 @@ func TestMultipleCalls_DoNotCauseSideEffects(t *testing.T) {
 	t.Run("3rd Call", func(t *testing.T) {
 		stsFunc(sts)
 		assertStatefulSetIsBuiltCorrectly(t, mdb, sts)
+	})
+}
+
+func TestMongod_Container(t *testing.T) {
+	c := container.New(mongodbContainer("4.2", []corev1.VolumeMount{}))
+
+	t.Run("Has correct Env vars", func(t *testing.T) {
+		assert.Len(t, c.Env, 1)
+		assert.Equal(t, agentHealthStatusFilePathEnv, c.Env[0].Name)
+		assert.Equal(t, "/healthstatus/agent-health-status.json", c.Env[0].Value)
+	})
+
+	t.Run("Image is correct", func(t *testing.T) {
+		assert.Equal(t, getMongoDBImage("4.2"), c.Image)
+	})
+
+	t.Run("Resource requirements are correct", func(t *testing.T) {
+		assert.Equal(t, resourcerequirements.Defaults(), c.Resources)
 	})
 }
 

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -284,9 +284,13 @@ func mongodbContainer(version string, volumeMounts []corev1.VolumeMount) contain
 # wait for config and keyfile to be created by the agent
  while ! [ -f %s -a -f %s ]; do sleep 3 ; done ; sleep 2 ;
 
+# with mongod configured to append logs, we need to provide them to stdout as
+# mongod does not write to stdout and a log file
+tail -F /var/log/mongodb-mms-automation/mongodb.log > /dev/stdout &
 
 # start mongod with this configuration
 exec mongod -f %s;
+
 `, automationconfFilePath, keyfileFilePath, automationconfFilePath)
 
 	containerCommand := []string{

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -67,7 +67,8 @@ func (p *Process) SetReplicaSetName(replSetName string) *Process {
 
 func (p *Process) SetSystemLog(systemLog SystemLog) *Process {
 	return p.SetArgs26Field("systemLog.path", systemLog.Path).
-		SetArgs26Field("systemLog.destination", systemLog.Destination)
+		SetArgs26Field("systemLog.destination", systemLog.Destination).
+		SetArgs26Field("systemLog.logAppend", systemLog.LogAppend)
 }
 
 func (p *Process) SetWiredTigerCache(cacheSizeGb *float32) *Process {
@@ -105,6 +106,7 @@ type ProcessType string
 type SystemLog struct {
 	Destination string `json:"destination"`
 	Path        string `json:"path"`
+	LogAppend   bool   `json:"logAppend"`
 }
 
 type WiredTiger struct {

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -216,6 +216,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		process.SetSystemLog(SystemLog{
 			Destination: "file",
 			Path:        path.Join(DefaultAgentLogPath, "/mongodb.log"),
+			LogAppend:   true,
 		})
 
 		if b.fcv != "" {


### PR DESCRIPTION
### All Submissions:

This PR ensures that the logs of the Mongod are displayed upon restart, previously they were being written to a log file and not displayed when the container was restarted.