### PR TITLE
Added required env vars for make run to work correctly

### DIFF
--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -54,7 +54,7 @@ spec:
               nullable: true
               type: object
             arbiters:
-              description: Arbiters is the number arbiters (each counted as a member)
+              description: Arbiters is the number of arbiters (each counted as a member)
                 in the replica set
               type: integer
             featureCompatibilityVersion:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,17 +1,13 @@
-# MongoDB Kubernetes Operator 0.6.2
+# MongoDB Kubernetes Operator 0.6.3
 
 ## Kubernetes Operator
 
 - Changes
-  - stability improvements when changing version of MongoDB.
-  - increased number of concurrent resources the operator can act on.
-  - mongodb will now send its log to stdout by default.
-  - changed the default values for `MONGODB_REPO_URL` and `MONGODB_IMAGE` in the operator deployment
-  - added the support of arbiters for the replica sets.
+  - added the support for arbiters for the replica sets.
 
 ## Updated Image Tags
 
-- mongodb-kubernetes-operator:0.6.2
+- mongodb-kubernetes-operator:0.6.3
 
 _All the images can be found in:_
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## Kubernetes Operator
 
 - Changes
-  - added the support for arbiters for the replica sets.
+  - Members of a Replica Set can be configured as arbiters.
 
 ## Updated Image Tags
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -147,6 +147,11 @@ To remove the operator and any created resources you can run
 make undeploy
 ```
 
+Alternatively, you can run the operator locally with
+
+```sh
+make run
+```
 
 # Running Tests
 

--- a/scripts/dev/get_e2e_env_vars.py
+++ b/scripts/dev/get_e2e_env_vars.py
@@ -27,6 +27,8 @@ def _get_e2e_test_envs(dev_config: DevConfig) -> Dict[str, str]:
         "READINESS_PROBE_IMAGE": f"{dev_config.repo_url}/{dev_config.readiness_probe_image}",
         "PERFORM_CLEANUP": "true" if cleanup else "false",
         "WATCH_NAMESPACE": dev_config.namespace,
+        "MONGODB_IMAGE": "mongo",
+        "MONGODB_REPO_URL": "docker.io",
     }
 
 


### PR DESCRIPTION
This PR adds the missing env vars so that `make run` works correctly.

Updated release notes to remove notes from the 0.6.2 release that went out.