### PR TITLE
Add predicates to controller

### DIFF
--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/controllers/predicates"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/container"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/functions"
@@ -77,7 +80,7 @@ func NewReconciler(mgr manager.Manager) *ReplicaSetReconciler {
 // SetupWithManager sets up the controller with the Manager and configures the necessary watches.
 func (r *ReplicaSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&mdbv1.MongoDBCommunity{}).
+		For(&mdbv1.MongoDBCommunity{}, builder.WithPredicates(predicates.OnlyOnSpecChange())).
 		Complete(r)
 }
 

--- a/dev_notes/RELEASE_NOTES.md
+++ b/dev_notes/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 - Bug fixes
   - when deleting MongoDB Resource cleanup related resources (k8s services, secrets).
-
+  - fixed an issue where the operator would reconcile based on events emitted by itself in certain situations.
 ## MongoDB Agent ReadinessProbe
 
 - Changes

--- a/dev_notes/RELEASE_NOTES.md
+++ b/dev_notes/RELEASE_NOTES.md
@@ -4,7 +4,10 @@
 
 - Bug fixes
   - when deleting MongoDB Resource cleanup related resources (k8s services, secrets).
+  
+- Changes
   - fixed an issue where the operator would reconcile based on events emitted by itself in certain situations.
+
 ## MongoDB Agent ReadinessProbe
 
 - Changes


### PR DESCRIPTION
When we refactored the project to use the latest versions of the Operator SDK, we accidentally removed the set of predicates that we pass. This change ensures that the operator reconciles only on spec changes (not on status updates / other changes ) made by itself or other entities.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

