### PR TITLE
Ensure Inventory files use images specified in config.json

### DIFF
--- a/inventories/e2e-inventory.yaml
+++ b/inventories/e2e-inventory.yaml
@@ -6,7 +6,8 @@ images:
     vars:
       context: .
       template_context: scripts/dev/templates
-
+    inputs:
+      - e2e_image
     stages:
       - name: e2e-template
         task_type: dockerfile_template
@@ -28,8 +29,8 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/community-operator-e2e
+          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/community-operator-e2e
+          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
             tag: latest
 

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -9,6 +9,7 @@ images:
 
     inputs:
       - operator_image
+      - operator_image_dev
 
     stages:
       - name: operator-template-ubi
@@ -31,8 +32,8 @@ images:
         dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
             tag: latest
 

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -8,7 +8,6 @@ images:
       template_context: scripts/dev/templates
 
     inputs:
-      - operator_image
       - operator_image_dev
 
     stages:

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -7,6 +7,9 @@ images:
       context: .
       template_context: scripts/dev/templates
 
+    inputs:
+      - operator_image
+
     stages:
       - name: operator-template-ubi
         task_type: dockerfile_template
@@ -28,8 +31,8 @@ images:
         dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
 
         output:
-          - registry: $(inputs.params.registry)/community-operator-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/community-operator-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
             tag: latest
 

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -11,6 +11,7 @@ images:
       - agent_version
       - tools_version
       - agent_image
+      - agent_image_dev
 
     stages:
       - name: agent-ubuntu-context
@@ -27,7 +28,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
             tag: $(inputs.params.version_id)-context
 
       - name: agent-template-ubuntu
@@ -45,16 +46,16 @@ images:
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubuntu-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context
           agent_version: $(inputs.params.agent_version)
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
             tag: latest
 
       - name: agent-template-ubuntu-s3
@@ -83,7 +84,7 @@ images:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)-context
 
       - name: agent-ubuntu-release
@@ -94,14 +95,14 @@ images:
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubuntu-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-agent:$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.version_id)-context
           agent_version: $(inputs.params.agent_version)
 
         labels:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)
 
   - name: agent-ubi
@@ -112,7 +113,8 @@ images:
     inputs:
       - agent_version
       - tools_version
-      - agent_version
+      - agent_image
+      - agent_image_dev
 
     stages:
       - name: agent-ubi-context
@@ -129,7 +131,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
             tag: $(inputs.params.version_id)-context
 
 
@@ -149,16 +151,16 @@ images:
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context
           agent_version: $(inputs.params.agent_version)
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
             tag: latest
 
       - name: agent-template-ubi-s3
@@ -195,14 +197,14 @@ images:
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-agent-ubi:$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.version_id)-context
           agent_version: $(inputs.params.agent_version)
 
         labels:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent-ubi
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)
 
   - name: readiness-probe-init
@@ -211,6 +213,7 @@ images:
 
     inputs:
       - readiness_probe_image
+      - readiness_probe_image_dev
 
     stages:
       - name: readiness-init-context-build
@@ -221,7 +224,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
             tag: $(inputs.params.version_id)-context
 
       - name: readiness-init-build
@@ -233,12 +236,12 @@ images:
 
         tags: ["readiness-probe"]
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
             tag: latest
 
 
@@ -283,6 +286,7 @@ images:
 
     inputs:
       - version_post_start_hook_image
+      - version_post_start_hook_image_dev
 
     stages:
       - name: version-post-start-hook-init-context-build
@@ -294,7 +298,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
             tag: $(inputs.params.version_id)-context
 
       - name: version-post-start-hook-init-build
@@ -302,15 +306,15 @@ images:
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook
         tags: ["post-start-hook"]
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev):$(inputs.params.version_id)-context
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
             tag: latest
 
 

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -10,6 +10,7 @@ images:
     inputs:
       - agent_version
       - tools_version
+      - agent_image
 
     stages:
       - name: agent-ubuntu-context
@@ -26,7 +27,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_version)
             tag: $(inputs.params.version_id)-context
 
       - name: agent-template-ubuntu
@@ -44,16 +45,16 @@ images:
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubuntu-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-agent-dev:$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.version_id)-context
           agent_version: $(inputs.params.agent_version)
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/mongodb-agent-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: latest
 
       - name: agent-template-ubuntu-s3
@@ -111,6 +112,7 @@ images:
     inputs:
       - agent_version
       - tools_version
+      - agent_version
 
     stages:
       - name: agent-ubi-context
@@ -127,7 +129,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent-ubi-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)-context
 
 
@@ -143,19 +145,20 @@ images:
       - name: agent-ubi-build
         task_type: docker_build
         tags: ["ubi"]
+
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-agent-ubi-dev:$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.version_id)-context
           agent_version: $(inputs.params.agent_version)
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent-ubi-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/mongodb-agent-ubi-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: latest
 
       - name: agent-template-ubi-s3
@@ -183,7 +186,7 @@ images:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-agent-ubi
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)-context
 
       - name: agent-ubi-release
@@ -206,17 +209,19 @@ images:
     vars:
       context: .
 
+    inputs:
+      - readiness_probe_image
+
     stages:
       - name: readiness-init-context-build
         task_type: docker_build
         dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
         tags: ["readiness-probe"]
-
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
             tag: $(inputs.params.version_id)-context
 
       - name: readiness-init-build
@@ -228,12 +233,12 @@ images:
 
         tags: ["readiness-probe"]
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe-dev:$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.version_id)-context
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
             tag: latest
 
 
@@ -249,7 +254,7 @@ images:
           - release_version
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe
+          - registry: $(inputs.params.registry)/(inputs.params.readiness_probe_image)
             tag: $(inputs.params.release_version)-context
 
 
@@ -259,7 +264,7 @@ images:
         tags: ["readiness-probe", "release"]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe:$(inputs.params.release_version)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.release_version)-context
 
         labels:
           quay.expires-after: Never
@@ -268,13 +273,16 @@ images:
           - release_version
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-readinessprobe
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
             tag: $(inputs.params.release_version)
 
 
   - name: version-post-start-hook-init
     vars:
       context: .
+
+    inputs:
+      - version_post_start_hook_image
 
     stages:
       - name: version-post-start-hook-init-context-build
@@ -286,7 +294,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
             tag: $(inputs.params.version_id)-context
 
       - name: version-post-start-hook-init-build
@@ -294,15 +302,15 @@ images:
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook
         tags: ["post-start-hook"]
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev:$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.version_id)-context
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
             tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
             tag: latest
 
 
@@ -318,7 +326,7 @@ images:
           - release_version
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
             tag: $(inputs.params.release_version)-context
 
 
@@ -327,7 +335,7 @@ images:
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook
         tags: ["release", "post-start-hook"]
         buildargs:
-          imagebase: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook:$(inputs.params.release_version)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.release_version)-context
 
         labels:
           quay.expires-after: Never
@@ -336,5 +344,5 @@ images:
           - release_version
 
         output:
-          - registry: $(inputs.params.registry)/mongodb-kubernetes-operator-version-upgrade-post-start-hook
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
             tag: $(inputs.params.release_version)

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -27,7 +27,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_version)
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.version_id)-context
 
       - name: agent-template-ubuntu

--- a/pipeline.py
+++ b/pipeline.py
@@ -35,8 +35,6 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
         "agent_version": release["mongodb-agent"]["version"],
         "release_version": release["mongodb-agent"]["version"],
         "tools_version": release["mongodb-agent"]["tools_version"],
-        "agent_image": config.agent_image,
-        "agent_image_dev": config.agent_dev_image,
         "registry": config.repo_url,
         "s3_bucket": config.s3_bucket,
     }
@@ -45,6 +43,8 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
 def build_agent_image_ubi(config: DevConfig) -> None:
     image_name = "agent-ubi"
     args = _build_agent_args(config)
+    args["agent_image"] = config.agent_image_ubi
+    args["agent_image_dev"] = config.agent_dev_image_ubi
     config.ensure_tag_is_run("ubi")
 
     sonar_build_image(
@@ -57,6 +57,8 @@ def build_agent_image_ubi(config: DevConfig) -> None:
 def build_agent_image_ubuntu(config: DevConfig) -> None:
     image_name = "agent-ubuntu"
     args = _build_agent_args(config)
+    args["agent_image"] = config.agent_image_ubuntu
+    args["agent_image_dev"] = config.agent_dev_image_ubuntu
     config.ensure_tag_is_run("ubuntu")
 
     sonar_build_image(

--- a/pipeline.py
+++ b/pipeline.py
@@ -36,6 +36,7 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
         "release_version": release["mongodb-agent"]["version"],
         "tools_version": release["mongodb-agent"]["tools_version"],
         "agent_image": config.agent_image,
+        "agent_image_dev": config.agent_dev_image,
         "registry": config.repo_url,
         "s3_bucket": config.s3_bucket,
     }
@@ -76,6 +77,7 @@ def build_readiness_probe_image(config: DevConfig) -> None:
             "registry": config.repo_url,
             "release_version": release["readiness-probe"],
             "readiness_probe_image": config.readiness_probe_image,
+            "readiness_probe_image_dev": config.readiness_probe_image_dev,
         },
     )
 
@@ -91,6 +93,7 @@ def build_version_post_start_hook_image(config: DevConfig) -> None:
             "registry": config.repo_url,
             "release_version": release["version-upgrade-hook"],
             "version_post_start_hook_image": config.version_upgrade_hook_image,
+            "version_post_start_hook_image_dev": config.version_upgrade_hook_image_dev,
         },
     )
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -35,6 +35,7 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
         "agent_version": release["mongodb-agent"]["version"],
         "release_version": release["mongodb-agent"]["version"],
         "tools_version": release["mongodb-agent"]["tools_version"],
+        "agent_image": config.agent_image,
         "registry": config.repo_url,
         "s3_bucket": config.s3_bucket,
     }
@@ -74,6 +75,7 @@ def build_readiness_probe_image(config: DevConfig) -> None:
         args={
             "registry": config.repo_url,
             "release_version": release["readiness-probe"],
+            "readiness_probe_image": config.readiness_probe_image,
         },
     )
 
@@ -88,6 +90,7 @@ def build_version_post_start_hook_image(config: DevConfig) -> None:
         args={
             "registry": config.repo_url,
             "release_version": release["version-upgrade-hook"],
+            "version_post_start_hook_image": config.version_upgrade_hook_image,
         },
     )
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -105,6 +105,7 @@ def build_operator_ubi_image(config: DevConfig) -> None:
             "builder": "true",
             "builder_image": f"golang:{GOLANG_TAG}",
             "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
+            "operator_image": config.operator_image,
         },
         inventory="inventories/operator-inventory.yaml",
     )
@@ -117,6 +118,7 @@ def build_e2e_image(config: DevConfig) -> None:
         args={
             "registry": config.repo_url,
             "base_image": f"golang:{GOLANG_TAG}",
+            "e2e_image": config.e2e_image,
         },
         inventory="inventories/e2e-inventory.yaml",
     )

--- a/pipeline.py
+++ b/pipeline.py
@@ -109,6 +109,7 @@ def build_operator_ubi_image(config: DevConfig) -> None:
             "builder_image": f"golang:{GOLANG_TAG}",
             "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
             "operator_image": config.operator_image,
+            "operator_image_dev": config.operator_image_dev,
         },
         inventory="inventories/operator-inventory.yaml",
     )

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -1,12 +1,16 @@
 {
   "namespace": "default",
   "repo_url": "quay.io/mongodb",
-  "operator_image": "community-operator-dev",
+  "operator_image": "mongodb-kubernetes-operator",
+  "operator_image_dev": "community-operator-dev",
   "e2e_image": "community-operator-e2e",
-  "version_upgrade_hook_image": "mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev",
-  "testrunner_image": "community-operator-testrunner",
-  "agent_image_ubuntu": "mongodb-agent-dev",
-  "agent_image_ubi": "mongodb-agent-ubi-dev",
-  "readiness_probe_image": "mongodb-kubernetes-readinessprobe-dev",
+  "version_upgrade_hook_image": "mongodb-kubernetes-operator-version-upgrade-post-start-hook",
+  "version_upgrade_hook_image_dev": "mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev",
+  "agent_image_ubuntu": "mongodb-agent",
+  "agent_image_ubuntu_dev": "mongodb-agent-dev",
+  "agent_image_ubi": "mongodb-agent-ubi",
+  "agent_image_ubi_dev": "mongodb-agent-ubi-dev",
+  "readiness_probe_image": "mongodb-kubernetes-readinessprobe",
+  "readiness_probe_image_dev": "mongodb-kubernetes-readinessprobe-dev",
   "s3_bucket": "s3://enterprise-operator-dockerfiles/dockerfiles"
 }

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -108,16 +108,26 @@ class DevConfig:
         return self._get_dev_image("readiness_probe_image_dev", "readiness_probe_image")
 
     @property
-    def agent_dev_image(self) -> str:
-        if self._distro == Distro.UBI:
-            return self._get_dev_image("agent_image_ubi_dev", "agent_image_ubi")
+    def agent_dev_image_ubi(self) -> str:
+        return self._get_dev_image("agent_image_ubi_dev", "agent_image_ubi")
+
+    @property
+    def agent_dev_image_ubuntu(self) -> str:
         return self._get_dev_image("agent_image_ubuntu_dev", "agent_image_ubuntu")
+
+    @property
+    def agent_image_ubuntu(self) -> str:
+        return self._config["agent_image_ubuntu"]
+
+    @property
+    def agent_image_ubi(self) -> str:
+        return self._config["agent_image_ubi"]
 
     @property
     def agent_image(self) -> str:
         if self._distro == Distro.UBI:
-            return self._config["agent_image_ubi"]
-        return self._config["agent_image_ubuntu"]
+            return self.agent_dev_image_ubi
+        return self.agent_dev_image_ubuntu
 
     def ensure_skip_tag(self, tag: str) -> None:
         if tag not in self.skip_tags:

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -63,6 +63,10 @@ class DevConfig:
         return self._config["operator_image"]
 
     @property
+    def operator_image_dev(self) -> str:
+        return self._get_dev_image("operator_image_dev", "operator_image")
+
+    @property
     def e2e_image(self) -> str:
         return self._config["e2e_image"]
 
@@ -71,8 +75,24 @@ class DevConfig:
         return self._config["version_upgrade_hook_image"]
 
     @property
+    def version_upgrade_hook_image_dev(self) -> str:
+        return self._get_dev_image(
+            "version_upgrade_hook_image_dev", "version_upgrade_hook_image"
+        )
+
+    @property
     def readiness_probe_image(self) -> str:
         return self._config["readiness_probe_image"]
+
+    @property
+    def readiness_probe_image_dev(self) -> str:
+        return self._get_dev_image("readiness_probe_image_dev", "readiness_probe_image")
+
+    @property
+    def agent_dev_image(self) -> str:
+        if self._distro == Distro.UBI:
+            return self._get_dev_image("agent_image_ubi_dev", "agent_image_ubi")
+        return self._get_dev_image("agent_image_ubuntu_dev", "agent_image_ubuntu")
 
     @property
     def agent_image(self) -> str:
@@ -83,6 +103,11 @@ class DevConfig:
     def ensure_skip_tag(self, tag: str) -> None:
         if tag not in self.skip_tags:
             self.skip_tags.append(tag)
+
+    def _get_dev_image(self, dev_image: str, image: str) -> str:
+        if dev_image in self._config:
+            return self._config[dev_image]
+        return self._config[image]
 
 
 def load_config(

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -130,7 +130,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "OPERATOR_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.operator_image}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.operator_image_dev}:{args.tag}",
                         },
                         {
                             "name": "AGENT_IMAGE",
@@ -142,11 +142,11 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "VERSION_UPGRADE_HOOK_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.version_upgrade_hook_image}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.version_upgrade_hook_image_dev}:{args.tag}",
                         },
                         {
                             "name": "READINESS_PROBE_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.readiness_probe_image}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.version_upgrade_hook_image_dev}:{args.tag}",
                         },
                         {
                             "name": "PERFORM_CLEANUP",

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -134,7 +134,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "AGENT_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.agent_image}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.agent_dev_image}:{args.tag}",
                         },
                         {
                             "name": "TEST_NAMESPACE",

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -134,7 +134,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "AGENT_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.agent_dev_image}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.agent_image}:{args.tag}",
                         },
                         {
                             "name": "TEST_NAMESPACE",

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -146,7 +146,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "READINESS_PROBE_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.version_upgrade_hook_image_dev}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.readiness_probe_image_dev}:{args.tag}",
                         },
                         {
                             "name": "PERFORM_CLEANUP",


### PR DESCRIPTION
This PR ensures that the values from ~/.community-operator/config.json are substituted into the inventory.yaml files and so are the single source of truth throughout the development pipeline.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

