### PR TITLE
Moved DeleteServiceIfItExists to Community

### DIFF
--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -1,7 +1,11 @@
 package service
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,6 +46,19 @@ type GetUpdateCreateDeleter interface {
 	Updater
 	Creator
 	Deleter
+}
+
+func DeleteServiceIfItExists(getterDeleter GetDeleter, serviceName types.NamespacedName) error {
+	_, err := getterDeleter.GetService(serviceName)
+	if err != nil {
+		// If it is not found return
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
+		// Otherwise we got an error when trying to get it
+		return fmt.Errorf("can't get service %s: %s", serviceName, err)
+	}
+	return getterDeleter.DeleteService(serviceName)
 }
 
 // Merge merges `source` into `dest`. Both arguments will remain unchanged


### PR DESCRIPTION

Following discussion on https://github.com/10gen/ops-manager-kubernetes/pull/1599 we move the method to community.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
