### PR TITLE
CLOUDP-90175: cleanup all resources

### DIFF
--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -10,10 +10,12 @@ import argparse
 import sys
 import yaml
 
-TEST_POD_NAME = "e2e-test"
-TEST_CLUSTER_ROLE_NAME = "e2e-test"
-TEST_CLUSTER_ROLE_BINDING_NAME = "e2e-test"
-TEST_SERVICE_ACCOUNT_NAME = "e2e-test"
+(
+    TEST_POD_NAME,
+    TEST_CLUSTER_ROLE_NAME,
+    TEST_CLUSTER_ROLE_BINDING_NAME,
+    TEST_SERVICE_ACCOUNT_NAME,
+) = "e2e-test"
 
 
 def load_yaml_from_file(path: str) -> Dict:
@@ -35,7 +37,7 @@ def _load_test_role_binding() -> Dict:
 
 def _prepare_test_environment(config_file: str) -> None:
     """
-    _prepare_testrunner_environment ensures that the namespace, cluster role,
+    _prepare_test_environment ensures that the namespace, cluster role,
     cluster role binding and service account are created for the test pod.
     """
     rbacv1 = client.RbacAuthorizationV1Api()
@@ -148,7 +150,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
         timeout=60,
         exceptions_to_ignore=ApiException,
     ):
-        raise Exception("Could not create test_runner pod!")
+        raise Exception("Could not create test pod!")
 
 
 def wait_for_pod_to_be_running(

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -11,9 +11,9 @@ import sys
 import yaml
 
 TEST_POD_NAME = "e2e-test"
-TEST_CLUSTER_ROLE_NAME= "e2e-test"
-TEST_CLUSTER_ROLE_BINDING_NAME="e2e-test"
-TEST_SERVICE_ACCOUNT_NAME="e2e-test"
+TEST_CLUSTER_ROLE_NAME = "e2e-test"
+TEST_CLUSTER_ROLE_BINDING_NAME = "e2e-test"
+TEST_SERVICE_ACCOUNT_NAME = "e2e-test"
 
 
 def load_yaml_from_file(path: str) -> Dict:
@@ -186,7 +186,9 @@ def _delete_test_environment(config_file: str) -> None:
     )
 
     k8s_conditions.ignore_if_doesnt_exist(
-        lambda: corev1.delete_namespaced_service_account(TEST_SERVICE_ACCOUNT_NAME, dev_config.namespace)
+        lambda: corev1.delete_namespaced_service_account(
+            TEST_SERVICE_ACCOUNT_NAME, dev_config.namespace
+        )
     )
 
 

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -10,12 +10,10 @@ import argparse
 import sys
 import yaml
 
-(
-    TEST_POD_NAME,
-    TEST_CLUSTER_ROLE_NAME,
-    TEST_CLUSTER_ROLE_BINDING_NAME,
-    TEST_SERVICE_ACCOUNT_NAME,
-) = "e2e-test"
+TEST_POD_NAME = "e2e-test"
+TEST_CLUSTER_ROLE_NAME = "e2e-test"
+TEST_CLUSTER_ROLE_BINDING_NAME = "e2e-test"
+TEST_SERVICE_ACCOUNT_NAME = "e2e-test"
 
 
 def load_yaml_from_file(path: str) -> Dict:

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -35,8 +35,8 @@ def _load_test_role_binding() -> Dict:
 
 def _prepare_test_environment(config_file: str) -> None:
     """
-    _prepare_testrunner_environment ensures the ServiceAccount,
-    Role and ClusterRole and bindings are created for the test runner.
+    _prepare_testrunner_environment ensures that the namespace, cluster role,
+    cluster role binding and service account are created for the test pod.
     """
     rbacv1 = client.RbacAuthorizationV1Api()
     corev1 = client.CoreV1Api()
@@ -49,12 +49,12 @@ def _prepare_test_environment(config_file: str) -> None:
         )
     )
 
-    print("Creating Role")
+    print("Creating Cluster Role")
     k8s_conditions.ignore_if_already_exists(
         lambda: rbacv1.create_cluster_role(_load_test_role())
     )
 
-    print("Creating Role Binding")
+    print("Creating Cluster Role Binding")
     role_binding = _load_test_role_binding()
     # set namespace specified in config.json
     role_binding["subjects"][0]["namespace"] = dev_config.namespace
@@ -63,7 +63,7 @@ def _prepare_test_environment(config_file: str) -> None:
         lambda: rbacv1.create_cluster_role_binding(role_binding)
     )
 
-    print("Creating ServiceAccount")
+    print("Creating Service Account")
     k8s_conditions.ignore_if_already_exists(
         lambda: corev1.create_namespaced_service_account(
             dev_config.namespace, _load_test_service_account()
@@ -170,8 +170,8 @@ def wait_for_pod_to_be_running(
 
 def _delete_test_environment(config_file: str) -> None:
     """
-    _delete_test_environment deletes the cluster role, cluster role binding and service account
-    for the test pod.
+    _delete_test_environment ensures that the cluster role, cluster role binding and service account
+    for the test pod are deleted.
     """
     rbacv1 = client.RbacAuthorizationV1Api()
     corev1 = client.CoreV1Api()
@@ -257,8 +257,7 @@ def prepare_and_run_test(args: argparse.Namespace, dev_config: DevConfig) -> Non
 
 def delete_test_resources(config_file: str) -> None:
     """
-    delete_test_resources ensures the resources that are created
-    for the test are deleted.
+    delete_test_resources ensures that the test environment and test pod are deleted.
     """
     _delete_test_environment(config_file)
     _delete_test_pod(config_file)

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -37,12 +37,15 @@ def _load_test_role_binding() -> Dict:
 
 def _prepare_test_environment(config_file: str) -> None:
     """
-    _prepare_test_environment ensures that the namespace, cluster role,
-    cluster role binding and service account are created for the test pod.
+    _prepare_test_environment ensures that the old test pod is deleted
+    and that namespace, cluster role, cluster role binding and service account
+    are created for the test pod.
     """
     rbacv1 = client.RbacAuthorizationV1Api()
     corev1 = client.CoreV1Api()
     dev_config = load_config(config_file)
+
+    _delete_test_pod(config_file)
 
     print("Creating Namespace")
     k8s_conditions.ignore_if_already_exists(
@@ -257,14 +260,6 @@ def prepare_and_run_test(args: argparse.Namespace, dev_config: DevConfig) -> Non
         print(line.decode("utf-8").rstrip())
 
 
-def delete_test_resources(config_file: str) -> None:
-    """
-    delete_test_resources ensures that the test environment and test pod are deleted.
-    """
-    _delete_test_environment(config_file)
-    _delete_test_pod(config_file)
-
-
 def main() -> int:
     args = parse_args()
     config.load_kube_config()
@@ -281,7 +276,7 @@ def main() -> int:
         exceptions_to_ignore=ApiException,
     ):
         return 1
-    delete_test_resources(args.config_file)
+    _delete_test_environment(args.config_file)
     return 0
 
 

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -45,7 +45,6 @@ def _prepare_test_environment(config_file: str) -> None:
             client.V1Namespace(metadata=dict(name=dev_config.namespace))
         )
     )
-    _delete_test_pod(config_file)
 
     print("Creating Role")
     k8s_conditions.ignore_if_already_exists(
@@ -71,7 +70,7 @@ def _prepare_test_environment(config_file: str) -> None:
 
 def _delete_test_pod(config_file: str) -> None:
     """
-    _delete_testrunner_pod deletes the test runner pod
+    _delete_test_pod deletes the test runner pod
     if it already exists.
     """
     dev_config = load_config(config_file)
@@ -246,6 +245,7 @@ def main() -> int:
         exceptions_to_ignore=ApiException,
     ):
         return 1
+    _delete_test_pod(args.config_file)
     return 0
 
 

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -38,8 +38,8 @@ func (*CleanupOptions) ApplyToCreate(*client.CreateOptions) {}
 
 // Context tracks cleanup functions to be called at the end of a test.
 type Context struct {
-	// shouldPerformCleanup indicates whether or not cleanup should happen after this test
-	shouldPerformCleanup bool
+	// ShouldPerformCleanup indicates whether or not cleanup should happen after this test
+	ShouldPerformCleanup bool
 
 	// ExecutionId is a unique identifier for this test run.
 	ExecutionId string
@@ -59,12 +59,12 @@ func NewContext(t *testing.T, performCleanup bool) (*Context, error) {
 		return nil, err
 	}
 
-	return &Context{t: t, ExecutionId: testId, shouldPerformCleanup: performCleanup}, nil
+	return &Context{t: t, ExecutionId: testId, ShouldPerformCleanup: performCleanup}, nil
 }
 
 // Teardown is called at the end of a test.
 func (ctx *Context) Teardown() {
-	if !ctx.shouldPerformCleanup {
+	if !ctx.ShouldPerformCleanup {
 		return
 	}
 	for _, fn := range ctx.cleanupFuncs {

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -38,8 +38,8 @@ func (*CleanupOptions) ApplyToCreate(*client.CreateOptions) {}
 
 // Context tracks cleanup functions to be called at the end of a test.
 type Context struct {
-	// ShouldPerformCleanup indicates whether or not cleanup should happen after this test
-	ShouldPerformCleanup bool
+	// shouldPerformCleanup indicates whether or not cleanup should happen after this test
+	shouldPerformCleanup bool
 
 	// ExecutionId is a unique identifier for this test run.
 	ExecutionId string
@@ -59,12 +59,12 @@ func NewContext(t *testing.T, performCleanup bool) (*Context, error) {
 		return nil, err
 	}
 
-	return &Context{t: t, ExecutionId: testId, ShouldPerformCleanup: performCleanup}, nil
+	return &Context{t: t, ExecutionId: testId, shouldPerformCleanup: performCleanup}, nil
 }
 
 // Teardown is called at the end of a test.
 func (ctx *Context) Teardown() {
-	if !ctx.ShouldPerformCleanup {
+	if !ctx.shouldPerformCleanup {
 		return
 	}
 	for _, fn := range ctx.cleanupFuncs {

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -216,7 +216,7 @@ func buildKubernetesResourceFromYamlFile(ctx *e2eutil.Context, yamlFilePath stri
 		opt(obj)
 	}
 
-	return createOrUpdate(obj, ctx)
+	return createOrUpdate(ctx, obj)
 }
 
 // marshalRuntimeObjectFromYAMLBytes accepts the bytes of a yaml resource
@@ -229,7 +229,7 @@ func marshalRuntimeObjectFromYAMLBytes(bytes []byte, obj runtime.Object) error {
 	return json.Unmarshal(jsonBytes, &obj)
 }
 
-func createOrUpdate(obj client.Object, ctx *e2eutil.Context) error {
+func createOrUpdate(ctx *e2eutil.Context, obj client.Object) error {
 	if err := e2eutil.TestClient.Create(context.TODO(), obj, &e2eutil.CleanupOptions{TestContext: ctx}); err != nil {
 		if apiErrors.IsAlreadyExists(err) {
 			return e2eutil.TestClient.Update(context.TODO(), obj)

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -46,7 +46,7 @@ func Setup(t *testing.T) *e2eutil.Context {
 		t.Fatal(err)
 	}
 
-	if err := deployOperator(); err != nil {
+	if err := deployOperator(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +130,8 @@ func deployDir() string {
 	return envvar.GetEnvOrDefault(deployDirEnv, "/workspace/config/manager")
 }
 
-func deployOperator() error {
+func deployOperator(ctx *e2eutil.Context) error {
+
 	testConfig := loadTestConfigFromEnv()
 
 	e2eutil.OperatorNamespace = testConfig.namespace
@@ -141,24 +142,24 @@ func deployOperator() error {
 	}
 	fmt.Printf("Setting namespace to watch to %s\n", watchNamespace)
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(roleDir(), "role.yaml"), &rbacv1.Role{}, withNamespace(testConfig.namespace)); err != nil {
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(roleDir(), "role.yaml"), &rbacv1.Role{}, withNamespace(testConfig.namespace)); err != nil {
 		return errors.Errorf("error building operator role: %s", err)
 	}
 	fmt.Println("Successfully created the operator Role")
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(roleDir(), "service_account.yaml"), &corev1.ServiceAccount{}, withNamespace(testConfig.namespace)); err != nil {
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(roleDir(), "service_account.yaml"), &corev1.ServiceAccount{}, withNamespace(testConfig.namespace)); err != nil {
 		return errors.Errorf("error building operator service account: %s", err)
 	}
 	fmt.Println("Successfully created the operator Service Account")
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(roleDir(), "role_binding.yaml"), &rbacv1.RoleBinding{}, withNamespace(testConfig.namespace)); err != nil {
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(roleDir(), "role_binding.yaml"), &rbacv1.RoleBinding{}, withNamespace(testConfig.namespace)); err != nil {
 		return errors.Errorf("error building operator role binding: %s", err)
 	}
 	fmt.Println("Successfully created the operator Role Binding")
 
 	dep := &appsv1.Deployment{}
 
-	if err := buildKubernetesResourceFromYamlFile(path.Join(deployDir(), "manager.yaml"),
+	if err := buildKubernetesResourceFromYamlFile(ctx, path.Join(deployDir(), "manager.yaml"),
 		dep,
 		withNamespace(testConfig.namespace),
 		withOperatorImage(testConfig.operatorImage),
@@ -201,7 +202,7 @@ func hasDeploymentRequiredReplicas(dep *appsv1.Deployment) wait.ConditionFunc {
 
 // buildKubernetesResourceFromYamlFile will create the kubernetes resource defined in yamlFilePath. All of the functional options
 // provided will be applied before creation.
-func buildKubernetesResourceFromYamlFile(yamlFilePath string, obj client.Object, options ...func(obj runtime.Object)) error {
+func buildKubernetesResourceFromYamlFile(ctx *e2eutil.Context, yamlFilePath string, obj client.Object, options ...func(obj runtime.Object)) error {
 	data, err := ioutil.ReadFile(yamlFilePath)
 	if err != nil {
 		return errors.Errorf("error reading file: %s", err)
@@ -215,7 +216,7 @@ func buildKubernetesResourceFromYamlFile(yamlFilePath string, obj client.Object,
 		opt(obj)
 	}
 
-	return createOrUpdate(obj)
+	return createOrUpdate(obj, ctx)
 }
 
 // marshalRuntimeObjectFromYAMLBytes accepts the bytes of a yaml resource
@@ -228,8 +229,8 @@ func marshalRuntimeObjectFromYAMLBytes(bytes []byte, obj runtime.Object) error {
 	return json.Unmarshal(jsonBytes, &obj)
 }
 
-func createOrUpdate(obj client.Object) error {
-	if err := e2eutil.TestClient.Create(context.TODO(), obj, &e2eutil.CleanupOptions{}); err != nil {
+func createOrUpdate(obj client.Object, ctx *e2eutil.Context) error {
+	if err := e2eutil.TestClient.Create(context.TODO(), obj, &e2eutil.CleanupOptions{TestContext: ctx}); err != nil {
 		if apiErrors.IsAlreadyExists(err) {
 			return e2eutil.TestClient.Update(context.TODO(), obj)
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Tested by running replica_set test and observing that after the following resources do not exist:
e2e-test: pod, clusterrole, clusterrolebinding, serviceaccount
mongodb-kubernetes-operator: deployment, role, role binding, service account
I did not delete the namespace.
Note that it will only delete those resources if they do not exist before (the delete functions are registered upon creation, not when existing resources are only updated). Thus, please make sure to delete any e2e-related resources before running a new e2e test.
