### PR TITLE
Remove safe-to-test label any time a PR is updated

### DIFF
--- a/.github/workflows/remove-label.yml
+++ b/.github/workflows/remove-label.yml
@@ -1,0 +1,13 @@
+name: Remove Label
+on: [ pull_request ]
+jobs:
+  remove-safe-to-test-label:
+    runs-on: ubuntu-latest
+    name: Remove Label
+    steps:
+      - name:
+        uses: buildsville/add-remove-label@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          label: safe-to-test
+          type: remove


### PR DESCRIPTION
### All Submissions:

As discussed, we can remove the label any time a PR is updated to make the fork approval process smoother.

It succeeds in the case of no label.

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you signed all of your commits?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
