### PR TITLE
Updates image release process.

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -399,7 +399,7 @@ buildvariants:
     expansions:
       distro: ubuntu
     run_on:
-      - ubuntu1804-small
+      - ubuntu1804-large
     depends_on:
       - name: build_operator_image
         variant: init_test_run
@@ -419,7 +419,7 @@ buildvariants:
     expansions:
       distro: ubi
     run_on:
-      - ubuntu1804-small
+      - ubuntu1804-large
     depends_on:
       - name: build_operator_image
         variant: init_test_run

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -98,7 +98,7 @@ functions:
     command: subprocess.exec
     type: setup
     params:
-      command: virtualenv --python /opt/python/3.7/bin/python3 ./venv
+      command: virtualenv --python /opt/python/3.9/bin/python3 ./venv
 
   python_requirements: &python_requirements
     command: subprocess.exec
@@ -137,7 +137,7 @@ functions:
           - atlas_password
           - atlas_database
           - image_name
-        command: "${workdir}/venv/bin/python scripts/ci/add_supported_release.py --c ${image_name}"
+        command: "${workdir}/venv/bin/python scripts/ci/add_supported_release.py --image ${image_name}"
 
 task_groups:
 - name: e2e_test_group
@@ -399,7 +399,7 @@ buildvariants:
     expansions:
       distro: ubuntu
     run_on:
-      - ubuntu1604-build
+      - ubuntu1804-small
     depends_on:
       - name: build_operator_image
         variant: init_test_run
@@ -419,7 +419,7 @@ buildvariants:
     expansions:
       distro: ubi
     run_on:
-      - ubuntu1604-build
+      - ubuntu1804-small
     depends_on:
       - name: build_operator_image
         variant: init_test_run
@@ -437,7 +437,7 @@ buildvariants:
   - name: init_test_run
     display_name: init_test_run
     run_on:
-      - ubuntu1604-build
+      - ubuntu1804-small
     tasks:
       - name: build_operator_image
       - name: build_e2e_image
@@ -467,7 +467,7 @@ buildvariants:
       - name: build_agent_image_ubi
         variant: init_test_run
     run_on:
-      - ubuntu1604-test
+      - ubuntu1804-small
     tasks:
     - name: release_operator
     - name: release_version_upgrade_post_start_hook

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ black==20.8b1
 mypy==0.782
 tqdm==v4.49.0
 boto3==1.16.21
-pymongo==3.11.2
+pymongo==3.11.4
 dnspython==2.0.0
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
### Summary

* Updates tooling to Python3.9
* Updates build and release hosts to ubuntu1804-small (much higher capacity, 600 vs 200 of ubuntu1604-small)
* Fixes a certificate validation error when accessing Atlas mongodb over TLS ([like this one](https://spruce.mongodb.com/task/mongodb_kubernetes_operator_release_images_quay_release_agent_ubuntu_patch_f923235f9a4673f6aeb3e826e549d58814e4f39b_60c0fc520305b93bd2261e55_21_06_09_17_37_22/logs?execution=0))



### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
