### PR TITLE
Added secret exists method 

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -31,7 +31,7 @@ func executeHelmCommand(args []string, messagePredicate func(string) bool) error
 	cmd := exec.Command("helm", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		if messagePredicate != nil && messagePredicate(string(output)){
+		if messagePredicate != nil && messagePredicate(string(output)) {
 			return nil
 		}
 		return fmt.Errorf("error executing command: %s %s", err, output)

--- a/pkg/kube/configmap/configmap.go
+++ b/pkg/kube/configmap/configmap.go
@@ -130,7 +130,7 @@ func ReadFileLikeField(getter Getter, objectKey client.ObjectKey, externalKey st
 	return value, nil
 }
 
-// Exists return whether a secret with the given namespaced name exists
+// Exists return whether a configmap with the given namespaced name exists
 func Exists(cmGetter Getter, nsName types.NamespacedName) (bool, error) {
 	_, err := cmGetter.GetConfigMap(nsName)
 

--- a/pkg/kube/configmap/configmap.go
+++ b/pkg/kube/configmap/configmap.go
@@ -129,3 +129,16 @@ func ReadFileLikeField(getter Getter, objectKey client.ObjectKey, externalKey st
 	}
 	return value, nil
 }
+
+// Exists return whether a secret with the given namespaced name exists
+func Exists(cmGetter Getter, nsName types.NamespacedName) (bool, error) {
+	_, err := cmGetter.GetConfigMap(nsName)
+
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/kube/configmap/configmap_test.go
+++ b/pkg/kube/configmap/configmap_test.go
@@ -124,13 +124,13 @@ func (c configMapGetUpdater) GetConfigMap(objectKey client.ObjectKey) (corev1.Co
 	return corev1.ConfigMap{}, notFoundError()
 }
 
-func (c configMapGetUpdater) UpdateConfigMap(cm corev1.ConfigMap) error {
+func (c *configMapGetUpdater) UpdateConfigMap(cm corev1.ConfigMap) error {
 	c.cm = cm
 	return nil
 }
 
 func newGetUpdater(cm corev1.ConfigMap) GetUpdater {
-	return configMapGetUpdater{
+	return &configMapGetUpdater{
 		cm: cm,
 	}
 }

--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -150,3 +150,16 @@ func CopySecret(fromClient Getter, toClient GetUpdateCreator, sourceSecretNsName
 
 	return CreateOrUpdate(toClient, secretCopy)
 }
+
+// Exists return whether a secret with the given namespaced name exists
+func Exists(secretGetter Getter, nsName types.NamespacedName) (bool, error) {
+	_, err := secretGetter.GetSecret(nsName)
+
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/pkg/kube/secret/secret_test.go
+++ b/pkg/kube/secret/secret_test.go
@@ -102,13 +102,13 @@ func (c secretGetUpdater) GetSecret(objectKey client.ObjectKey) (corev1.Secret, 
 	return corev1.Secret{}, notFoundError()
 }
 
-func (c secretGetUpdater) UpdateSecret(s corev1.Secret) error {
+func (c *secretGetUpdater) UpdateSecret(s corev1.Secret) error {
 	c.secret = s
 	return nil
 }
 
 func newGetUpdater(s corev1.Secret) GetUpdater {
-	return secretGetUpdater{
+	return &secretGetUpdater{
 		secret: s,
 	}
 }

--- a/test/e2e/replica_set_cross_namespace_deploy/replica_set_cross_namespace_deploy_test.go
+++ b/test/e2e/replica_set_cross_namespace_deploy/replica_set_cross_namespace_deploy_test.go
@@ -3,11 +3,12 @@ package replica_set_cross_namespace_deploy
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
-	"testing"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/generate"
 	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
@@ -64,7 +65,6 @@ func TestCrossNamespaceDeploy(t *testing.T) {
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 }
 
-
 // createDatabaseServiceAccountRoleAndRoleBinding creates the ServiceAccount, Role and RoleBinding required
 // for the database StatefulSet in the other namespace.
 func createDatabaseServiceAccountRoleAndRoleBinding(t *testing.T, namespace string) error {
@@ -111,4 +111,3 @@ func createDatabaseServiceAccountRoleAndRoleBinding(t *testing.T, namespace stri
 	}
 	return nil
 }
-

--- a/test/e2e/util/wait/wait.go
+++ b/test/e2e/util/wait/wait.go
@@ -59,14 +59,12 @@ func waitForMongoDBCondition(mdb *mdbv1.MongoDBCommunity, retryInterval, timeout
 	})
 }
 
-
 // ForDeploymentToExist waits until a Deployment of the given name exists
 // using the provided retryInterval and timeout
 func ForDeploymentToExist(deployName string, retryInterval, timeout time.Duration, namespace string) (appsv1.Deployment, error) {
 	deploy := appsv1.Deployment{}
 	return deploy, waitForRuntimeObjectToExist(deployName, retryInterval, timeout, &deploy, namespace)
 }
-
 
 // ForStatefulSetToExist waits until a StatefulSet of the given name exists
 // using the provided retryInterval and timeout


### PR DESCRIPTION
This PR adds a convenience function to check whether a secret exists or not.


Note: all changes not to `secret.go` are either to fix pre-commit errors or introduced by `gofmt`

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
