### PR TITLE
CLOUDP-65796: Update CRD from v1beta1 to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAMESPACE := $(shell jq -r .namespace < ~/.community-operator-dev/config.json)
 IMG := $(REPO_URL)/$(OPERATOR_IMAGE)
 DOCKERFILE ?= operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=true,crdVersions=v1beta1"
+CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/PROJECT
+++ b/PROJECT
@@ -3,7 +3,7 @@ layout: go.kubebuilder.io/v3
 projectName: mko-v1
 repo: github.com/mongodb/mongodb-kubernetes-operator
 resources:
-- crdVersion: v1beta1
+- crdVersion: v1
   group: mongodbcommunity
   kind: MongoDBCommunity
   version: v1

--- a/api/v1/doc.go
+++ b/api/v1/doc.go
@@ -1,0 +1,4 @@
+package v1
+
+// +k8s:deepcopy-gen=package
+// +versionName=v1

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -90,6 +90,7 @@ type MongoDBCommunitySpec struct {
 	// configuration file: https://docs.mongodb.com/manual/reference/configuration-options/
 	// +kubebuilder:validation:Type=object
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +nullable
 	AdditionalMongodConfig MongodConfiguration `json:"additionalMongodConfig,omitempty"`
 }

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -192,6 +192,7 @@ type AuthenticationRestriction struct {
 // StatefulSetConfiguration holds the optional custom StatefulSet
 // that should be merged into the operator created one.
 type StatefulSetConfiguration struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
 	SpecWrapper StatefulSetSpecWrapper `json:"spec"`
 }
 

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,15 +8,6 @@ metadata:
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Current state of the MongoDB deployment
-    name: Phase
-    type: string
-  - JSONPath: .status.version
-    description: Version of MongoDB server
-    name: Version
-    type: string
   group: mongodbcommunity.mongodb.com
   names:
     kind: MongoDBCommunity
@@ -26,307 +17,317 @@ spec:
     - mdbc
     singular: mongodbcommunity
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MongoDBCommunity is the Schema for the mongodbs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MongoDBCommunitySpec defines the desired state of MongoDB
-          properties:
-            additionalMongodConfig:
-              description: 'AdditionalMongodConfig is additional configuration that
-                can be passed to each data-bearing mongod at runtime. Uses the same
-                structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
-              nullable: true
-              type: object
-            arbiters:
-              description: Arbiters is the number of arbiters (each counted as a member)
-                in the replica set
-              type: integer
-            featureCompatibilityVersion:
-              description: FeatureCompatibilityVersion configures the feature compatibility
-                version that will be set for the deployment
-              type: string
-            members:
-              description: Members is the number of members in the replica set
-              type: integer
-            replicaSetHorizons:
-              description: ReplicaSetHorizons Add this parameter and values if you
-                need your database to be accessed outside of Kubernetes. This setting
-                allows you to provide different DNS settings within the Kubernetes
-                cluster and to the Kubernetes cluster. The Kubernetes Operator uses
-                split horizon DNS for replica set members. This feature allows communication
-                both within the Kubernetes cluster and from outside Kubernetes.
-              items:
-                additionalProperties:
-                  type: string
+  versions:
+  - additionalPrinterColumns:
+    - description: Current state of the MongoDB deployment
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Version of MongoDB server
+      jsonPath: .status.version
+      name: Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: MongoDBCommunity is the Schema for the mongodbs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MongoDBCommunitySpec defines the desired state of MongoDB
+            properties:
+              additionalMongodConfig:
+                description: 'AdditionalMongodConfig is additional configuration that
+                  can be passed to each data-bearing mongod at runtime. Uses the same
+                  structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                nullable: true
                 type: object
-              type: array
-            security:
-              description: Security configures security features, such as TLS, and
-                authentication settings for a deployment
-              properties:
-                authentication:
-                  properties:
-                    ignoreUnknownUsers:
-                      nullable: true
-                      type: boolean
-                    modes:
-                      description: Modes is an array specifying which authentication
-                        methods should be enabled.
-                      items:
-                        enum:
-                        - SCRAM
-                        - SCRAM-SHA-256
-                        - SCRAM-SHA-1
-                        type: string
-                      type: array
-                  required:
-                  - modes
+                x-kubernetes-preserve-unknown-fields: true
+              arbiters:
+                description: Arbiters is the number of arbiters (each counted as a
+                  member) in the replica set
+                type: integer
+              featureCompatibilityVersion:
+                description: FeatureCompatibilityVersion configures the feature compatibility
+                  version that will be set for the deployment
+                type: string
+              members:
+                description: Members is the number of members in the replica set
+                type: integer
+              replicaSetHorizons:
+                description: ReplicaSetHorizons Add this parameter and values if you
+                  need your database to be accessed outside of Kubernetes. This setting
+                  allows you to provide different DNS settings within the Kubernetes
+                  cluster and to the Kubernetes cluster. The Kubernetes Operator uses
+                  split horizon DNS for replica set members. This feature allows communication
+                  both within the Kubernetes cluster and from outside Kubernetes.
+                items:
+                  additionalProperties:
+                    type: string
                   type: object
-                roles:
-                  description: User-specified custom MongoDB roles that should be
-                    configured in the deployment.
-                  items:
-                    description: CustomRole defines a custom MongoDB role.
-                    properties:
-                      authenticationRestrictions:
-                        description: The authentication restrictions the server enforces
-                          on the role.
-                        items:
-                          description: AuthenticationRestriction specifies a list
-                            of IP addresses and CIDR ranges users are allowed to connect
-                            to or from.
-                          properties:
-                            clientSource:
-                              items:
-                                type: string
-                              type: array
-                            serverAddress:
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - clientSource
-                          - serverAddress
-                          type: object
-                        type: array
-                      db:
-                        description: The database of the role.
-                        type: string
-                      privileges:
-                        description: The privileges to grant the role.
-                        items:
-                          description: Privilege defines the actions a role is allowed
-                            to perform on a given resource.
-                          properties:
-                            actions:
-                              items:
-                                type: string
-                              type: array
-                            resource:
-                              description: Resource specifies specifies the resources
-                                upon which a privilege permits actions. See https://docs.mongodb.com/manual/reference/resource-document
-                                for more.
-                              properties:
-                                anyResource:
-                                  type: boolean
-                                cluster:
-                                  type: boolean
-                                collection:
-                                  type: string
-                                db:
-                                  type: string
-                              type: object
-                          required:
-                          - actions
-                          - resource
-                          type: object
-                        type: array
-                      role:
-                        description: The name of the role.
-                        type: string
-                      roles:
-                        description: An array of roles from which this role inherits
-                          privileges.
-                        items:
-                          description: Role is the database role this user should
-                            have
-                          properties:
-                            db:
-                              description: DB is the database the role can act on
-                              type: string
-                            name:
-                              description: Name is the name of the role
-                              type: string
-                          required:
-                          - db
-                          - name
-                          type: object
-                        type: array
-                    required:
-                    - db
-                    - privileges
-                    - role
-                    type: object
-                  type: array
-                tls:
-                  description: TLS configuration for both client-server and server-server
-                    communication
-                  properties:
-                    caConfigMapRef:
-                      description: CaConfigMap is a reference to a ConfigMap containing
-                        the certificate for the CA which signed the server certificates
-                        The certificate is expected to be available under the key
-                        "ca.crt"
-                      properties:
-                        name:
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    certificateKeySecretRef:
-                      description: CertificateKeySecret is a reference to a Secret
-                        containing a private key and certificate to use for TLS. The
-                        key and cert are expected to be PEM encoded and available
-                        at "tls.key" and "tls.crt". This is the same format used for
-                        the standard "kubernetes.io/tls" Secret type, but no specific
-                        type is required.
-                      properties:
-                        name:
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    enabled:
-                      type: boolean
-                    optional:
-                      description: Optional configures if TLS should be required or
-                        optional for connections
-                      type: boolean
-                  required:
-                  - enabled
-                  type: object
-              type: object
-            statefulSet:
-              description: StatefulSetConfiguration holds the optional custom StatefulSet
-                that should be merged into the operator created one.
-              properties:
-                spec:
-                  type: object
-              required:
-              - spec
-              type: object
-            type:
-              description: Type defines which type of MongoDB deployment the resource
-                should create
-              enum:
-              - ReplicaSet
-              type: string
-            users:
-              description: Users specifies the MongoDB users that should be configured
-                in your deployment
-              items:
+                type: array
+              security:
+                description: Security configures security features, such as TLS, and
+                  authentication settings for a deployment
                 properties:
-                  db:
-                    description: DB is the database the user is stored in. Defaults
-                      to "admin"
-                    type: string
-                  name:
-                    description: Name is the username of the user
-                    type: string
-                  passwordSecretRef:
-                    description: PasswordSecretRef is a reference to the secret containing
-                      this user's password
+                  authentication:
                     properties:
-                      key:
-                        description: Key is the key in the secret storing this password.
-                          Defaults to "password"
-                        type: string
-                      name:
-                        description: Name is the name of the secret storing this user's
-                          password
-                        type: string
+                      ignoreUnknownUsers:
+                        default: true
+                        nullable: true
+                        type: boolean
+                      modes:
+                        description: Modes is an array specifying which authentication
+                          methods should be enabled.
+                        items:
+                          enum:
+                          - SCRAM
+                          - SCRAM-SHA-256
+                          - SCRAM-SHA-1
+                          type: string
+                        type: array
                     required:
-                    - name
+                    - modes
                     type: object
                   roles:
-                    description: Roles is an array of roles assigned to this user
+                    description: User-specified custom MongoDB roles that should be
+                      configured in the deployment.
                     items:
-                      description: Role is the database role this user should have
+                      description: CustomRole defines a custom MongoDB role.
                       properties:
+                        authenticationRestrictions:
+                          description: The authentication restrictions the server
+                            enforces on the role.
+                          items:
+                            description: AuthenticationRestriction specifies a list
+                              of IP addresses and CIDR ranges users are allowed to
+                              connect to or from.
+                            properties:
+                              clientSource:
+                                items:
+                                  type: string
+                                type: array
+                              serverAddress:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - clientSource
+                            - serverAddress
+                            type: object
+                          type: array
                         db:
-                          description: DB is the database the role can act on
+                          description: The database of the role.
                           type: string
-                        name:
-                          description: Name is the name of the role
+                        privileges:
+                          description: The privileges to grant the role.
+                          items:
+                            description: Privilege defines the actions a role is allowed
+                              to perform on a given resource.
+                            properties:
+                              actions:
+                                items:
+                                  type: string
+                                type: array
+                              resource:
+                                description: Resource specifies specifies the resources
+                                  upon which a privilege permits actions. See https://docs.mongodb.com/manual/reference/resource-document
+                                  for more.
+                                properties:
+                                  anyResource:
+                                    type: boolean
+                                  cluster:
+                                    type: boolean
+                                  collection:
+                                    type: string
+                                  db:
+                                    type: string
+                                type: object
+                            required:
+                            - actions
+                            - resource
+                            type: object
+                          type: array
+                        role:
+                          description: The name of the role.
                           type: string
+                        roles:
+                          description: An array of roles from which this role inherits
+                            privileges.
+                          items:
+                            description: Role is the database role this user should
+                              have
+                            properties:
+                              db:
+                                description: DB is the database the role can act on
+                                type: string
+                              name:
+                                description: Name is the name of the role
+                                type: string
+                            required:
+                            - db
+                            - name
+                            type: object
+                          type: array
                       required:
                       - db
-                      - name
+                      - privileges
+                      - role
                       type: object
                     type: array
-                  scramCredentialsSecretName:
-                    description: ScramCredentialsSecretName appended by string "scram-credentials"
-                      is the name of the secret object created by the mongoDB operator
-                      for storing SCRAM credentials
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                required:
-                - name
-                - passwordSecretRef
-                - roles
-                - scramCredentialsSecretName
+                  tls:
+                    description: TLS configuration for both client-server and server-server
+                      communication
+                    properties:
+                      caConfigMapRef:
+                        description: CaConfigMap is a reference to a ConfigMap containing
+                          the certificate for the CA which signed the server certificates
+                          The certificate is expected to be available under the key
+                          "ca.crt"
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      certificateKeySecretRef:
+                        description: CertificateKeySecret is a reference to a Secret
+                          containing a private key and certificate to use for TLS.
+                          The key and cert are expected to be PEM encoded and available
+                          at "tls.key" and "tls.crt". This is the same format used
+                          for the standard "kubernetes.io/tls" Secret type, but no
+                          specific type is required.
+                        properties:
+                          name:
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      enabled:
+                        type: boolean
+                      optional:
+                        description: Optional configures if TLS should be required
+                          or optional for connections
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
                 type: object
-              type: array
-            version:
-              description: Version defines which version of MongoDB will be used
-              type: string
-          required:
-          - security
-          - type
-          - users
-          - version
-          type: object
-        status:
-          description: MongoDBCommunityStatus defines the observed state of MongoDB
-          properties:
-            currentMongoDBMembers:
-              type: integer
-            currentStatefulSetReplicas:
-              type: integer
-            message:
-              type: string
-            mongoUri:
-              type: string
-            phase:
-              type: string
-          required:
-          - currentMongoDBMembers
-          - currentStatefulSetReplicas
-          - mongoUri
-          - phase
-          type: object
-      type: object
-  version: v1
-  versions:
-  - name: v1
+              statefulSet:
+                description: StatefulSetConfiguration holds the optional custom StatefulSet
+                  that should be merged into the operator created one.
+                properties:
+                  spec:
+                    type: object
+                required:
+                - spec
+                type: object
+              type:
+                description: Type defines which type of MongoDB deployment the resource
+                  should create
+                enum:
+                - ReplicaSet
+                type: string
+              users:
+                description: Users specifies the MongoDB users that should be configured
+                  in your deployment
+                items:
+                  properties:
+                    db:
+                      description: DB is the database the user is stored in. Defaults
+                        to "admin"
+                      type: string
+                    name:
+                      description: Name is the username of the user
+                      type: string
+                    passwordSecretRef:
+                      description: PasswordSecretRef is a reference to the secret
+                        containing this user's password
+                      properties:
+                        key:
+                          description: Key is the key in the secret storing this password.
+                            Defaults to "password"
+                          type: string
+                        name:
+                          description: Name is the name of the secret storing this
+                            user's password
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    roles:
+                      description: Roles is an array of roles assigned to this user
+                      items:
+                        description: Role is the database role this user should have
+                        properties:
+                          db:
+                            description: DB is the database the role can act on
+                            type: string
+                          name:
+                            description: Name is the name of the role
+                            type: string
+                        required:
+                        - db
+                        - name
+                        type: object
+                      type: array
+                    scramCredentialsSecretName:
+                      description: ScramCredentialsSecretName appended by string "scram-credentials"
+                        is the name of the secret object created by the mongoDB operator
+                        for storing SCRAM credentials
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  - passwordSecretRef
+                  - roles
+                  - scramCredentialsSecretName
+                  type: object
+                type: array
+              version:
+                description: Version defines which version of MongoDB will be used
+                type: string
+            required:
+            - security
+            - type
+            - users
+            - version
+            type: object
+          status:
+            description: MongoDBCommunityStatus defines the observed state of MongoDB
+            properties:
+              currentMongoDBMembers:
+                type: integer
+              currentStatefulSetReplicas:
+                type: integer
+              message:
+                type: string
+              mongoUri:
+                type: string
+              phase:
+                type: string
+            required:
+            - currentMongoDBMembers
+            - currentStatefulSetReplicas
+            - mongoUri
+            - phase
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -230,6 +230,7 @@ spec:
                 properties:
                   spec:
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
                 - spec
                 type: object

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -4,13 +4,13 @@ nameReference:
   version: v1
   fieldSpecs:
   - kind: CustomResourceDefinition
-    version: v1beta1
+    version: v1
     group: apiextensions.k8s.io
     path: spec/conversion/webhook/clientConfig/service/name
 
 namespace:
 - kind: CustomResourceDefinition
-  version: v1beta1
+  version: v1
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 
-apiVersion: kustomize.config.k8s.io/v1beta1
+apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 images:
 - name: mongodb-kubernetes-operator

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
   - Members of a Replica Set can be configured as arbiters.
   - Reduce the number of permissions for operator role.
   - Support SHA-1 as an authentication method.
+  - Upgraded `mongodbcommunity.mongodbcommunity.mongodb.com` CRD to `v1` from `v1beta1`
+    *  Users upgrading their CRD from v1beta1 to v1 need to set: `spec.preserveUnknownFields` to `false` in the CRD file `config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml` before applying the CRD to the cluster.
 
 ## Updated Image Tags
 


### PR DESCRIPTION
Kubernetes is removing support for `v1beta1` CRD from version 1.22. This PR migrates the Community CRD to version `v1`.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
