### PR TITLE
Fix Dependabot PRs

### DIFF
--- a/.action_templates/e2e-fork-template.yaml
+++ b/.action_templates/e2e-fork-template.yaml
@@ -1,7 +1,8 @@
 name: Run E2E Fork
 jobs:
   - template: setup
-    if: github.event.pull_request.head.repo.full_name != 'mongodb/mongodb-kubernetes-operator' && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    # dependabot gets a read only github token, and so must use pull_request_target instead of pull_request.
+    if: (github.event.pull_request.head.repo.full_name != 'mongodb/mongodb-kubernetes-operator' || github.actor == 'dependabot[bot]') && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
     steps:
     - template: cancel-previous
     - template: checkout-fork

--- a/.action_templates/e2e-fork-template.yaml
+++ b/.action_templates/e2e-fork-template.yaml
@@ -2,7 +2,7 @@ name: Run E2E Fork
 jobs:
   - template: setup
     # dependabot gets a read only github token, and so must use pull_request_target instead of pull_request.
-    if: (github.event.pull_request.head.repo.full_name != 'mongodb/mongodb-kubernetes-operator' || github.actor == 'dependabot[bot]') && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    if: github.actor == 'dependabot[bot]' || (github.event.pull_request.head.repo.full_name != github.repository && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
     steps:
     - template: cancel-previous
     - template: checkout-fork
@@ -23,4 +23,4 @@ jobs:
   - template: e2e-success
 
 events:
-  - template: labeled-pull-request-target
+  - template: pull-request-target

--- a/.action_templates/e2e-pr-template.yaml
+++ b/.action_templates/e2e-pr-template.yaml
@@ -1,7 +1,7 @@
 name: Run E2E
 jobs:
   - template: setup
-    if: github.event.pull_request.head.repo.full_name == 'mongodb/mongodb-kubernetes-operator'
+    if: github.event.pull_request.head.repo.full_name == 'mongodb/mongodb-kubernetes-operator' && github.actor != 'dependabot[bot]'
     steps:
     - template: cancel-previous
     - template: checkout

--- a/.action_templates/e2e-pr-template.yaml
+++ b/.action_templates/e2e-pr-template.yaml
@@ -1,7 +1,8 @@
 name: Run E2E
 jobs:
   - template: setup
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    # run on master, or if a PR is being created from a branch.
+    if: github.ref == 'refs/heads/master' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     steps:
     - template: cancel-previous
     - template: checkout

--- a/.action_templates/e2e-pr-template.yaml
+++ b/.action_templates/e2e-pr-template.yaml
@@ -1,7 +1,7 @@
 name: Run E2E
 jobs:
   - template: setup
-    if: github.event.pull_request.head.repo.full_name == 'mongodb/mongodb-kubernetes-operator' && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     steps:
     - template: cancel-previous
     - template: checkout

--- a/.action_templates/events/pull-request-target.yaml
+++ b/.action_templates/events/pull-request-target.yaml
@@ -1,6 +1,6 @@
 # pull_request_target means that the secrets of this repo will be used.
 pull_request_target:
-  types: [labeled]
+  types: [labeled, synchronize, opened]
   branches:
     - master
   paths-ignore:

--- a/.action_templates/events/pull-request-target.yaml
+++ b/.action_templates/events/pull-request-target.yaml
@@ -1,6 +1,6 @@
 # pull_request_target means that the secrets of this repo will be used.
 pull_request_target:
-  types: [labeled, synchronize, opened]
+  types: [labeled, opened]
   branches:
     - master
   paths-ignore:

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -9,9 +9,9 @@
 
 name: Run E2E Fork
 on:
-  # template: .action_templates/events/labeled-pull-request-target.yaml
+  # template: .action_templates/events/pull-request-target.yaml
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize, opened]
     branches:
     - master
     paths-ignore:
@@ -30,9 +30,8 @@ jobs:
         - pipeline-argument: agent-ubi
         - pipeline-argument: agent-ubuntu
         - pipeline-argument: e2e
-    if: (github.event.pull_request.head.repo.full_name != 'mongodb/mongodb-kubernetes-operator'
-      || github.actor == 'dependabot[bot]') && contains(github.event.pull_request.labels.*.name,
-      'safe-to-test')
+    if: github.actor == 'dependabot[bot]' || (github.event.pull_request.head.repo.full_name
+      != github.repository && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -11,7 +11,7 @@ name: Run E2E Fork
 on:
   # template: .action_templates/events/pull-request-target.yaml
   pull_request_target:
-    types: [labeled, synchronize, opened]
+    types: [labeled, opened]
     branches:
     - master
     paths-ignore:

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -30,8 +30,9 @@ jobs:
         - pipeline-argument: agent-ubi
         - pipeline-argument: agent-ubuntu
         - pipeline-argument: e2e
-    if: github.event.pull_request.head.repo.full_name != 'mongodb/mongodb-kubernetes-operator'
-      && contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    if: (github.event.pull_request.head.repo.full_name != 'mongodb/mongodb-kubernetes-operator'
+      || github.actor == 'dependabot[bot]') && contains(github.event.pull_request.labels.*.name,
+      'safe-to-test')
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,8 +37,8 @@ jobs:
         - pipeline-argument: agent-ubi
         - pipeline-argument: agent-ubuntu
         - pipeline-argument: e2e
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor
-      != 'dependabot[bot]'
+    if: github.ref == 'refs/heads/master' || (github.event.pull_request.head.repo.full_name
+      == github.repository && github.actor != 'dependabot[bot]')
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,8 +37,8 @@ jobs:
         - pipeline-argument: agent-ubi
         - pipeline-argument: agent-ubuntu
         - pipeline-argument: e2e
-    if: github.event.pull_request.head.repo.full_name == 'mongodb/mongodb-kubernetes-operator'
-      && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor
+      != 'dependabot[bot]'
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,7 @@ jobs:
         - pipeline-argument: agent-ubuntu
         - pipeline-argument: e2e
     if: github.event.pull_request.head.repo.full_name == 'mongodb/mongodb-kubernetes-operator'
+      && github.actor != 'dependabot[bot]'
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/mongodb/sonar@0.0.11#egg=sonar
-git+https://github.com/chatton/GithubActionTemplates@v0.0.2
+git+https://github.com/chatton/GithubActionTemplates@v0.0.4
 docker==4.3.1
 kubernetes==11.0.0
 jinja2==2.11.3


### PR DESCRIPTION
Dependabot PRs are supplied with a **read only** GitHub token. This means that secrets are not passed to our tests, which means our tests cannot run.

This PR updates the condition for which our tests run which should allow the use of the `safe-to-test` label on dependabot PRs.