### PR TITLE
Fix Github Actions for Release

### DIFF
--- a/.github/workflows/comment-release-pr.yml
+++ b/.github/workflows/comment-release-pr.yml
@@ -1,0 +1,21 @@
+name: Link Github Releases
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  comment:
+    # only link releases on release PRs
+    if: startsWith(github.event.pull_request.title, 'Release MongoDB Kubernetes Operator')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Review and publish the release here: https://github.com/mongodb/mongodb-kubernetes-operator/releases
+            })

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -64,7 +64,7 @@ jobs:
           ATLAS_DATABASE: "${{ secrets.ATLAS_DATABASE }}"
           ATLAS_CONNECTION_STRING: "${{ secrets.ATLAS_CONNECTION_STRING }}"
 
-  merge-release-pr-and-draft-github-release:
+  create-draft-release:
     runs-on: ubuntu-latest
     needs: [release-images]
     steps:
@@ -75,14 +75,6 @@ jobs:
       run: |
         OUTPUT=$(jq -r '."mongodb-kubernetes-operator"' < $GITHUB_WORKSPACE/release.json)
         echo "::set-output name=OUTPUT::$OUTPUT"
-    - name: Merge Release PR
-      uses: pascalgn/automerge-action@v0.14.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        MERGE_LABELS: ""
-        MERGE_DELETE_BRANCH: true
-        MERGE_METHOD: squash
-        MERGE_COMMIT_MESSAGE: "Release MongoDB Kubernetes Operator v${{ steps.release_tag.outputs.OUTPUT }}"
     - name: Create Github Release
       uses: ncipollo/release-action@v1
       with:
@@ -91,25 +83,3 @@ jobs:
         bodyFile: "${{ github.workspace }}/docs/RELEASE_NOTES.md"
         draft: true
         token: ${{ secrets.GITHUB_TOKEN }}
-
-  comment:
-    runs-on: ubuntu-latest
-    needs: [merge-release-pr-and-draft-github-release]
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Determine Release Version
-        id: release_version
-        run: |
-          VERSION=$(jq -r '."mongodb-kubernetes-operator"' < $GITHUB_WORKSPACE/release.json)
-          echo "::set-output name=version::${VERSION}"
-      - uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Review and publish the release here: https://github.com/mongodb/mongodb-kubernetes-operator/releases/tag/v${{ steps.release_version.outputs.version }}'
-            })

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -10,6 +10,6 @@
     
 * Have this PR Reviewed and Approved.
     * Upon approval, all new images for this release will be built and released, and a Github release draft will be created.
-    * No need to merge this PR, when all images are successfully released, the PR will be merged.
+    * Once tests have passed, merge the release PR.
 
 * Review and publish the new GitHub release draft.


### PR DESCRIPTION
There were a few issues with the release process. This PR makes some changes.

* Remove the merge action. This was not working correctly as if there are other E2E tests running, this can cause the merge to fail and interrupt the release process. We can leave this as a manual action.
* Only comment on releases **after** the PR is merged. Previously it was commenting too early.