### PR TITLE
Release MongoDB Kubernetes Operator v0.7.2

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,7 +54,7 @@ spec:
           value: mongo
         - name: MONGODB_REPO_URL
           value: docker.io
-        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.1
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.2
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator
         resources:

--- a/deploy/openshift/operator_openshift.yaml
+++ b/deploy/openshift/operator_openshift.yaml
@@ -56,7 +56,7 @@ spec:
           value: mongo
         - name: MONGODB_REPO_URL
           value: docker.io
-        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.1
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.2
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator
         resources:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,23 +1,18 @@
-# MongoDB Kubernetes Operator 0.7.1
+# MongoDB Kubernetes Operator 0.7.2
 
 ## Kubernetes Operator
 
-- Changes
-  - MongoDB database of the statefulSet is managed using distinct Role, ServiceAccount and RoleBinding.
-  - TLS Secret can also contain a single "tls.pem" entry, containing the concatenation of the certificate and key
-    - If a TLS secret contains all of "tls.key", "tls.crt" and "tls.pem" entries, the operator will raise an error if the "tls.pem" one is not equal to the concatenation of "tls.crt" with "tls.key"
-  - Readinessprobe reports MongoDB running as Arbitrer as _Running_ & _Healthy_.
-  - The `CLUSTER_DOMAIN` environment variable can be set on the Operator Pod, to configure the Kubernetes cluster's Domain,
-    in case this one differs from the default `cluster.local`.
+- Bug fixes
+  - Adds missing roles for Database Pods.
+  - Fixes OpenShift install.
 
 ## MongoDBCommunity Resource
-* Changes
-* Specifying `spec.additionalMongodConfig.storage.dbPath` will now be respected correctly. 
+* No changes
 
 
 ## Updated Image Tags
 
-- mongodb-kubernetes-operator:0.7.1
+- mongodb-kubernetes-operator:0.7.2
 
 _All the images can be found in:_
 

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -5,6 +5,8 @@
     * Update any changing versions in [release.json](../release.json).
     * Ensure that [the release notes](./RELEASE_NOTES.md) are up to date for this release.
     * Run `python scripts/ci/update_release.py` to update the relevant yaml manifests.
+    * Copy `CRD`s to Helm Chart
+      - `cp config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml helm-charts/charts/community-operator-crds/templates/mongodbcommunity.mongodb.com_mongodbcommunity.yaml`
     * Commit all changes.
     * Create a PR with the title `Release MongoDB Kubernetes Operator v<operator-version>` (the title must match this pattern)
     

--- a/release.json
+++ b/release.json
@@ -1,5 +1,5 @@
 {
-  "mongodb-kubernetes-operator": "0.7.1",
+  "mongodb-kubernetes-operator": "0.7.2",
   "version-upgrade-hook": "1.0.3",
   "readiness-probe": "1.0.6",
   "mongodb-agent": {

--- a/scripts/ci/update_release.py
+++ b/scripts/ci/update_release.py
@@ -62,14 +62,14 @@ def update_operator_deployment(operator_deployment: Dict, release: Dict) -> None
             )
 
 
-def update_chart_values(values: Dict, release: Dict):
+def update_chart_values(values: Dict, release: Dict) -> None:
     values["agent"]["version"] = release["mongodb-agent"]["version"]
     values["versionUpgradeHook"]["version"] = release["version-upgrade-hook"]
     values["readinessProbe"]["version"] = release["readiness-probe"]
     values["operator"]["version"] = release["mongodb-kubernetes-operator"]
 
 
-def update_chart(chart: Dict, release: Dict):
+def update_chart(chart: Dict, release: Dict) -> None:
     chart["version"] = release["mongodb-kubernetes-operator"]
     chart["appVersion"] = release["mongodb-kubernetes-operator"]
 

--- a/scripts/ci/update_release.py
+++ b/scripts/ci/update_release.py
@@ -2,16 +2,23 @@
 
 import json
 import sys
-import yaml
-from typing import Dict
+from typing import Dict, Callable
+
+import ruamel.yaml
+
+yaml = ruamel.yaml.YAML()
+
 
 RELATIVE_PATH_TO_MANAGER_YAML = "config/manager/manager.yaml"
 RELATIVE_PATH_TO_OPENSHIFT_MANAGER_YAML = "deploy/openshift/operator_openshift.yaml"
 
+RELATIVE_PATH_TO_CHART_VALUES = "helm-charts/charts/community-operator/values.yaml"
+RELATIVE_PATH_TO_CHART = "helm-charts/charts/community-operator/Chart.yaml"
+
 
 def _load_yaml_file(path: str) -> Dict:
     with open(path, "r") as f:
-        return yaml.safe_load(f.read())
+        return yaml.load(f.read())
 
 
 def _dump_yaml(operator: Dict, path: str) -> None:
@@ -19,10 +26,10 @@ def _dump_yaml(operator: Dict, path: str) -> None:
         yaml.dump(operator, f)
 
 
-def update_and_write_file(path: str) -> None:
+def update_and_write_file(path: str, update_function: Callable) -> None:
     release = _load_release()
     yaml_file = _load_yaml_file(path)
-    _update_operator_deployment(yaml_file, release)
+    update_function(yaml_file, release)
     _dump_yaml(yaml_file, path)
 
 
@@ -36,7 +43,7 @@ def _replace_tag(image: str, new_tag: str) -> str:
     return split_image[0] + ":" + new_tag
 
 
-def _update_operator_deployment(operator_deployment: Dict, release: Dict) -> None:
+def update_operator_deployment(operator_deployment: Dict, release: Dict) -> None:
     operator_container = operator_deployment["spec"]["template"]["spec"]["containers"][
         0
     ]
@@ -55,9 +62,33 @@ def _update_operator_deployment(operator_deployment: Dict, release: Dict) -> Non
             )
 
 
+def update_chart_values(values: Dict, release: Dict):
+    values["agent"]["version"] = release["mongodb-agent"]["version"]
+    values["versionUpgradeHook"]["version"] = release["version-upgrade-hook"]
+    values["readinessProbe"]["version"] = release["readiness-probe"]
+    values["operator"]["version"] = release["mongodb-kubernetes-operator"]
+
+
+def update_chart(chart: Dict, release: Dict):
+    chart["version"] = release["mongodb-kubernetes-operator"]
+    chart["appVersion"] = release["mongodb-kubernetes-operator"]
+
+    for dependency in chart["dependencies"]:
+        if dependency["name"] == "community-operator-crds":
+            dependency["version"] = release["mongodb-kubernetes-operator"]
+
+
 def main() -> int:
-    update_and_write_file(RELATIVE_PATH_TO_MANAGER_YAML)
-    update_and_write_file(RELATIVE_PATH_TO_OPENSHIFT_MANAGER_YAML)
+    # Updating local files
+    update_and_write_file(RELATIVE_PATH_TO_MANAGER_YAML, update_operator_deployment)
+    update_and_write_file(
+        RELATIVE_PATH_TO_OPENSHIFT_MANAGER_YAML, update_operator_deployment
+    )
+
+    # Updating Helm Chart files
+    update_and_write_file(RELATIVE_PATH_TO_CHART_VALUES, update_chart_values)
+    update_and_write_file(RELATIVE_PATH_TO_CHART, update_chart)
+
     return 0
 
 


### PR DESCRIPTION
# Summary

Prepares release for a new version for a new Helm Chart (https://github.com/mongodb/helm-charts/pull/80).

I have scripted some of the missing steps for the new out-of-band Helm Chart.