### PR TITLE
Allows both TLS and SSL to be specified

### DIFF
--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -274,9 +274,9 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		},
 	}
 
-	if b.tlsConfig != nil && b.sslConfig != nil {
-		return AutomationConfig{}, errors.Errorf("must specify only one of tlsConfig and sslConfig")
-	}
+	// if b.tlsConfig != nil && b.sslConfig != nil {
+	// 	return AutomationConfig{}, errors.Errorf("must specify only one of tlsConfig and sslConfig")
+	// }
 
 	if b.tlsConfig != nil {
 		currentAc.SSLConfig = nil

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -274,17 +274,11 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		},
 	}
 
-	// if b.tlsConfig != nil && b.sslConfig != nil {
-	// 	return AutomationConfig{}, errors.Errorf("must specify only one of tlsConfig and sslConfig")
-	// }
-
 	if b.tlsConfig != nil {
-		//	currentAc.SSLConfig = nil
 		currentAc.TLSConfig = b.tlsConfig
 	}
 
 	if b.sslConfig != nil {
-		//	currentAc.TLSConfig = nil
 		currentAc.SSLConfig = b.sslConfig
 	}
 

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -279,12 +279,12 @@ func (b *Builder) Build() (AutomationConfig, error) {
 	// }
 
 	if b.tlsConfig != nil {
-		currentAc.SSLConfig = nil
+		//	currentAc.SSLConfig = nil
 		currentAc.TLSConfig = b.tlsConfig
 	}
 
 	if b.sslConfig != nil {
-		currentAc.TLSConfig = nil
+		//	currentAc.TLSConfig = nil
 		currentAc.SSLConfig = b.sslConfig
 	}
 


### PR DESCRIPTION
This is needed in AppDB works when performing a TLS upgrade from an Agent that understands only SSL to one that understands TLS

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
