### PR TITLE
Add test labels to test resources and cleanup before running a new test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ vet:
 
 # Run e2e tests locally using go build while also setting up a proxy in the shell to allow
 # the test to run as if it were inside the cluster. This enables mongodb connectivity while running locally.
-e2e-telepresence: install
+e2e-telepresence: cleanup-e2e install
 	telepresence connect; \
 	telepresence status; \
 	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \
@@ -75,18 +75,21 @@ e2e-telepresence: install
 	telepresence quit
 
 # Run e2e test by deploying test image in kubernetes.
-e2e-k8s: install e2e-image
+e2e-k8s: cleanup-e2e install e2e-image
 	python scripts/dev/e2e.py --perform-cleanup --test $(test)
 
 # Run e2e test locally.
 # e.g. make e2e test=replica_set cleanup=true
-e2e: install
+e2e: cleanup-e2e install
 	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \
 	go test -v -short -timeout=30m -failfast ./test/e2e/$(test)
 
 # Trigger a Github Action of the given test
 e2e-gh:
 	scripts/dev/run_e2e_gh.sh $(test)
+
+cleanup-e2e:
+	kubectl delete mdbc,all -l e2e-test=true
 
 # Generate code
 generate: controller-gen

--- a/pkg/kube/configmap/configmap_builder.go
+++ b/pkg/kube/configmap/configmap_builder.go
@@ -10,6 +10,7 @@ type builder struct {
 	name            string
 	namespace       string
 	ownerReferences []metav1.OwnerReference
+	labels          map[string]string
 }
 
 func (b *builder) SetName(name string) *builder {
@@ -32,12 +33,22 @@ func (b *builder) SetOwnerReferences(ownerReferences []metav1.OwnerReference) *b
 	return b
 }
 
+func (b *builder) SetLabels(labels map[string]string) *builder {
+	newLabels := make(map[string]string)
+	for k, v := range labels {
+		newLabels[k] = v
+	}
+	b.labels = newLabels
+	return b
+}
+
 func (b builder) Build() corev1.ConfigMap {
 	return corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            b.name,
 			Namespace:       b.namespace,
 			OwnerReferences: b.ownerReferences,
+			Labels:          b.labels,
 		},
 		Data: b.data,
 	}
@@ -47,5 +58,6 @@ func Builder() *builder {
 	return &builder{
 		data:            map[string]string{},
 		ownerReferences: []metav1.OwnerReference{},
+		labels:          map[string]string{},
 	}
 }

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -81,6 +81,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
         "metadata": {
             "name": TEST_POD_NAME,
             "namespace": dev_config.namespace,
+            "labels": {"e2e-test": "true"},
         },
         "spec": {
             "restartPolicy": "Never",

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -21,6 +21,13 @@ import (
 
 const testDataDirEnv = "TEST_DATA_DIR"
 
+// TestLabels should be applied to all resources created by tests.
+func TestLabels() map[string]string {
+	return map[string]string{
+		"e2e-test": "true",
+	}
+}
+
 func TestDataDir() string {
 	return envvar.GetEnvOrDefault(testDataDirEnv, "/workspace/testdata")
 }
@@ -51,6 +58,7 @@ func NewTestMongoDB(ctx *Context, name string, namespace string) (mdbv1.MongoDBC
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: mongodbNamespace,
+			Labels:    TestLabels(),
 		},
 		Spec: mdbv1.MongoDBCommunitySpec{
 			Members:  3,
@@ -154,6 +162,7 @@ func NewTestTLSConfig(optional bool) mdbv1.TLS {
 
 func ensureObject(ctx *Context, obj k8sClient.Object) error {
 	key := k8sClient.ObjectKeyFromObject(obj)
+	obj.SetLabels(TestLabels())
 
 	err := TestClient.Get(context.TODO(), key, obj)
 	if err != nil {
@@ -178,7 +187,8 @@ func ensureObject(ctx *Context, obj k8sClient.Object) error {
 func EnsureNamespace(ctx *Context, namespace string) error {
 	return ensureObject(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: TestLabels(),
 		},
 	})
 }

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -75,6 +75,7 @@ func CreateTLSResources(namespace string, ctx *e2eutil.Context, secretType tlsSe
 		SetName(tlsConfig.CaConfigMap.Name).
 		SetNamespace(namespace).
 		SetField("ca.crt", string(ca)).
+		SetLabels(e2eutil.TestLabels()).
 		Build()
 
 	err = e2eutil.TestClient.Create(context.TODO(), &caConfigMap, &e2eutil.CleanupOptions{TestContext: ctx})
@@ -84,6 +85,7 @@ func CreateTLSResources(namespace string, ctx *e2eutil.Context, secretType tlsSe
 
 	certKeySecretBuilder := secret.Builder().
 		SetName(tlsConfig.CertificateKeySecret.Name).
+		SetLabels(e2eutil.TestLabels()).
 		SetNamespace(namespace)
 
 	if secretType == CertKeyPair {
@@ -132,6 +134,7 @@ func GeneratePasswordForUser(ctx *e2eutil.Context, mdbu mdbv1.MongoDBUser, names
 		SetName(mdbu.PasswordSecretRef.Name).
 		SetNamespace(nsp).
 		SetField(passwordKey, password).
+		SetLabels(e2eutil.TestLabels()).
 		Build()
 
 	return password, e2eutil.TestClient.Create(context.TODO(), &passwordSecret, &e2eutil.CleanupOptions{TestContext: ctx})
@@ -245,6 +248,7 @@ func buildKubernetesResourceFromYamlFile(ctx *e2eutil.Context, yamlFilePath stri
 		}
 	}
 
+	obj.SetLabels(e2eutil.TestLabels())
 	return createOrUpdate(ctx, obj)
 }
 


### PR DESCRIPTION
This PR adds the label `e2e-test: true` to resources created by the tests. This allows for easy cleanup. A new make target has been added which runs before running and tests. This causes cleanup of resources before any new tests run.