### PR TITLE
Allow readiness probe to be configurable in test runs

### DIFF
--- a/dev_notes/dev-quick-start.md
+++ b/dev_notes/dev-quick-start.md
@@ -47,7 +47,8 @@ cat > ~/.community-operator-dev/config.json << EOL
     "e2e_image": "e2e",
     "prestop_hook_image": "prehook",
     "testrunner_image": "test-runner",
-    "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook"
+    "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook",
+    "readiness_probe_image": "mongodb-kubernetes-readinessprobe"
 }
 EOL
 ```

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -3,7 +3,7 @@
   "repo_url": "quay.io/mongodb",
   "operator_image": "community-operator-dev",
   "e2e_image": "community-operator-e2e",
-  "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook",
+  "version_upgrade_hook_image": "mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev",
   "testrunner_image": "community-operator-testrunner",
   "agent_image_ubuntu": "mongodb-agent-dev",
   "agent_image_ubi": "mongodb-agent-ubi-dev",

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -7,5 +7,6 @@
   "testrunner_image": "community-operator-testrunner",
   "agent_image_ubuntu": "mongodb-agent-dev",
   "agent_image_ubi": "mongodb-agent-ubi-dev",
+  "readiness_probe_image": "mongodb-kubernetes-readinessprobe-dev",
   "s3_bucket": "s3://enterprise-operator-dockerfiles/dockerfiles"
 }

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -71,6 +71,10 @@ class DevConfig:
         return self._config["version_upgrade_hook_image"]
 
     @property
+    def readiness_probe_image(self) -> str:
+        return self._config["readiness_probe_image"]
+
+    @property
     def agent_image(self) -> str:
         if self._distro == Distro.UBI:
             return self._config["agent_image_ubi"]

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -156,8 +156,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "VERSION_UPGRADE_HOOK_IMAGE",
-                            # TODO: this needs to come from somewhere else
-                            "value": "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2",
+                            "value": f"{dev_config.repo_url}/{dev_config.version_upgrade_hook_image}:{args.tag}",
                         },
                         {
                             "name": "READINESS_PROBE_IMAGE",

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -160,6 +160,10 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                             "value": "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2",
                         },
                         {
+                            "name": "READINESS_PROBE_IMAGE",
+                            "value": f"{dev_config.repo_url}/{dev_config.readiness_probe_image}:{args.tag}",
+                        },
+                        {
                             "name": "PERFORM_CLEANUP",
                             "value": f"{args.perform_cleanup}",
                         },

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -144,10 +144,10 @@ func deployOperator() error {
 		&appsv1.Deployment{},
 		withNamespace(testConfig.namespace),
 		withOperatorImage(testConfig.operatorImage),
-		withVersionUpgradeHookImage(testConfig.versionUpgradeHookImage),
 		withEnvVar("WATCH_NAMESPACE", watchNamespace),
 		withEnvVar(construct.AgentImageEnv, testConfig.agentImage),
 		withEnvVar(construct.ReadinessProbeImageEnv, testConfig.readinessProbeImage),
+		withEnvVar(construct.VersionUpgradeHookImageEnv, testConfig.versionUpgradeHookImage),
 	); err != nil {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}
@@ -233,30 +233,6 @@ func updateEnvVarList(envVarList []corev1.EnvVar, key, val string) []corev1.EnvV
 		}
 	}
 	return append(envVarList, corev1.EnvVar{Name: key, Value: val})
-}
-
-// withVersionUpgradeHookImage sets the value of the VERSION_UPGRADE_HOOK_IMAGE
-// EnvVar from first container to `image`. The EnvVar is updated
-// if it exists. Or appended if there is no EnvVar with this `Name`.
-func withVersionUpgradeHookImage(image string) func(runtime.Object) {
-	return func(obj runtime.Object) {
-		if dep, ok := obj.(*appsv1.Deployment); ok {
-			versionUpgradeHookEnv := corev1.EnvVar{
-				Name:  construct.VersionUpgradeHookImageEnv,
-				Value: image,
-			}
-			found := false
-			for idx := range dep.Spec.Template.Spec.Containers[0].Env {
-				if dep.Spec.Template.Spec.Containers[0].Env[idx].Name == versionUpgradeHookEnv.Name {
-					dep.Spec.Template.Spec.Containers[0].Env[idx].Value = versionUpgradeHookEnv.Value
-					found = true
-				}
-			}
-			if !found {
-				dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, versionUpgradeHookEnv)
-			}
-		}
-	}
 }
 
 // withOperatorImage assumes that the underlying type is an appsv1.Deployment

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -147,7 +147,7 @@ func deployOperator() error {
 		withVersionUpgradeHookImage(testConfig.versionUpgradeHookImage),
 		withEnvVar("WATCH_NAMESPACE", watchNamespace),
 		withEnvVar(construct.AgentImageEnv, testConfig.agentImage),
-		withEnvVar(construct.ReadinessProbeContainerName, testConfig.readinessProbeImage),
+		withEnvVar(construct.ReadinessProbeImageEnv, testConfig.readinessProbeImage),
 	); err != nil {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -147,6 +147,7 @@ func deployOperator() error {
 		withVersionUpgradeHookImage(testConfig.versionUpgradeHookImage),
 		withEnvVar("WATCH_NAMESPACE", watchNamespace),
 		withEnvVar(construct.AgentImageEnv, testConfig.agentImage),
+		withEnvVar(construct.ReadinessProbeContainerName, testConfig.readinessProbeImage),
 	); err != nil {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}

--- a/test/e2e/setup/test_config.go
+++ b/test/e2e/setup/test_config.go
@@ -19,6 +19,7 @@ type testConfig struct {
 	clusterWide             bool
 	performCleanup          bool
 	agentImage              string
+	readinessProbeImage     string
 }
 
 func loadTestConfigFromEnv() testConfig {
@@ -29,5 +30,6 @@ func loadTestConfigFromEnv() testConfig {
 		agentImage:              envvar.GetEnvOrDefault(construct.AgentImageEnv, "quay.io/mongodb/mongodb-agent:10.29.0.6830-1"), // TODO: better way to decide default agent image.
 		clusterWide:             envvar.ReadBool(clusterWideEnvName),
 		performCleanup:          envvar.ReadBool(performCleanupEnvName),
+		readinessProbeImage:     envvar.GetEnvOrDefault(construct.ReadinessProbeImageEnv, "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.3"),
 	}
 }


### PR DESCRIPTION
### All Submissions:

This PR ensures that the readiness probe and version upgrade hooks that we build every run are used in our e2e tests.

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

