### PR TITLE
CLOUDP 90175: cleanup all resources

### DIFF
--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -45,7 +45,6 @@ def _prepare_test_environment(config_file: str) -> None:
             client.V1Namespace(metadata=dict(name=dev_config.namespace))
         )
     )
-    _delete_test_pod(config_file)
 
     print("Creating Role")
     k8s_conditions.ignore_if_already_exists(
@@ -71,7 +70,7 @@ def _prepare_test_environment(config_file: str) -> None:
 
 def _delete_test_pod(config_file: str) -> None:
     """
-    _delete_testrunner_pod deletes the test runner pod
+    _delete_test_pod deletes the test runner pod
     if it already exists.
     """
     dev_config = load_config(config_file)
@@ -246,6 +245,7 @@ def main() -> int:
         exceptions_to_ignore=ApiException,
     ):
         return 1
+    _delete_test_pod(args.config_file)
     return 0
 
 

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -38,8 +38,8 @@ func (*CleanupOptions) ApplyToCreate(*client.CreateOptions) {}
 
 // Context tracks cleanup functions to be called at the end of a test.
 type Context struct {
-	// shouldPerformCleanup indicates whether or not cleanup should happen after this test
-	shouldPerformCleanup bool
+	// ShouldPerformCleanup indicates whether or not cleanup should happen after this test
+	ShouldPerformCleanup bool
 
 	// ExecutionId is a unique identifier for this test run.
 	ExecutionId string
@@ -59,12 +59,12 @@ func NewContext(t *testing.T, performCleanup bool) (*Context, error) {
 		return nil, err
 	}
 
-	return &Context{t: t, ExecutionId: testId, shouldPerformCleanup: performCleanup}, nil
+	return &Context{t: t, ExecutionId: testId, ShouldPerformCleanup: performCleanup}, nil
 }
 
 // Teardown is called at the end of a test.
 func (ctx *Context) Teardown() {
-	if !ctx.shouldPerformCleanup {
+	if !ctx.ShouldPerformCleanup {
 		return
 	}
 	for _, fn := range ctx.cleanupFuncs {

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -38,8 +38,8 @@ func (*CleanupOptions) ApplyToCreate(*client.CreateOptions) {}
 
 // Context tracks cleanup functions to be called at the end of a test.
 type Context struct {
-	// ShouldPerformCleanup indicates whether or not cleanup should happen after this test
-	ShouldPerformCleanup bool
+	// shouldPerformCleanup indicates whether or not cleanup should happen after this test
+	shouldPerformCleanup bool
 
 	// ExecutionId is a unique identifier for this test run.
 	ExecutionId string
@@ -59,12 +59,12 @@ func NewContext(t *testing.T, performCleanup bool) (*Context, error) {
 		return nil, err
 	}
 
-	return &Context{t: t, ExecutionId: testId, ShouldPerformCleanup: performCleanup}, nil
+	return &Context{t: t, ExecutionId: testId, shouldPerformCleanup: performCleanup}, nil
 }
 
 // Teardown is called at the end of a test.
 func (ctx *Context) Teardown() {
-	if !ctx.ShouldPerformCleanup {
+	if !ctx.shouldPerformCleanup {
 		return
 	}
 	for _, fn := range ctx.cleanupFuncs {

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -46,7 +46,7 @@ func Setup(t *testing.T) *e2eutil.Context {
 		t.Fatal(err)
 	}
 
-	if err := deployOperator(); err != nil {
+	if err := deployOperator(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +130,8 @@ func deployDir() string {
 	return envvar.GetEnvOrDefault(deployDirEnv, "/workspace/config/manager")
 }
 
-func deployOperator() error {
+func deployOperator(ctx *e2eutil.Context) error {
+
 	testConfig := loadTestConfigFromEnv()
 
 	e2eutil.OperatorNamespace = testConfig.namespace
@@ -141,24 +142,24 @@ func deployOperator() error {
 	}
 	fmt.Printf("Setting namespace to watch to %s\n", watchNamespace)
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(roleDir(), "role.yaml"), &rbacv1.Role{}, withNamespace(testConfig.namespace)); err != nil {
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(roleDir(), "role.yaml"), &rbacv1.Role{}, withNamespace(testConfig.namespace)); err != nil {
 		return errors.Errorf("error building operator role: %s", err)
 	}
 	fmt.Println("Successfully created the operator Role")
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(roleDir(), "service_account.yaml"), &corev1.ServiceAccount{}, withNamespace(testConfig.namespace)); err != nil {
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(roleDir(), "service_account.yaml"), &corev1.ServiceAccount{}, withNamespace(testConfig.namespace)); err != nil {
 		return errors.Errorf("error building operator service account: %s", err)
 	}
 	fmt.Println("Successfully created the operator Service Account")
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(roleDir(), "role_binding.yaml"), &rbacv1.RoleBinding{}, withNamespace(testConfig.namespace)); err != nil {
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(roleDir(), "role_binding.yaml"), &rbacv1.RoleBinding{}, withNamespace(testConfig.namespace)); err != nil {
 		return errors.Errorf("error building operator role binding: %s", err)
 	}
 	fmt.Println("Successfully created the operator Role Binding")
 
 	dep := &appsv1.Deployment{}
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(deployDir(), "manager.yaml"),
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(deployDir(), "manager.yaml"),
 		dep,
 		withNamespace(testConfig.namespace),
 		withOperatorImage(testConfig.operatorImage),
@@ -201,7 +202,7 @@ func hasDeploymentRequiredReplicas(dep *appsv1.Deployment) wait.ConditionFunc {
 
 // buildKubernetesResourceFromYamlFile will create the kubernetes resource defined in yamlFilePath. All of the functional options
 // provided will be applied before creation.
-func buildKubernetesResourceFromYamlFile(yamlFilePath string, obj client.Object, options ...func(obj runtime.Object)) error {
+func buildKubernetesResourceFromYamlFile(ctx *e2eutil.Context, yamlFilePath string, obj client.Object, options ...func(obj runtime.Object)) error {
 	data, err := ioutil.ReadFile(yamlFilePath)
 	if err != nil {
 		return errors.Errorf("error reading file: %s", err)
@@ -215,7 +216,7 @@ func buildKubernetesResourceFromYamlFile(yamlFilePath string, obj client.Object,
 		opt(obj)
 	}
 
-	return createOrUpdate(obj)
+	return createOrUpdate(obj, ctx)
 }
 
 // marshalRuntimeObjectFromYAMLBytes accepts the bytes of a yaml resource
@@ -228,8 +229,8 @@ func marshalRuntimeObjectFromYAMLBytes(bytes []byte, obj runtime.Object) error {
 	return json.Unmarshal(jsonBytes, &obj)
 }
 
-func createOrUpdate(obj client.Object) error {
-	if err := e2eutil.TestClient.Create(context.TODO(), obj, &e2eutil.CleanupOptions{}); err != nil {
+func createOrUpdate(obj client.Object, ctx *e2eutil.Context) error {
+	if err := e2eutil.TestClient.Create(context.TODO(), obj, &e2eutil.CleanupOptions{TestContext: ctx}); err != nil {
 		if apiErrors.IsAlreadyExists(err) {
 			return e2eutil.TestClient.Update(context.TODO(), obj)
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Tested by running e2e replica_set test and checking after that the following resources are not existing:
e2e-test pod, serviceaccount, clusterrole, clusterrolebinding
as well as the
mongodb-kubernetes-operator role, service account, role binding and deployment.
I did not delete the namespace.


