### PR TITLE
Fix script to launch github action

### DIFF
--- a/scripts/dev/run_e2e_gh.sh
+++ b/scripts/dev/run_e2e_gh.sh
@@ -6,6 +6,9 @@ current_branch="$(git branch --show-current)"
 
 gh workflow run e2e-dispatch.yml -f "test-name=${test_name}" --ref "${current_branch}"
 
-run_id="$(gh run list --workflow=e2e-dispatch.yml | grep workflow_dispatch | grep -Eo "[0-9]+" | head -n 1)"
+echo "Waiting for task to start..."
+sleep 2
+
+run_id="$(gh run list --workflow=e2e-dispatch.yml | grep workflow_dispatch | grep -Eo "[0-9]{9,11}" | head -n 1)"
 
 gh run view "${run_id}" --web


### PR DESCRIPTION
Task ID is not immediately visible as soon as you create the task, we must wait a few seconds for it to start, then we can open it.