### PR TITLE
Added job e2e-success

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -209,9 +209,10 @@ jobs:
           path: "${{ github.workspace }}/diagnostics"
 
   e2e-success:
+    if: always()
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check E2E Result
-        if: ${{ needs.tests.result != 'success' }}
+        if: needs.tests.result != 'success'
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -207,3 +207,11 @@ jobs:
         with:
           name: "${{ matrix.test-name }}-${{ matrix.distro }}-diagnostics"
           path: "${{ github.workspace }}/diagnostics"
+
+  e2e-success:
+    needs: [tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check E2E Result
+        if: ${{ needs.tests.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
It is not possible to depend on a `strategy matrix` job (without individually specifying each generated task)

This Pr introduces a job that will fail if any e2e tests have failed. We can block PRs on this job.