### PR TITLE
Use "run" script instead of GH Action to install kind

### DIFF
--- a/.action_templates/steps/setup-kind-cluster.yaml
+++ b/.action_templates/steps/setup-kind-cluster.yaml
@@ -1,6 +1,8 @@
-- name: Start MiniKube
-  id: minikube
-  uses: medyagh/setup-minikube@master
+- name: Setup Kind Cluster
+  run: |
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+    chmod +x ./kind
+    ./kind create cluster
 
 - name: Install CRD
   run: kubectl apply -f config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml

--- a/.action_templates/steps/setup-kind-cluster.yaml
+++ b/.action_templates/steps/setup-kind-cluster.yaml
@@ -1,7 +1,6 @@
-- name: Setup Kind Cluster
-  uses: engineerd/setup-kind@v0.5.0
-  with:
-    version: "v0.8.1"
+- name: Start MiniKube
+  id: minikube
+  uses: medyagh/setup-minikube@master
 
 - name: Install CRD
   run: kubectl apply -f config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -97,9 +97,11 @@ jobs:
     - name: Install Python Dependencies
       run: pip install -r requirements.txt
     # template: .action_templates/steps/setup-kind-cluster.yaml
-    - name: Start MiniKube
-      id: minikube
-      uses: medyagh/setup-minikube@master
+    - name: Setup Kind Cluster
+      run: |
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+        chmod +x ./kind
+        ./kind create cluster
 
     - name: Install CRD
       run: kubectl apply -f config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -97,10 +97,9 @@ jobs:
     - name: Install Python Dependencies
       run: pip install -r requirements.txt
     # template: .action_templates/steps/setup-kind-cluster.yaml
-    - name: Setup Kind Cluster
-      uses: engineerd/setup-kind@v0.5.0
-      with:
-        version: v0.8.1
+    - name: Start MiniKube
+      id: minikube
+      uses: medyagh/setup-minikube@master
 
     - name: Install CRD
       run: kubectl apply -f config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -201,9 +201,11 @@ jobs:
     - name: Install Python Dependencies
       run: pip install -r requirements.txt
     # template: .action_templates/steps/setup-kind-cluster.yaml
-    - name: Start MiniKube
-      id: minikube
-      uses: medyagh/setup-minikube@master
+    - name: Setup Kind Cluster
+      run: |
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+        chmod +x ./kind
+        ./kind create cluster
 
       if: steps.last_run_status.outputs.last_run_status != 'success'
     - name: Install CRD

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -201,10 +201,9 @@ jobs:
     - name: Install Python Dependencies
       run: pip install -r requirements.txt
     # template: .action_templates/steps/setup-kind-cluster.yaml
-    - name: Setup Kind Cluster
-      uses: engineerd/setup-kind@v0.5.0
-      with:
-        version: v0.8.1
+    - name: Start MiniKube
+      id: minikube
+      uses: medyagh/setup-minikube@master
 
       if: steps.last_run_status.outputs.last_run_status != 'success'
     - name: Install CRD

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -202,9 +202,11 @@ jobs:
     - name: Install Python Dependencies
       run: pip install -r requirements.txt
     # template: .action_templates/steps/setup-kind-cluster.yaml
-    - name: Start MiniKube
-      id: minikube
-      uses: medyagh/setup-minikube@master
+    - name: Setup Kind Cluster
+      run: |
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+        chmod +x ./kind
+        ./kind create cluster
 
       if: steps.last_run_status.outputs.last_run_status != 'success'
     - name: Install CRD

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -202,10 +202,9 @@ jobs:
     - name: Install Python Dependencies
       run: pip install -r requirements.txt
     # template: .action_templates/steps/setup-kind-cluster.yaml
-    - name: Setup Kind Cluster
-      uses: engineerd/setup-kind@v0.5.0
-      with:
-        version: v0.8.1
+    - name: Start MiniKube
+      id: minikube
+      uses: medyagh/setup-minikube@master
 
       if: steps.last_run_status.outputs.last_run_status != 'success'
     - name: Install CRD


### PR DESCRIPTION
Kind GithubAction was causing failures during setup of cluster.

Setting up the cluster manually seems to fix this issue.