### PR TITLE
Make DefaultSecurityContext return a pointer to security context to align with corev1.SecurityContext

### DIFF
--- a/pkg/kube/container/container_test.go
+++ b/pkg/kube/container/container_test.go
@@ -20,7 +20,7 @@ func TestContainer(t *testing.T) {
 		WithImage("image"),
 		WithImagePullPolicy(corev1.PullAlways),
 		WithPorts([]corev1.ContainerPort{{Name: "port-1", ContainerPort: int32(1000)}}),
-		WithSecurityContext(corev1.SecurityContext{
+		WithSecurityContext(&corev1.SecurityContext{
 			RunAsGroup:   int64Ref(100),
 			RunAsNonRoot: boolRef(true),
 		}),

--- a/pkg/kube/container/containers.go
+++ b/pkg/kube/container/containers.go
@@ -178,17 +178,17 @@ func WithPorts(ports []corev1.ContainerPort) Modification {
 }
 
 // WithSecurityContext sets teh container's SecurityContext
-func WithSecurityContext(context corev1.SecurityContext) Modification {
+func WithSecurityContext(context *corev1.SecurityContext) Modification {
 	return func(container *corev1.Container) {
-		container.SecurityContext = &context
+		container.SecurityContext = context
 	}
 }
 
 // DefaultSecurityContext returns the default security context for containers.
 // It sets RunAsUser = 2000 and RunAsNonRoot = true
-func DefaultSecurityContext() corev1.SecurityContext {
+func DefaultSecurityContext() *corev1.SecurityContext {
 	runAsNonRoot := true
 	runAsUser := int64(2000)
 
-	return corev1.SecurityContext{RunAsUser: &runAsUser, RunAsNonRoot: &runAsNonRoot}
+	return &corev1.SecurityContext{RunAsUser: &runAsUser, RunAsNonRoot: &runAsNonRoot}
 }


### PR DESCRIPTION
This change will be imported in enterprise-operator
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
