### PR TITLE
CLOUDP-92631: mongodb log to stdout

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,6 +9,4 @@ kind: Kustomization
 images:
 - name: mongodb-kubernetes-operator
   newName: quay.io/mongodb/mongodb-kubernetes-operator:0.5.0
-- name: quay.io/mongodb/mongodb-kubernetes-operator
-  newName: 268558157000.dkr.ecr.us-east-1.amazonaws.com/nideg/ubuntu/mongodb-kubernetes-operator
-  newTag: latest
+

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,3 +9,6 @@ kind: Kustomization
 images:
 - name: mongodb-kubernetes-operator
   newName: quay.io/mongodb/mongodb-kubernetes-operator:0.5.0
+- name: quay.io/mongodb/mongodb-kubernetes-operator
+  newName: 268558157000.dkr.ecr.us-east-1.amazonaws.com/nideg/ubuntu/mongodb-kubernetes-operator
+  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,4 +9,3 @@ kind: Kustomization
 images:
 - name: mongodb-kubernetes-operator
   newName: quay.io/mongodb/mongodb-kubernetes-operator:0.5.0
-

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - Changes
   - stability improvements when changing version of MongoDB.
   - increased number of concurrent resources the operator can act on.
+  - mongodb will now send its log to stdout by default.
 
 ## Updated Image Tags
 

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -2,7 +2,6 @@ package automationconfig
 
 import (
 	"fmt"
-	"path"
 	"reflect"
 	"strings"
 
@@ -214,11 +213,6 @@ func (b *Builder) Build() (AutomationConfig, error) {
 			Version:                     b.mongodbVersion,
 			AuthSchemaVersion:           5,
 		}
-		process.SetSystemLog(SystemLog{
-			Destination: "file",
-			Path:        path.Join(DefaultAgentLogPath, "/mongodb.log"),
-			LogAppend:   true,
-		})
 
 		if b.fcv != "" {
 			process.FeatureCompatibilityVersion = b.fcv

--- a/pkg/automationconfig/automation_config_secret_test.go
+++ b/pkg/automationconfig/automation_config_secret_test.go
@@ -93,13 +93,13 @@ func (m mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey) (corev
 }
 
 func (m mockSecretGetUpdateCreator) UpdateSecret(secret corev1.Secret) error {
-	m.secret = &secret
+	//m.secret = &secret
 	return nil
 }
 
 func (m mockSecretGetUpdateCreator) CreateSecret(secret corev1.Secret) error {
 	if m.secret != nil {
-		m.secret = &secret
+		//		m.secret = &secret
 		return nil
 	}
 	return alreadyExistsError()

--- a/pkg/automationconfig/automation_config_secret_test.go
+++ b/pkg/automationconfig/automation_config_secret_test.go
@@ -25,7 +25,7 @@ func TestEnsureSecret(t *testing.T) {
 			SetNamespace(secretNsName.Namespace).
 			Build()
 
-		secretGetUpdateCreator := mockSecretGetUpdateCreator{secret: &s}
+		secretGetUpdateCreator := &mockSecretGetUpdateCreator{secret: &s}
 
 		ac, err := EnsureSecret(secretGetUpdateCreator, secretNsName, []metav1.OwnerReference{}, desiredAutomationConfig)
 		assert.NoError(t, err)
@@ -45,7 +45,7 @@ func TestEnsureSecret(t *testing.T) {
 		existingSecret, err := newAutomationConfigSecret(oldAc, secretNsName)
 		assert.NoError(t, err)
 
-		secretGetUpdateCreator := mockSecretGetUpdateCreator{secret: &existingSecret}
+		secretGetUpdateCreator := &mockSecretGetUpdateCreator{secret: &existingSecret}
 
 		newAc, err := newAutomationConfigBuilder().SetDomain("different-domain").Build()
 		assert.NoError(t, err)
@@ -83,7 +83,7 @@ type mockSecretGetUpdateCreator struct {
 	secret *corev1.Secret
 }
 
-func (m mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey) (corev1.Secret, error) {
+func (m *mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey) (corev1.Secret, error) {
 	if m.secret != nil {
 		if objectKey.Name == m.secret.Name && objectKey.Namespace == m.secret.Namespace {
 			return *m.secret, nil
@@ -92,14 +92,14 @@ func (m mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey) (corev
 	return corev1.Secret{}, notFoundError()
 }
 
-func (m mockSecretGetUpdateCreator) UpdateSecret(secret corev1.Secret) error {
-	//m.secret = &secret
+func (m *mockSecretGetUpdateCreator) UpdateSecret(secret corev1.Secret) error {
+	m.secret = &secret
 	return nil
 }
 
-func (m mockSecretGetUpdateCreator) CreateSecret(secret corev1.Secret) error {
-	if m.secret != nil {
-		//		m.secret = &secret
+func (m *mockSecretGetUpdateCreator) CreateSecret(secret corev1.Secret) error {
+	if m.secret == nil {
+		m.secret = &secret
 		return nil
 	}
 	return alreadyExistsError()


### PR DESCRIPTION
closes #570 
by not defaulting to saving `mongodb` logs to file. Users can still obtain the old behaviour through `spec.additionalMongodConfig`

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
