### PR TITLE
CLOUDP-93590: Service name configurable

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -528,11 +528,10 @@ func (m MongoDBCommunity) Hosts() []string {
 // this resource which is either the default name resourcename-svc or the user defined name
 func (m MongoDBCommunity) ServiceName() string {
 	serviceName := m.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName
-	if serviceName == "" {
-		return m.Name + "-svc"
-	} else {
+	if serviceName != "" {
 		return serviceName
 	}
+	return m.Name + "-svc"
 }
 
 func (m MongoDBCommunity) AutomationConfigSecretName() string {

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -524,8 +524,7 @@ func (m MongoDBCommunity) Hosts() []string {
 	return hosts
 }
 
-// ServiceName returns the name of the Service that should be created for
-// this resource which is either the default name resourcename-svc or the user defined name
+// ServiceName returns the name of the Service that should be created for this resource
 func (m MongoDBCommunity) ServiceName() string {
 	serviceName := m.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName
 	if serviceName != "" {

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -525,9 +525,14 @@ func (m MongoDBCommunity) Hosts() []string {
 }
 
 // ServiceName returns the name of the Service that should be created for
-// this resource
+// this resource which is either the default name resourcename-svc or the user defined name
 func (m MongoDBCommunity) ServiceName() string {
-	return m.Name + "-svc"
+	serviceName := m.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName
+	if serviceName == "" {
+		return m.Name + "-svc"
+	} else {
+		return serviceName
+	}
 }
 
 func (m MongoDBCommunity) AutomationConfigSecretName() string {

--- a/config/samples/arbitrary_statefulset_configuration/mongodb.com_v1_custom_volume_cr.yaml
+++ b/config/samples/arbitrary_statefulset_configuration/mongodb.com_v1_custom_volume_cr.yaml
@@ -23,6 +23,7 @@ spec:
 
   statefulSet:
     spec:
+        # Name for the service object created by the operator
       serviceName: example-openshift-mongodb-svc
       selector: {}
         # Specifies a size for the data volume different from the default 10Gi

--- a/config/samples/mongodb.com_v1_mongodbcommunity_cr.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_cr.yaml
@@ -23,6 +23,9 @@ spec:
       scramCredentialsSecretName: my-scram
   additionalMongodConfig:
     storage.wiredTiger.engineConfig.journalCompressor: zlib
+  statefulSet:
+    spec:
+      serviceName: newdatabasename
 
 # the user credentials will be generated from this secret
 # once the credentials are generated, this secret is no longer required

--- a/config/samples/mongodb.com_v1_mongodbcommunity_cr.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_cr.yaml
@@ -23,9 +23,6 @@ spec:
       scramCredentialsSecretName: my-scram
   additionalMongodConfig:
     storage.wiredTiger.engineConfig.journalCompressor: zlib
-  statefulSet:
-    spec:
-      serviceName: newdatabasename
 
 # the user credentials will be generated from this secret
 # once the credentials are generated, this secret is no longer required

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
   - Support SHA-1 as an authentication method.
   - Upgraded `mongodbcommunity.mongodbcommunity.mongodb.com` CRD to `v1` from `v1beta1`
     *  Users upgrading their CRD from v1beta1 to v1 need to set: `spec.preserveUnknownFields` to `false` in the CRD file `config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml` before applying the CRD to the cluster.
+  - Made service name configurable in mongdb custom resource with statefulSet.spec.serviceName
 
 ## Updated Image Tags
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -289,6 +289,13 @@ func BasicFunctionality(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 	}
 }
 
+// ServiceHasCorrectName asserts whether the actual service name equals the expected service name
+func ServiceHasCorrectName(mdb *mdbv1.MongoDBCommunity, expectedName string) func(t *testing.T) {
+	return func(t *testing.T) {
+		assert.Equal(t, expectedName, mdb.ServiceName())
+	}
+}
+
 // DeletePod will delete a pod that belongs to this MongoDB resource's StatefulSet
 func DeletePod(mdb *mdbv1.MongoDBCommunity, podNum int) func(*testing.T) {
 	return func(t *testing.T) {

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -289,15 +289,16 @@ func BasicFunctionality(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 	}
 }
 
-// ServiceHasCorrectName asserts whether service with the expected name exists
-func ServiceHasCorrectName(mdb *mdbv1.MongoDBCommunity, expectedName string) func(t *testing.T) {
+// ServiceWithNameExists checks whether a service with the name serviceName exists
+func ServiceWithNameExists(mdb *mdbv1.MongoDBCommunity, serviceName string) func(t *testing.T) {
 	return func(t *testing.T) {
-		serviceNamespacedName := types.NamespacedName{Name: expectedName, Namespace: mdb.Namespace}
+		serviceNamespacedName := types.NamespacedName{Name: serviceName, Namespace: mdb.Namespace}
 		srv := corev1.Service{}
 		err := e2eutil.TestClient.Get(context.TODO(), serviceNamespacedName, &srv)
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Logf("Service with name %s exists", serviceName)
 	}
 }
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -290,9 +290,9 @@ func BasicFunctionality(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 }
 
 // ServiceWithNameExists checks whether a service with the name serviceName exists
-func ServiceWithNameExists(mdb *mdbv1.MongoDBCommunity, serviceName string) func(t *testing.T) {
+func ServiceWithNameExists(serviceName string, namespace string) func(t *testing.T) {
 	return func(t *testing.T) {
-		serviceNamespacedName := types.NamespacedName{Name: serviceName, Namespace: mdb.Namespace}
+		serviceNamespacedName := types.NamespacedName{Name: serviceName, Namespace: namespace}
 		srv := corev1.Service{}
 		err := e2eutil.TestClient.Get(context.TODO(), serviceNamespacedName, &srv)
 		if err != nil {

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -289,10 +289,15 @@ func BasicFunctionality(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 	}
 }
 
-// ServiceHasCorrectName asserts whether the actual service name equals the expected service name
+// ServiceHasCorrectName asserts whether service with the expected name exists
 func ServiceHasCorrectName(mdb *mdbv1.MongoDBCommunity, expectedName string) func(t *testing.T) {
 	return func(t *testing.T) {
-		assert.Equal(t, expectedName, mdb.ServiceName())
+		serviceNamespacedName := types.NamespacedName{Name: expectedName, Namespace: mdb.Namespace}
+		srv := corev1.Service{}
+		err := e2eutil.TestClient.Get(context.TODO(), serviceNamespacedName, &srv)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
+++ b/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
@@ -34,8 +34,8 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 
 	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.Template.Spec.Containers[1].ReadinessProbe = &corev1.Probe{TimeoutSeconds: 100}
 
-	serviceName := "database"
-	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName = serviceName
+	customServiceName := "database"
+	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName = customServiceName
 
 	tester, err := mongotester.FromResource(t, mdb)
 	if err != nil {
@@ -44,7 +44,7 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
-	t.Run("Test setting Service Name", mongodbtests.ServiceWithNameExists(&mdb, serviceName))
+	t.Run("Test setting Service Name", mongodbtests.ServiceWithNameExists(customServiceName, mdb.Namespace))
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 	t.Run("Container has been merged by name", mongodbtests.StatefulSetContainerConditionIsTrue(&mdb, "mongodb-agent", func(container corev1.Container) bool {

--- a/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
+++ b/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
@@ -22,11 +22,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestStatefulSetArbitraryConfig(t *testing.T) {
-	// creates operator/deployment from the yaml files
 	ctx := setup.Setup(t)
 	defer ctx.Teardown()
 
-	// creates basic mongodb resource/custom resource
 	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
 
 	_, err := setup.GeneratePasswordForUser(ctx, user, "")
@@ -36,7 +34,8 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 
 	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.Template.Spec.Containers[1].ReadinessProbe = &corev1.Probe{TimeoutSeconds: 100}
 
-	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName = "database"
+	serviceName := "database"
+	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName = serviceName
 
 	tester, err := mongotester.FromResource(t, mdb)
 	if err != nil {
@@ -45,7 +44,7 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
-	t.Run("Test setting Service Name", mongodbtests.ServiceHasCorrectName(&mdb, "database"))
+	t.Run("Test setting Service Name", mongodbtests.ServiceHasCorrectName(&mdb, serviceName))
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 	t.Run("Container has been merged by name", mongodbtests.StatefulSetContainerConditionIsTrue(&mdb, "mongodb-agent", func(container corev1.Container) bool {

--- a/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
+++ b/test/e2e/statefulset_arbitrary_config/statefulset_arbitrary_config_test.go
@@ -44,7 +44,7 @@ func TestStatefulSetArbitraryConfig(t *testing.T) {
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
-	t.Run("Test setting Service Name", mongodbtests.ServiceHasCorrectName(&mdb, serviceName))
+	t.Run("Test setting Service Name", mongodbtests.ServiceWithNameExists(&mdb, serviceName))
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 	t.Run("Container has been merged by name", mongodbtests.StatefulSetContainerConditionIsTrue(&mdb, "mongodb-agent", func(container corev1.Container) bool {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Tested by adding 
statefulSet:
    spec:
      serviceName: database
to the custom resource yaml file and running make run to observe that the serviceName field now contains database and by setting the service name in statefulset_arbitrary_config_test.go and checking the name is correctly set in mongodbtests.go