### PR TITLE
Configure Env Vars with make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ manager: generate fmt vet
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: install
 	$(KUSTOMIZE) build config/local_run | kubectl apply -n $(NAMESPACE) -f -
+	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \
 	go run ./cmd/manager/main.go
 
 # Install CRDs into a cluster

--- a/scripts/dev/get_e2e_env_vars.py
+++ b/scripts/dev/get_e2e_env_vars.py
@@ -26,6 +26,7 @@ def _get_e2e_test_envs(dev_config: DevConfig) -> Dict[str, str]:
         "TEST_NAMESPACE": dev_config.namespace,
         "READINESS_PROBE_IMAGE": f"{dev_config.repo_url}/{dev_config.readiness_probe_image}",
         "PERFORM_CLEANUP": "true" if cleanup else "false",
+        "WATCH_NAMESPACE": dev_config.namespace,
     }
 
 


### PR DESCRIPTION
This PR ensures the correct env vars are set based on the development config file when using `make run`