### PR TITLE
CLOUDP-79509: Added deleter interface

### DIFF
--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -28,7 +28,7 @@ type Client interface {
 	// TODO: remove this function, add mongodb package which has GetAndUpdate function
 	GetAndUpdate(nsName types.NamespacedName, obj k8sClient.Object, updateFunc func()) error
 	configmap.GetUpdateCreateDeleter
-	service.GetUpdateCreator
+	service.GetUpdateCreateDeleter
 	secret.GetUpdateCreateDeleter
 	statefulset.GetUpdateCreateDeleter
 	pod.Getter

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -140,8 +140,14 @@ func (c client) CreateService(service corev1.Service) error {
 }
 
 // DeleteService provides a thin wrapper around client.Client to delete corev1.Service types
-func (c client) DeleteService(service corev1.Service) error {
-	return c.Delete(context.TODO(), &service)
+func (c client) DeleteService(objectKey k8sClient.ObjectKey) error {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objectKey.Name,
+			Namespace: objectKey.Namespace,
+		},
+	}
+	return c.Delete(context.TODO(), &svc)
 }
 
 // GetStatefulSet provides a thin wrapper and client.Client to access appsv1.StatefulSet types

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -139,6 +139,11 @@ func (c client) CreateService(service corev1.Service) error {
 	return c.Create(context.TODO(), &service)
 }
 
+// DeleteService provides a thin wrapper around client.Client to delete corev1.Service types
+func (c client) DeleteService(service corev1.Service) error {
+	return c.Delete(context.TODO(), &service)
+}
+
 // GetStatefulSet provides a thin wrapper and client.Client to access appsv1.StatefulSet types
 func (c client) GetStatefulSet(objectKey k8sClient.ObjectKey) (appsv1.StatefulSet, error) {
 	sts := appsv1.StatefulSet{}

--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -21,7 +21,7 @@ type Deleter interface {
 	DeleteService(service corev1.Service) error
 }
 
-type GetterDeleter interface {
+type GetDeleter interface {
 	Getter
 	Deleter
 }

--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -37,6 +37,13 @@ type GetUpdateCreator interface {
 	Creator
 }
 
+type GetUpdateCreatDeleter interface {
+	Getter
+	Updater
+	Creator
+	Deleter
+}
+
 // Merge merges `source` into `dest`. Both arguments will remain unchanged
 // a new service will be created and returned.
 // The "merging" process is arbitrary and it only handle specific attributes

--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -18,7 +18,7 @@ type Creator interface {
 }
 
 type Deleter interface {
-	DeleteService(service corev1.Service) error
+	DeleteService(objectKey client.ObjectKey) error
 }
 
 type GetDeleter interface {

--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -10,11 +10,20 @@ type Getter interface {
 }
 
 type Updater interface {
-	UpdateService(secret corev1.Service) error
+	UpdateService(service corev1.Service) error
 }
 
 type Creator interface {
-	CreateService(secret corev1.Service) error
+	CreateService(service corev1.Service) error
+}
+
+type Deleter interface {
+	DeleteService(service corev1.Service) error
+}
+
+type GetterDeleter interface {
+	Getter
+	Deleter
 }
 
 type GetUpdater interface {

--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -37,7 +37,7 @@ type GetUpdateCreator interface {
 	Creator
 }
 
-type GetUpdateCreatDeleter interface {
+type GetUpdateCreateDeleter interface {
 	Getter
 	Updater
 	Creator


### PR DESCRIPTION
This PR adds a `deleteService` method to the client package. This is needed for CLOUDP-79509 (enterprise)

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
