### PR TITLE
Add spec.version limitations to deploy docs (#758)

### DIFF
--- a/docs/deploy-configure.md
+++ b/docs/deploy-configure.md
@@ -199,7 +199,7 @@ To add arbiters:
 
 You can upgrade the major, minor, and/or feature compatibility versions of your MongoDB resource. These settings are configured in your resource definition YAML file.
 
-- To upgrade your resource's major and/or minor versions, set the `spec.version` setting to the desired MongoDB version.
+- To upgrade your resource's major and/or minor versions, set the `spec.version` setting to the desired MongoDB version. Make sure to specify a full image tag, such as `5.0.3`. Setting the `spec.version` to loosely-defined tags such as `5.0` is not currently supported.
 
 - To modify your resource's [feature compatibility version](https://docs.mongodb.com/manual/reference/command/setFeatureCompatibilityVersion/), set the `spec.featureCompatibilityVersion` setting to the desired version.
 


### PR DESCRIPTION
This allows users to be aware of the current limitation which prevents
clusters from starting when specifying loosely-defined tags in MongoDB
image version. 

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you signed all of your commits?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
