### PR TITLE
Adds missing roles to database.

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -2,3 +2,6 @@ resources:
 - role.yaml
 - role_binding.yaml
 - service_account.yaml
+- service_account_database.yaml
+- role_binding_database.yaml
+- role_database.yaml


### PR DESCRIPTION
# Summary

These roles are missing from the kustomize file; the roles are required because the Pods are bound to this Service Account that does not exist.