### PR TITLE
Remove non-isolated-pod check

### DIFF
--- a/.github/config_files/config_lint.yaml
+++ b/.github/config_files/config_lint.yaml
@@ -12,3 +12,4 @@ checks:
   - "no-liveness-probe"
   - "no-readiness-probe"
   - "use-namespace"
+  - "non-isolated-pod"

--- a/.github/config_files/config_lint_clusterwide.yaml
+++ b/.github/config_files/config_lint_clusterwide.yaml
@@ -16,3 +16,4 @@ checks:
   - "use-namespace"
   - "access-to-secrets"
   - "access-to-create-pods"
+  - "non-isolated-pod"

--- a/.github/config_files/config_lint_openshift.yaml
+++ b/.github/config_files/config_lint_openshift.yaml
@@ -15,3 +15,4 @@ checks:
   - "run-as-non-root"
   - "no-read-only-root-fs"
   - "use-namespace"
+  - "non-isolated-pod"


### PR DESCRIPTION
Our kube-linter check is failing because our openshit yaml violates this new rule that was introduced with the most recent release of kube-linter.

There isn't currently a way to ping a kubelinter version in the GH action but I created an issue on their repo here: https://github.com/stackrox/kube-linter-action/issues/8 

In the meantime we can disable the check 

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
