### PR TITLE
CLOUDP-91632: E2E tests should fail fast if the operator pod doesn't reach READY state

### DIFF
--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -170,7 +170,7 @@ func deployOperator() error {
 		return errors.Errorf("error building operator deployment: %s", err)
 	}
 
-	if err := wait.PollImmediate(time.Second, time.Duration(30)*time.Second, hasDeploymentRequiredReplicas(dep)); err != nil {
+	if err := wait.PollImmediate(time.Second, 30*time.Second, hasDeploymentRequiredReplicas(dep)); err != nil {
 		return errors.New("error building operator deployment: the deployment does not have the required replicas")
 	}
 

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -187,6 +187,9 @@ func hasDeploymentRequiredReplicas(dep *appsv1.Deployment) wait.ConditionFunc {
 				Namespace: e2eutil.OperatorNamespace},
 			dep)
 		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				return false, nil
+			}
 			return false, errors.Errorf("error getting operator deployment: %s", err)
 		}
 		if dep.Status.ReadyReplicas == *dep.Spec.Replicas {

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -179,7 +179,7 @@ func deployOperator() error {
 }
 
 // hasDeploymentRequiredReplicas returns a condition function that indicates whether the given deployment
-// currently has the required amount of replicas
+// currently has the required amount of replicas in the ready state as specified in spec.replicas
 func hasDeploymentRequiredReplicas(dep *appsv1.Deployment) wait.ConditionFunc {
 	return func() (bool, error) {
 		err := e2eutil.TestClient.Get(context.TODO(),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Tested it by changing the parameters of the field "operatorImage" in the testConfig on line 28 in test/e2e/setup/setup.go to "blah".