### PR TITLE
Fix pod annotations overwrite

### DIFF
--- a/cmd/readiness/testdata/k8sobjects.go
+++ b/cmd/readiness/testdata/k8sobjects.go
@@ -7,6 +7,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Currently seems like the appending functionality on the library used by the fake
+// implementation to simulate JSONPatch is broken: https://github.com/evanphx/json-patch/issues/138
+// The short term workaround is to have the annotation empty.
+
 // These are just k8s objects used for testing. Note, that these are defined in a non "_test.go" file as they are reused
 // by other modules
 func TestSecret(namespace, name string, version int) *corev1.Secret {
@@ -21,6 +25,9 @@ func TestPod(namespace, name string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				"agent.mongodb.com/version": "",
+			},
 		},
 	}
 }

--- a/pkg/readiness/pod/podannotation.go
+++ b/pkg/readiness/pod/podannotation.go
@@ -1,26 +1,25 @@
 package pod
 
 import (
-	"strconv"
-
 	"go.uber.org/zap"
+	"strconv"
+	"strings"
+
 	"k8s.io/client-go/kubernetes"
 )
 
-type mongodbAgentVersion struct {
-	Version string `json:"agent.mongodb.com/version"`
-}
+const mongodbAgentVersionAnnotation = "agent.mongodb.com/version"
 
 func PatchPodAnnotation(podNamespace string, lastVersionAchieved int64, memberName string, clientSet kubernetes.Interface) error {
 	patcher := NewKubernetesPodPatcher(clientSet)
-	mdbAgentVersion := mongodbAgentVersion{Version: strconv.FormatInt(lastVersionAchieved, 10)}
+	mdbAgentVersion := strconv.FormatInt(lastVersionAchieved, 10)
 	return patchPod(patcher, podNamespace, mdbAgentVersion, memberName)
 }
 
-func patchPod(patcher Patcher, podNamespace string, mdbAgentVersion mongodbAgentVersion, memberName string) error {
+func patchPod(patcher Patcher, podNamespace string, mdbAgentVersion string, memberName string) error {
 	payload := []patchValue{{
 		Op:    "add",
-		Path:  "/metadata/annotations",
+		Path:  "/metadata/annotations/" + strings.Replace(mongodbAgentVersionAnnotation, "/", "~1", -1),
 		Value: mdbAgentVersion,
 	}}
 

--- a/pkg/readiness/pod/podannotation_test.go
+++ b/pkg/readiness/pod/podannotation_test.go
@@ -11,17 +11,24 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+// Currently seems like the appending functionality on the library used by the fake
+// implementation to simulate JSONPatch is broken: https://github.com/evanphx/json-patch/issues/138
+// The short term workaround is to have the annotation empty.
+
 // TestPatchPodAnnotation verifies that patching of the pod works correctly
 func TestPatchPodAnnotation(t *testing.T) {
 	clientset := fake.NewSimpleClientset(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-replica-set-0",
 			Namespace: "test-ns",
+			Annotations: map[string]string{
+				mongodbAgentVersionAnnotation: "",
+			},
 		},
 	})
 
 	pod, _ := clientset.CoreV1().Pods("test-ns").Get(context.TODO(), "my-replica-set-0", metav1.GetOptions{})
-	assert.Empty(t, pod.Annotations)
+	assert.Empty(t, pod.Annotations[mongodbAgentVersionAnnotation])
 
 	// adding the annotations
 	assert.NoError(t, PatchPodAnnotation("test-ns", 1, "my-replica-set-0", clientset))


### PR DESCRIPTION
Closes #482 

After this is merged a new version of the `readiness-probe` image must be released.