### PR TITLE
Add "WithVolumes" API to podspec template

### DIFF
--- a/pkg/kube/podtemplatespec/podspec_template.go
+++ b/pkg/kube/podtemplatespec/podspec_template.go
@@ -107,6 +107,22 @@ func WithServiceAccount(serviceAccountName string) Modification {
 	}
 }
 
+// WithVolumes appends the given volumes to the existing volume, it ensures not
+// to override existing volumes
+func WithVolumes(volumes []corev1.Volume) Modification {
+	return func(template *corev1.PodTemplateSpec) {
+		present := make(map[string]struct{})
+		for _, v := range template.Spec.Volumes {
+			present[v.Name] = struct{}{}
+		}
+		for _, v := range volumes {
+			if _, ok := present[v.Name]; !ok {
+				template.Spec.Volumes = append(template.Spec.Volumes, v)
+			}
+		}
+	}
+}
+
 // WithVolume ensures the given volume exists
 func WithVolume(volume corev1.Volume) Modification {
 	return func(template *corev1.PodTemplateSpec) {

--- a/pkg/kube/podtemplatespec/podspec_template_test.go
+++ b/pkg/kube/podtemplatespec/podspec_template_test.go
@@ -341,6 +341,39 @@ func TestMergeVolumes_DoesNotAddDuplicatesWithSameName(t *testing.T) {
 	assert.Equal(t, "new-volume-3", mergedPodSpecTemplate.Spec.Volumes[2].Name)
 }
 
+func TestAddVolumes(t *testing.T) {
+	volumeModification := WithVolume(corev1.Volume{
+		Name: "new-volume",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "old-host-path",
+			},
+		}},
+	)
+
+	toAddVolumes := []corev1.Volume{
+		{
+			Name: "new-volume",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "new-host-path",
+				},
+			},
+		},
+		{
+			Name: "new-volume-2",
+		},
+	}
+
+	volumesModification := WithVolumes(toAddVolumes)
+
+	p := New(volumeModification, volumesModification)
+	assert.Len(t, p.Spec.Volumes, 2)
+	assert.Equal(t, p.Spec.Volumes[0].Name, "new-volume")
+	assert.Equal(t, p.Spec.Volumes[1].Name, "new-volume-2")
+
+}
+
 func int64Ref(i int64) *int64 {
 	return &i
 }


### PR DESCRIPTION
This would enable us to patch volumes more cleanly, currently, it would be used to configure volumes when vault is configured or not.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
