### PR TITLE
Add required namespace

### DIFF
--- a/helm-chart/templates/operator_roles.yaml
+++ b/helm-chart/templates/operator_roles.yaml
@@ -70,6 +70,9 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}
+  {{- if eq (.Values.operator.watchNamespace | default "") "*" }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  {{- end }}
 roleRef:
   kind: {{ if eq (.Values.operator.watchNamespace | default "") "*" }} ClusterRole {{ else }} Role {{ end }}
   name: {{ .Values.operator.name }}


### PR DESCRIPTION
ClusterRoleBinding for ServiceAccount subjects are a required field:

```
Helm install failed: ClusterRoleBinding.rbac.authorization.k8s.io "mongodb-kubernetes-operator" is invalid: subjects[0].namespace: Required value
```

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
