### PR TITLE
Fix agent health-status file not being present as info instead of error

### DIFF
--- a/cmd/versionhook/main.go
+++ b/cmd/versionhook/main.go
@@ -127,7 +127,7 @@ func waitForAgentHealthStatus() (agent.Health, error) {
 func getAgentHealthStatus() (agent.Health, error) {
 	f, err := os.Open(os.Getenv(agentStatusFilePathEnv))
 	if err != nil {
-		return agent.Health{}, errors.Errorf("could not open file: %s", err)
+		return agent.Health{}, err
 	}
 	defer f.Close()
 

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
   "mongodb-kubernetes-operator": "0.7.0",
-  "version-upgrade-hook": "1.0.2",
+  "version-upgrade-hook": "1.0.3",
   "readiness-probe": "1.0.5",
   "mongodb-agent": {
     "version": "11.0.5.6963-1",


### PR DESCRIPTION
This is reported in quite a few community tickets about an error that is misleading
```
2021-08-31T22:04:19.938Z	INFO	versionhook/main.go:34	Running version change post-start hook
2021-08-31T22:04:19.939Z	INFO	versionhook/main.go:41	Waiting for agent health status...
2021-08-31T22:04:20.939Z	ERROR	versionhook/main.go:49	Error getting the agent health file: could not open file: open /healthstatus/agent-health-status.json: no such file or directory
main.main
	/go/cmd/versionhook/main.go:49
runtime.main
	/usr/local/go/src/runtime/proc.go:225
```

We intended to log it as info [here](https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/cmd/versionhook/main.go#L46) but it was not working because we are wrapping the error so it doesn't match with the os error type. This error just returns the error as it is without wrapping.  
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
