### PR TITLE
CLOUDP-89260: e2e test for readiness probe

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -163,7 +163,8 @@ task_groups:
     - func: create_kind_cluster
   tasks:
     - e2e_test_replica_set
-    - e2e_test_replica_set_readiness_probe
+    - e2e_test_replica_set_recovery
+    - e2e_test_replica_set_mongod_readiness
     - e2e_test_replica_set_scale
     - e2e_test_replica_set_scale_down
     - e2e_test_replica_set_change_version
@@ -262,11 +263,17 @@ tasks:
         vars:
           test: replica_set
 
-  - name: e2e_test_replica_set_readiness_probe
+  - name: e2e_test_replica_set_recovery
     commands:
       - func: run_e2e_test
         vars:
-          test: replica_set_readiness_probe
+          test: replica_set_recovery
+
+  - name: e2e_test_replica_set_mongod_readiness
+    commands:
+      - func: run_e2e_test
+        vars:
+          test: replica_set_mongod_readiness
 
   - name: e2e_test_replica_set_scale
     commands:

--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -67,6 +67,10 @@ func isPodReady(conf config.Config) (bool, error) {
 	}
 
 	inReadyState := isInReadyState(healthStatus)
+	if !inReadyState {
+		logger.Info("Mongod is not ready")
+	}
+
 	if inGoalState && inReadyState {
 		logger.Info("Agent has reached goal state")
 		return true, nil

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -234,7 +234,7 @@ func versionUpgradeHookInit(volumeMount []corev1.VolumeMount) container.Modifica
 func DefaultReadiness() probes.Modification {
 	return probes.Apply(
 		probes.WithExecCommand([]string{readinessProbePath}),
-		probes.WithFailureThreshold(20),
+		probes.WithFailureThreshold(40),
 		probes.WithInitialDelaySeconds(5),
 	)
 }

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -234,7 +234,7 @@ func versionUpgradeHookInit(volumeMount []corev1.VolumeMount) container.Modifica
 func DefaultReadiness() probes.Modification {
 	return probes.Apply(
 		probes.WithExecCommand([]string{readinessProbePath}),
-		probes.WithFailureThreshold(60), // TODO: this value needs further consideration
+		probes.WithFailureThreshold(4),
 		probes.WithInitialDelaySeconds(5),
 	)
 }

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -234,7 +234,7 @@ func versionUpgradeHookInit(volumeMount []corev1.VolumeMount) container.Modifica
 func DefaultReadiness() probes.Modification {
 	return probes.Apply(
 		probes.WithExecCommand([]string{readinessProbePath}),
-		probes.WithFailureThreshold(4),
+		probes.WithFailureThreshold(20),
 		probes.WithInitialDelaySeconds(5),
 	)
 }

--- a/deploy/e2e/role.yaml
+++ b/deploy/e2e/role.yaml
@@ -62,6 +62,12 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
   - apps
   resources:
   - replicasets

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -159,7 +159,7 @@ func (c *E2ETestClient) Execute(pod corev1.Pod, containerName, command string) (
 	errBuf := &bytes.Buffer{}
 	exec, err := remotecommand.NewSPDYExecutor(c.restConfig, "POST", req.URL())
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	err = exec.Stream(remotecommand.StreamOptions{
 		Stdout: buf,

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -13,7 +13,6 @@ import (
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/statefulset"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -353,16 +353,19 @@ func StatefulSetContainerConditionIsTrue(mdb *mdbv1.MongoDBCommunity, containerN
 	}
 }
 
-func PodContainerBecomesNotReady(mdb *mdbv1.MongoDBCommunity, podNum int, containerName string, timeout time.Duration) func(*testing.T) {
+// PodContainerBecomesReady waits until the container with 'containerName' in the pod #podNum becomes not ready.
+func PodContainerBecomesNotReady(mdb *mdbv1.MongoDBCommunity, podNum int, containerName string) func(*testing.T) {
 	return func(t *testing.T) {
 		pod := podFromMongoDBCommunity(mdb, podNum)
-		assert.NoError(t, e2eutil.WaitForPodReadiness(t, false, containerName, timeout, pod))
+		assert.NoError(t, e2eutil.WaitForPodReadiness(t, false, containerName, time.Minute*10, pod))
 	}
 }
-func PodContainerBecomesReady(mdb *mdbv1.MongoDBCommunity, podNum int, containerName string, timeout time.Duration) func(*testing.T) {
+
+// PodContainerBecomesReady waits until the container with 'containerName' in the pod #podNum becomes ready.
+func PodContainerBecomesReady(mdb *mdbv1.MongoDBCommunity, podNum int, containerName string) func(*testing.T) {
 	return func(t *testing.T) {
 		pod := podFromMongoDBCommunity(mdb, podNum)
-		assert.NoError(t, e2eutil.WaitForPodReadiness(t, true, containerName, timeout, pod))
+		assert.NoError(t, e2eutil.WaitForPodReadiness(t, true, containerName, time.Minute*3, pod))
 	}
 }
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
@@ -224,12 +223,7 @@ func BasicFunctionality(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 // DeletePod will delete a pod that belongs to this MongoDB resource's StatefulSet
 func DeletePod(mdb *mdbv1.MongoDBCommunity, podNum int) func(*testing.T) {
 	return func(t *testing.T) {
-		pod := corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-%d", mdb.Name, podNum),
-				Namespace: mdb.Namespace,
-			},
-		}
+		pod := podFromMongoDBCommunity(mdb, podNum)
 		if err := e2eutil.TestClient.Delete(context.TODO(), &pod); err != nil {
 			t.Fatal(err)
 		}
@@ -350,6 +344,27 @@ func StatefulSetContainerConditionIsTrue(mdb *mdbv1.MongoDBCommunity, containerN
 	}
 }
 
+func PodContainerBecomesNotReady(mdb *mdbv1.MongoDBCommunity, podNum int, containerName string, timeout time.Duration) func(*testing.T) {
+	return func(t *testing.T) {
+		pod := podFromMongoDBCommunity(mdb, podNum)
+		assert.NoError(t, e2eutil.WaitForPodReadiness(t, false, containerName, timeout, pod))
+	}
+}
+func PodContainerBecomesReady(mdb *mdbv1.MongoDBCommunity, podNum int, containerName string, timeout time.Duration) func(*testing.T) {
+	return func(t *testing.T) {
+		pod := podFromMongoDBCommunity(mdb, podNum)
+		assert.NoError(t, e2eutil.WaitForPodReadiness(t, true, containerName, timeout, pod))
+	}
+}
+
+func ExecInContainer(mdb *mdbv1.MongoDBCommunity, podNum int, containerName, command string) func(*testing.T) {
+	return func(t *testing.T) {
+		pod := podFromMongoDBCommunity(mdb, podNum)
+		_, err := e2eutil.TestClient.Execute(pod, containerName, command)
+		assert.NoError(t, err)
+	}
+}
+
 func findContainerByName(name string, containers []corev1.Container) *corev1.Container {
 	for _, c := range containers {
 		if c.Name == name {
@@ -358,6 +373,15 @@ func findContainerByName(name string, containers []corev1.Container) *corev1.Con
 	}
 
 	return nil
+}
+
+func podFromMongoDBCommunity(mdb *mdbv1.MongoDBCommunity, podNum int) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", mdb.Name, podNum),
+			Namespace: mdb.Namespace,
+		},
+	}
 }
 
 func assertEqualOwnerReference(t *testing.T, resourceType string, resourceNamespacedName types.NamespacedName, ownerReferences []metav1.OwnerReference, expectedOwnerReference metav1.OwnerReference) {

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -1,0 +1,58 @@
+package replica_set_mongod_readiness
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
+	"github.com/stretchr/testify/assert"
+
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+)
+
+func TestMain(m *testing.M) {
+	code, err := e2eutil.RunTest(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func TestReplicaSet(t *testing.T) {
+	ctx, shouldCleanup := setup.InitTest(t)
+
+	if shouldCleanup {
+		defer ctx.Cleanup()
+	}
+	mdb, user := e2eutil.NewTestMongoDB("mdb0", "")
+
+	_, err := setup.GeneratePasswordForUser(user, ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = FromResource(t, mdb)
+	assert.NoError(t, err)
+
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
+	t.Run("Ensure Agent container is marked as non-ready", func(t *testing.T) {
+		t.Run("Break mongod data files", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "mkdir /data/tmp; mv /data/WiredTiger.wt /data/tmp"))
+		// Just moving the file doesn't fail the mongod until any data is written - the easiest way is to kill the mongod
+		// and in this case it won't restart
+		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
+		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 4
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*2))
+	})
+	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
+		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot
+		// execute shell there. But both containers share the same /data directory so we can do it from any of them.
+		t.Run("Fix mongod data files", mongodbtests.ExecInContainer(&mdb, 0, "mongodb-agent", "mv /data/tmp/WiredTiger.wt /data/"))
+		// Eventually the agent will start mongod again
+		t.Run("Pod agent container becomes ready", mongodbtests.PodContainerBecomesReady(&mdb, 0, "mongodb-agent", time.Minute*3))
+	})
+}

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -44,7 +44,7 @@ func TestReplicaSet(t *testing.T) {
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
 		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 40 (40 * 5 -> 200 seconds)
-		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*6))
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*7))
 	})
 	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
 		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -44,7 +44,7 @@ func TestReplicaSet(t *testing.T) {
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
 		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 40 (40 * 5 -> 200 seconds)
-		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*8))
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*10))
 	})
 	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
 		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
 	"github.com/stretchr/testify/assert"
@@ -44,13 +43,14 @@ func TestReplicaSet(t *testing.T) {
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
 		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 40 (40 * 5 -> 200 seconds)
-		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*10))
+		// note, that this may take much longer on evergreen than locally
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent"))
 	})
 	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
 		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot
 		// execute shell there. But both containers share the same /data directory so we can do it from any of them.
 		t.Run("Fix mongod data files", mongodbtests.ExecInContainer(&mdb, 0, "mongodb-agent", "mv /data/tmp/WiredTiger.wt /data/"))
 		// Eventually the agent will start mongod again
-		t.Run("Pod agent container becomes ready", mongodbtests.PodContainerBecomesReady(&mdb, 0, "mongodb-agent", time.Minute*3))
+		t.Run("Pod agent container becomes ready", mongodbtests.PodContainerBecomesReady(&mdb, 0, "mongodb-agent"))
 	})
 }

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
-	"github.com/stretchr/testify/assert"
-
 	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
 	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
 	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
@@ -31,9 +28,6 @@ func TestReplicaSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = FromResource(t, mdb)
-	assert.NoError(t, err)
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -43,8 +43,8 @@ func TestReplicaSet(t *testing.T) {
 		// Just moving the file doesn't fail the mongod until any data is written - the easiest way is to kill the mongod
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
-		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 20 (20 * 5 -> 100 seconds)
-		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*5))
+		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 40 (40 * 5 -> 200 seconds)
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*6))
 	})
 	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
 		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -23,14 +23,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestReplicaSet(t *testing.T) {
-	ctx, shouldCleanup := setup.InitTest(t)
+	ctx := setup.Setup(t)
+	defer ctx.Teardown()
 
-	if shouldCleanup {
-		defer ctx.Cleanup()
-	}
-	mdb, user := e2eutil.NewTestMongoDB("mdb0", "")
+	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
 
-	_, err := setup.GeneratePasswordForUser(user, ctx, "")
+	_, err := setup.GeneratePasswordForUser(ctx, user, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -43,8 +43,8 @@ func TestReplicaSet(t *testing.T) {
 		// Just moving the file doesn't fail the mongod until any data is written - the easiest way is to kill the mongod
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
-		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 4
-		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*2))
+		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 20 (20 * 5 -> 100 seconds)
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*5))
 	})
 	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
 		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot

--- a/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
+++ b/test/e2e/replica_set_mongod_readiness/replica_set_mongod_readiness_test.go
@@ -44,7 +44,7 @@ func TestReplicaSet(t *testing.T) {
 		// and in this case it won't restart
 		t.Run("Kill mongod process", mongodbtests.ExecInContainer(&mdb, 0, "mongod", "kill 1"))
 		// CLOUDP-89260: mongod uptime 1 minute and readiness probe failureThreshold 40 (40 * 5 -> 200 seconds)
-		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*7))
+		t.Run("Pod agent container becomes not-ready", mongodbtests.PodContainerBecomesNotReady(&mdb, 0, "mongodb-agent", time.Minute*8))
 	})
 	t.Run("Ensure Agent container gets fixed", func(t *testing.T) {
 		// Note, that we call this command on the 'mongodb-agent' container as the 'mongod' container is down and we cannot

--- a/test/e2e/replica_set_recovery/replica_set_recovery_test.go
+++ b/test/e2e/replica_set_recovery/replica_set_recovery_test.go
@@ -1,4 +1,4 @@
-package replica_set_readiness_probe
+package replica_set_recovery
 
 import (
 	"crypto/rand"
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestReplicaSetReadinessProbeScaling(t *testing.T) {
+func TestReplicaSetRecovery(t *testing.T) {
 	ctx, shouldCleanup := setup.InitTest(t)
 
 	if shouldCleanup {


### PR DESCRIPTION
This is an e2e test for readiness improvements. 

The test executes into the container, moves the important data file and kills the mongod process (otherwise mongod will work fine until any data is written).

Then the test makes sure the `mongodb-agent` container becomes not ready.
Finally the test fixes the situation by moving the file back

**Update** I tried to set the `failureThreshold` to a much lower value (4) but this broke upgrade procedures, so I had to keep it high (though decreased from 60 to 40)
