### PR TITLE
Add SetData method to configmap builder

### DIFF
--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -286,7 +286,7 @@ func createTLSConfigMap(c k8sClient.Client, mdb mdbv1.MongoDBCommunity) error {
 	configMap := configmap.Builder().
 		SetName(mdb.Spec.Security.TLS.CaConfigMap.Name).
 		SetNamespace(mdb.Namespace).
-		SetField("ca.crt", "CERT").
+		SetDataField("ca.crt", "CERT").
 		Build()
 
 	return c.Create(context.TODO(), &configMap)

--- a/pkg/kube/client/mocked_client_test.go
+++ b/pkg/kube/client/mocked_client_test.go
@@ -18,6 +18,7 @@ func TestMockedClient(t *testing.T) {
 		SetName("cm-name").
 		SetNamespace("cm-namespace").
 		SetField("field-1", "value-1").
+		SetData(map[string]string{"key-2": "field-2"}).
 		Build()
 
 	err := mockedClient.Create(context.TODO(), &cm)
@@ -28,6 +29,7 @@ func TestMockedClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "cm-namespace", newCm.Namespace)
 	assert.Equal(t, "cm-name", newCm.Name)
+	assert.Equal(t, newCm.Data, map[string]string{"field-1": "value-1", "key-2": "field-2"})
 
 	svc := service.Builder().
 		SetName("svc-name").

--- a/pkg/kube/client/mocked_client_test.go
+++ b/pkg/kube/client/mocked_client_test.go
@@ -17,7 +17,7 @@ func TestMockedClient(t *testing.T) {
 	cm := configmap.Builder().
 		SetName("cm-name").
 		SetNamespace("cm-namespace").
-		SetField("field-1", "value-1").
+		SetDataField("field-1", "value-1").
 		SetData(map[string]string{"key-2": "field-2"}).
 		Build()
 

--- a/pkg/kube/configmap/configmap_builder.go
+++ b/pkg/kube/configmap/configmap_builder.go
@@ -23,7 +23,7 @@ func (b *builder) SetNamespace(namespace string) *builder {
 	return b
 }
 
-func (b *builder) SetField(key, value string) *builder {
+func (b *builder) SetDataField(key, value string) *builder {
 	b.data[key] = value
 	return b
 }

--- a/pkg/kube/configmap/configmap_builder.go
+++ b/pkg/kube/configmap/configmap_builder.go
@@ -42,6 +42,13 @@ func (b *builder) SetLabels(labels map[string]string) *builder {
 	return b
 }
 
+func (b *builder) SetData(data map[string]string) *builder {
+	for k, v := range data {
+		b.data[k] = v
+	}
+	return b
+}
+
 func (b builder) Build() corev1.ConfigMap {
 	return corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kube/configmap/configmap_builder.go
+++ b/pkg/kube/configmap/configmap_builder.go
@@ -44,7 +44,7 @@ func (b *builder) SetLabels(labels map[string]string) *builder {
 
 func (b *builder) SetData(data map[string]string) *builder {
 	for k, v := range data {
-		b.data[k] = v
+		b.SetDataField(k, v)
 	}
 	return b
 }

--- a/pkg/kube/configmap/configmap_test.go
+++ b/pkg/kube/configmap/configmap_test.go
@@ -33,8 +33,8 @@ func TestReadKey(t *testing.T) {
 		Builder().
 			SetName("name").
 			SetNamespace("namespace").
-			SetField("key1", "value1").
-			SetField("key2", "value2").
+			SetDataField("key1", "value1").
+			SetDataField("key2", "value2").
 			Build(),
 	)
 
@@ -55,8 +55,8 @@ func TestReadData(t *testing.T) {
 		Builder().
 			SetName("name").
 			SetNamespace("namespace").
-			SetField("key1", "value1").
-			SetField("key2", "value2").
+			SetDataField("key1", "value1").
+			SetDataField("key2", "value2").
 			Build(),
 	)
 
@@ -75,7 +75,7 @@ func TestReadFileLikeField(t *testing.T) {
 		Builder().
 			SetName("name").
 			SetNamespace("namespace").
-			SetField("key1", "value1=1\nvalue2=2").
+			SetDataField("key1", "value1=1\nvalue2=2").
 			Build(),
 	)
 
@@ -90,7 +90,7 @@ func TestReadFileLikeField_InvalidExternalKey(t *testing.T) {
 		Builder().
 			SetName("name").
 			SetNamespace("namespace").
-			SetField("key1", "value1=1\nvalue2=2").
+			SetDataField("key1", "value1=1\nvalue2=2").
 			Build(),
 	)
 
@@ -104,7 +104,7 @@ func TestReadFileLikeField_InvalidInternalKey(t *testing.T) {
 		Builder().
 			SetName("name").
 			SetNamespace("namespace").
-			SetField("key1", "value1=1\nvalue2=2").
+			SetDataField("key1", "value1=1\nvalue2=2").
 			Build(),
 	)
 
@@ -140,8 +140,8 @@ func TestUpdateField(t *testing.T) {
 		Builder().
 			SetName("name").
 			SetNamespace("namespace").
-			SetField("field1", "value1").
-			SetField("field2", "value2").
+			SetDataField("field1", "value1").
+			SetDataField("field2", "value2").
 			Build(),
 	)
 	err := UpdateField(getUpdater, nsName("namespace", "name"), "field1", "newValue")

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -74,7 +74,7 @@ func CreateTLSResources(namespace string, ctx *e2eutil.Context, secretType tlsSe
 	caConfigMap := configmap.Builder().
 		SetName(tlsConfig.CaConfigMap.Name).
 		SetNamespace(namespace).
-		SetField("ca.crt", string(ca)).
+		SetDataField("ca.crt", string(ca)).
 		SetLabels(e2eutil.TestLabels()).
 		Build()
 


### PR DESCRIPTION
Fixes the discussion [here](https://github.com/10gen/ops-manager-kubernetes/pull/1737#discussion_r675650367).
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
