### PR TITLE
CLOUDP-96891: operator does not recreate sts on being deleted

### DIFF
--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -86,6 +86,7 @@ func (r *ReplicaSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		For(&mdbv1.MongoDBCommunity{}, builder.WithPredicates(predicates.OnlyOnSpecChange())).
 		Watches(&source.Kind{Type: &corev1.Secret{}}, r.secretWatcher).
+		Owns(&appsv1.StatefulSet{}).
 		Complete(r)
 }
 

--- a/helm-chart/templates/tests/operator.yaml
+++ b/helm-chart/templates/tests/operator.yaml
@@ -1,78 +1,78 @@
-# ---
-# apiVersion: apps/v1
-# kind: Deployment
-# metadata:
-#   annotations:
-#     email: support@mongodb.com
-#   labels:
-#     owner: mongodb
-#   name: {{ .Values.operator.name }}
-#   {{- if .Values.namespace }}
-#   namespace: {{ .Values.namespace }}
-#   {{- end }}
-# spec:
-#   replicas: 1
-#   selector:
-#     matchLabels:
-#       name: {{ .Values.operator.name }}
-#   strategy:
-#     rollingUpdate:
-#       maxUnavailable: 1
-#     type: RollingUpdate
-#   template:
-#     metadata:
-#       labels:
-#         name: {{ .Values.operator.name }}
-#     spec:
-#       affinity:
-#         podAntiAffinity:
-#           requiredDuringSchedulingIgnoredDuringExecution:
-#             - labelSelector:
-#                 matchExpressions:
-#                   - key: name
-#                     operator: In
-#                     values:
-#                       - {{ .Values.operator.name }}
-#               topologyKey: kubernetes.io/hostname
-#       containers:
-#         - command:
-#             - /usr/local/bin/entrypoint
-#           env:
-#             - name: WATCH_NAMESPACE
-# {{- if .Values.operator.watchNamespace}}
-#               value: "{{ .Values.operator.watchNamespace }}"
-# {{- else }}
-#               valueFrom:
-#                 fieldRef:
-#                   fieldPath: metadata.namespace
-# {{- end }}
-#             - name: POD_NAME
-#               valueFrom:
-#                 fieldRef:
-#                   fieldPath: metadata.name
-#             - name: OPERATOR_NAME
-#               value: {{ .Values.operator.name }}
-#             - name: AGENT_IMAGE
-#               value: "{{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ .Values.agent.version }}"
-#             - name: VERSION_UPGRADE_HOOK_IMAGE
-#               value: "{{ .Values.registry.version_upgrade_hook }}/{{ .Values.version_upgrade_hook.name }}:{{ .Values.version_upgrade_hook.version }}"
-#             - name: READINESS_PROBE_IMAGE
-#               value: "{{ .Values.registry.readiness_probe }}/{{ .Values.readiness_probe.name }}:{{ .Values.readiness_probe.version }}"
-#             - name: MONGODB_IMAGE
-#               value: {{ .Values.mongodb.name }}
-#             - name: MONGODB_REPO_URL
-#               value: {{ .Values.mongodb.repo }}
-#           image: {{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}
-#           imagePullPolicy: {{ .Values.registry.pullPolicy}}
-#           name: {{ .Values.operator.deployment_name }}
-#           resources:
-#             limits:
-#               cpu: 1100m
-#               memory: 1Gi
-#             requests:
-#               cpu: 500m
-#               memory: 200Mi
-#           securityContext:
-#             readOnlyRootFilesystem: true
-#             runAsUser: 2000
-#       serviceAccountName: {{ .Values.operator.name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    email: support@mongodb.com
+  labels:
+    owner: mongodb
+  name: {{ .Values.operator.name }}
+  {{- if .Values.namespace }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.operator.name }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.operator.name }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - {{ .Values.operator.name }}
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - command:
+            - /usr/local/bin/entrypoint
+          env:
+            - name: WATCH_NAMESPACE
+{{- if .Values.operator.watchNamespace}}
+              value: "{{ .Values.operator.watchNamespace }}"
+{{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+{{- end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: {{ .Values.operator.name }}
+            - name: AGENT_IMAGE
+              value: "{{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ .Values.agent.version }}"
+            - name: VERSION_UPGRADE_HOOK_IMAGE
+              value: "{{ .Values.registry.version_upgrade_hook }}/{{ .Values.version_upgrade_hook.name }}:{{ .Values.version_upgrade_hook.version }}"
+            - name: READINESS_PROBE_IMAGE
+              value: "{{ .Values.registry.readiness_probe }}/{{ .Values.readiness_probe.name }}:{{ .Values.readiness_probe.version }}"
+            - name: MONGODB_IMAGE
+              value: {{ .Values.mongodb.name }}
+            - name: MONGODB_REPO_URL
+              value: {{ .Values.mongodb.repo }}
+          image: {{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}
+          imagePullPolicy: {{ .Values.registry.pullPolicy}}
+          name: {{ .Values.operator.deployment_name }}
+          resources:
+            limits:
+              cpu: 1100m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 200Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 2000
+      serviceAccountName: {{ .Values.operator.name }}

--- a/helm-chart/templates/tests/operator.yaml
+++ b/helm-chart/templates/tests/operator.yaml
@@ -1,78 +1,78 @@
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    email: support@mongodb.com
-  labels:
-    owner: mongodb
-  name: {{ .Values.operator.name }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: {{ .Values.operator.name }}
-  strategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        name: {{ .Values.operator.name }}
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                      - {{ .Values.operator.name }}
-              topologyKey: kubernetes.io/hostname
-      containers:
-        - command:
-            - /usr/local/bin/entrypoint
-          env:
-            - name: WATCH_NAMESPACE
-{{- if .Values.operator.watchNamespace}}
-              value: "{{ .Values.operator.watchNamespace }}"
-{{- else }}
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-{{- end }}
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: {{ .Values.operator.name }}
-            - name: AGENT_IMAGE
-              value: "{{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ .Values.agent.version }}"
-            - name: VERSION_UPGRADE_HOOK_IMAGE
-              value: "{{ .Values.registry.version_upgrade_hook }}/{{ .Values.version_upgrade_hook.name }}:{{ .Values.version_upgrade_hook.version }}"
-            - name: READINESS_PROBE_IMAGE
-              value: "{{ .Values.registry.readiness_probe }}/{{ .Values.readiness_probe.name }}:{{ .Values.readiness_probe.version }}"
-            - name: MONGODB_IMAGE
-              value: {{ .Values.mongodb.name }}
-            - name: MONGODB_REPO_URL
-              value: {{ .Values.mongodb.repo }}
-          image: {{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}
-          imagePullPolicy: {{ .Values.registry.pullPolicy}}
-          name: {{ .Values.operator.deployment_name }}
-          resources:
-            limits:
-              cpu: 1100m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 200Mi
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 2000
-      serviceAccountName: {{ .Values.operator.name }}
+# ---
+# apiVersion: apps/v1
+# kind: Deployment
+# metadata:
+#   annotations:
+#     email: support@mongodb.com
+#   labels:
+#     owner: mongodb
+#   name: {{ .Values.operator.name }}
+#   {{- if .Values.namespace }}
+#   namespace: {{ .Values.namespace }}
+#   {{- end }}
+# spec:
+#   replicas: 1
+#   selector:
+#     matchLabels:
+#       name: {{ .Values.operator.name }}
+#   strategy:
+#     rollingUpdate:
+#       maxUnavailable: 1
+#     type: RollingUpdate
+#   template:
+#     metadata:
+#       labels:
+#         name: {{ .Values.operator.name }}
+#     spec:
+#       affinity:
+#         podAntiAffinity:
+#           requiredDuringSchedulingIgnoredDuringExecution:
+#             - labelSelector:
+#                 matchExpressions:
+#                   - key: name
+#                     operator: In
+#                     values:
+#                       - {{ .Values.operator.name }}
+#               topologyKey: kubernetes.io/hostname
+#       containers:
+#         - command:
+#             - /usr/local/bin/entrypoint
+#           env:
+#             - name: WATCH_NAMESPACE
+# {{- if .Values.operator.watchNamespace}}
+#               value: "{{ .Values.operator.watchNamespace }}"
+# {{- else }}
+#               valueFrom:
+#                 fieldRef:
+#                   fieldPath: metadata.namespace
+# {{- end }}
+#             - name: POD_NAME
+#               valueFrom:
+#                 fieldRef:
+#                   fieldPath: metadata.name
+#             - name: OPERATOR_NAME
+#               value: {{ .Values.operator.name }}
+#             - name: AGENT_IMAGE
+#               value: "{{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ .Values.agent.version }}"
+#             - name: VERSION_UPGRADE_HOOK_IMAGE
+#               value: "{{ .Values.registry.version_upgrade_hook }}/{{ .Values.version_upgrade_hook.name }}:{{ .Values.version_upgrade_hook.version }}"
+#             - name: READINESS_PROBE_IMAGE
+#               value: "{{ .Values.registry.readiness_probe }}/{{ .Values.readiness_probe.name }}:{{ .Values.readiness_probe.version }}"
+#             - name: MONGODB_IMAGE
+#               value: {{ .Values.mongodb.name }}
+#             - name: MONGODB_REPO_URL
+#               value: {{ .Values.mongodb.repo }}
+#           image: {{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}
+#           imagePullPolicy: {{ .Values.registry.pullPolicy}}
+#           name: {{ .Values.operator.deployment_name }}
+#           resources:
+#             limits:
+#               cpu: 1100m
+#               memory: 1Gi
+#             requests:
+#               cpu: 500m
+#               memory: 200Mi
+#           securityContext:
+#             readOnlyRootFilesystem: true
+#             runAsUser: 2000
+#       serviceAccountName: {{ .Values.operator.name }}

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -342,6 +342,36 @@ func DeletePod(mdb *mdbv1.MongoDBCommunity, podNum int) func(*testing.T) {
 	}
 }
 
+// DeleteStatefulSet provides a wrapper to delete appsv1.StatefulSet types
+func DeleteStatefulSet(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
+	return func(t *testing.T) {
+		sts := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mdb.Name,
+				Namespace: mdb.Namespace,
+			},
+		}
+		if err := e2eutil.TestClient.Delete(context.TODO(), &sts); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("StatefulSet %s/%s deleted", sts.ObjectMeta.Namespace, sts.ObjectMeta.Name)
+	}
+}
+
+/* 	return func(t *testing.T) {
+	stsNamespacedName := types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}
+	sts := appsv1.StatefulSet{}
+	if err := e2eutil.TestClient.Get(context.TODO(), stsNamespacedName, &sts); err != nil {
+		t.Fatal(err)
+	}
+	if err := e2eutil.TestClient.Delete(context.TODO(), &sts); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("StatefulSet %s/%s deleted", sts.ObjectMeta.Namespace, sts.ObjectMeta.Name)
+} */
+
 // Status compares the given status to the actual status of the MongoDB resource
 func Status(mdb *mdbv1.MongoDBCommunity, expectedStatus mdbv1.MongoDBCommunityStatus) func(t *testing.T) {
 	return func(t *testing.T) {

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -359,19 +359,6 @@ func DeleteStatefulSet(mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 	}
 }
 
-/* 	return func(t *testing.T) {
-	stsNamespacedName := types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}
-	sts := appsv1.StatefulSet{}
-	if err := e2eutil.TestClient.Get(context.TODO(), stsNamespacedName, &sts); err != nil {
-		t.Fatal(err)
-	}
-	if err := e2eutil.TestClient.Delete(context.TODO(), &sts); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Logf("StatefulSet %s/%s deleted", sts.ObjectMeta.Namespace, sts.ObjectMeta.Name)
-} */
-
 // Status compares the given status to the actual status of the MongoDB resource
 func Status(mdb *mdbv1.MongoDBCommunity, expectedStatus mdbv1.MongoDBCommunityStatus) func(t *testing.T) {
 	return func(t *testing.T) {

--- a/test/e2e/statefulset_delete/statefulset_delete_test.go
+++ b/test/e2e/statefulset_delete/statefulset_delete_test.go
@@ -1,0 +1,50 @@
+package statefulset_delete
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+)
+
+func TestMain(m *testing.M) {
+	code, err := e2eutil.RunTest(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func TestStatefulSetDelete(t *testing.T) {
+	ctx := setup.Setup(t)
+	defer ctx.Teardown()
+
+	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
+
+	_, err := setup.GeneratePasswordForUser(ctx, user, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
+
+	t.Run("Operator recreates StatefulSet", func(t *testing.T) {
+		t.Run("Delete Statefulset", mongodbtests.DeleteStatefulSet(&mdb))
+		t.Run("Test Replica Set Recovers", mongodbtests.StatefulSetBecomesReady(&mdb))
+		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+		t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
+			mdbv1.MongoDBCommunityStatus{
+				MongoURI:                   mdb.MongoURI(),
+				Phase:                      mdbv1.Running,
+				Version:                    mdb.GetMongoDBVersion(),
+				CurrentMongoDBMembers:      3,
+				CurrentStatefulSetReplicas: 3,
+			}))
+
+	})
+}

--- a/test/e2e/statefulset_delete/statefulset_delete_test.go
+++ b/test/e2e/statefulset_delete/statefulset_delete_test.go
@@ -39,11 +39,10 @@ func TestStatefulSetDelete(t *testing.T) {
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 		t.Run("Test Status Was Updated", mongodbtests.Status(&mdb,
 			mdbv1.MongoDBCommunityStatus{
-				MongoURI:                   mdb.MongoURI(),
-				Phase:                      mdbv1.Running,
-				Version:                    mdb.GetMongoDBVersion(),
-				CurrentMongoDBMembers:      mdb.DesiredReplicas(),
-				CurrentStatefulSetReplicas: mdb.DesiredReplicas(),
+				MongoURI:              mdb.MongoURI(),
+				Phase:                 mdbv1.Running,
+				Version:               mdb.GetMongoDBVersion(),
+				CurrentMongoDBMembers: mdb.DesiredReplicas(),
 			}))
 	})
 }

--- a/test/e2e/statefulset_delete/statefulset_delete_test.go
+++ b/test/e2e/statefulset_delete/statefulset_delete_test.go
@@ -42,9 +42,8 @@ func TestStatefulSetDelete(t *testing.T) {
 				MongoURI:                   mdb.MongoURI(),
 				Phase:                      mdbv1.Running,
 				Version:                    mdb.GetMongoDBVersion(),
-				CurrentMongoDBMembers:      3,
-				CurrentStatefulSetReplicas: 3,
+				CurrentMongoDBMembers:      mdb.DesiredReplicas(),
+				CurrentStatefulSetReplicas: mdb.DesiredReplicas(),
 			}))
-
 	})
 }


### PR DESCRIPTION
This PR ensures that the reconciliation loop is started when the user deletes the sts or a pod created by the sts.


### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
