### PR TITLE
Fix clusterwide issues

### DIFF
--- a/deploy/clusterwide/role.yaml
+++ b/deploy/clusterwide/role.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - services
   - configmaps
+  - secrets
   verbs:
   - create
   - delete
@@ -20,7 +21,8 @@ rules:
   - apps
   resources:
   - statefulsets
-  verbs: 
+  verbs:
+  - create
   - delete
   - get
   - list

--- a/deploy/clusterwide/role_binding.yaml
+++ b/deploy/clusterwide/role_binding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mongodb-kubernetes-operator
 subjects:
 - kind: ServiceAccount
+  namespace: <your-namespace>
   name: mongodb-kubernetes-operator
 roleRef:
   kind: ClusterRole

--- a/docs/install-upgrade.md
+++ b/docs/install-upgrade.md
@@ -62,19 +62,21 @@ To configure the Operator to watch resources in other namespaces:
                  value: "*"
    ```
 
-2. Run the following command to create cluster-wide roles and role-bindings in the default namespace:
+2. Modify the [clusterRoleBinding](../deploy/clusterwide/role_binding.yaml) namespace value for the serviceAccount `mongodb-kubernetes-operator` to the namespace in which the operator is deployed.
+
+3. Run the following command to create cluster-wide roles and role-bindings in the default namespace:
 
    ```sh
    kubectl apply -f deploy/clusterwide
    ```
-3. For each namespace that you want the Operator to watch, run the following
+4. For each namespace that you want the Operator to watch, run the following
    commands to deploy a Role, RoleBinding and ServiceAccount in that namespace:
 
    ```sh
    kubectl apply -k config/rbac --namespace <my-namespace>
    ```
 
-4. [Install the operator](#procedure).
+5. [Install the operator](#procedure).
 
 ### Configure the MongoDB Docker Image or Container Registry
 


### PR DESCRIPTION
Fixes missing entries for `secrets` permissions in cluster role - closes #661 
Fixes missing verb `create` for statefulset in cluster role - closes #664 

Adds a placeholder and documentation on the serviceaccount namespace in the clusterrolebinding subject closes #663 
For the last one I created an internal ticket - CLOUDP-97033 to provide a better solution for the users.



### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
