### PR TITLE
CLOUDP-105706: Arbiters go into own Statefulset

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -495,6 +495,8 @@ func (m MongoDBCommunity) GetScramUsers() []scram.User {
 	return users
 }
 
+// IsStillScaling returns true if this resource is currently scaling,
+// considering both arbiters and regular members.
 func (m MongoDBCommunity) IsStillScaling() bool {
 	return scale.IsStillScaling(m) || scale.IsStillScaling(automationConfigReplicasScaler{
 		current: m.CurrentArbiters(),
@@ -639,6 +641,16 @@ func (m MongoDBCommunity) CurrentReplicas() int {
 	return m.Status.CurrentStatefulSetReplicas
 }
 
+// ForcedIndividualScaling if set to true, will always scale the deployment 1 by
+// 1, even if the resource has been just created.
+//
+// The reason for this is that we have 2 types of resources that are scaled at
+// different times: a) Regular members, which can be scaled from 0->n, for
+// instance, when the resource was just created; and b) Arbiters, which will be
+// scaled from 0->M 1 by 1 at all times.
+//
+// This was done to simplify the process of scaling arbiters, *after* members
+// have reached the desired amount of replicas.
 func (m MongoDBCommunity) ForcedIndividualScaling() bool {
 	return false
 }

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -582,13 +582,22 @@ func (m MongoDBCommunity) Hosts(clusterDomain string) []string {
 	return hosts
 }
 
-// ServiceName returns the name of the Service that should be created for this resource
+// ServiceName returns the name of the Service that should be created for this resource.
 func (m MongoDBCommunity) ServiceName() string {
 	serviceName := m.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName
 	if serviceName != "" {
 		return serviceName
 	}
 	return m.Name + "-svc"
+}
+
+// ArbiterServiceName returns the name of the Service for the Arbiters for this resource.
+func (m MongoDBCommunity) ArbiterServiceName() string {
+	serviceName := m.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName
+	if serviceName != "" {
+		return serviceName + "-arb-svc"
+	}
+	return m.Name + "-arb-svc"
 }
 
 func (m MongoDBCommunity) AutomationConfigSecretName() string {

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -61,7 +61,9 @@ type MongoDBCommunitySpec struct {
 	// Version defines which version of MongoDB will be used
 	Version string `json:"version,omitempty"`
 
-	// Arbiters is the number of arbiters (each counted as a member) in the replica set
+	// Arbiters is the number of arbiters to add to the Replica Set.
+	// It is not recommended to have more than one arbiter per Replica Set.
+	// More info: https://docs.mongodb.com/manual/tutorial/add-replica-set-arbiter/
 	// +optional
 	Arbiters int `json:"arbiters"`
 

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -323,7 +323,11 @@ spec:
           status:
             description: MongoDBCommunityStatus defines the observed state of MongoDB
             properties:
+              currentMongoDBArbiters:
+                type: integer
               currentMongoDBMembers:
+                type: integer
+              currentStatefulSetArbitersReplicas:
                 type: integer
               currentStatefulSetReplicas:
                 type: integer
@@ -336,7 +340,9 @@ spec:
               version:
                 type: string
             required:
+            - currentMongoDBArbiters
             - currentMongoDBMembers
+            - currentStatefulSetArbitersReplicas
             - currentStatefulSetReplicas
             - mongoUri
             - phase

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -55,8 +55,9 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               arbiters:
-                description: Arbiters is the number of arbiters (each counted as a
-                  member) in the replica set
+                description: 'Arbiters is the number of arbiters to add to the Replica
+                  Set. It is not recommended to have more than one arbiter per Replica
+                  Set. More info: https://docs.mongodb.com/manual/tutorial/add-replica-set-arbiter/'
                 type: integer
               featureCompatibilityVersion:
                 description: FeatureCompatibilityVersion configures the feature compatibility

--- a/controllers/mongodb_status_options.go
+++ b/controllers/mongodb_status_options.go
@@ -132,6 +132,20 @@ func (o *optionBuilder) withStatefulSetReplicas(members int) *optionBuilder {
 	return o
 }
 
+func (o *optionBuilder) withMongoDBArbiters(arbiters int) *optionBuilder {
+	o.options = append(o.options, mongoDBArbitersOption{
+		mongoDBArbiters: arbiters,
+	})
+	return o
+}
+
+func (o *optionBuilder) withStatefulSetArbiters(arbiters int) *optionBuilder {
+	o.options = append(o.options, statefulSetArbitersOption{
+		arbiters: arbiters,
+	})
+	return o
+}
+
 func (o *optionBuilder) withMessage(severityLevel severity, msg string) *optionBuilder {
 	if apierrors.IsTransientMessage(msg) {
 		severityLevel = Debug
@@ -201,5 +215,29 @@ func (s statefulSetReplicasOption) ApplyOption(mdb *mdbv1.MongoDBCommunity) {
 }
 
 func (s statefulSetReplicasOption) GetResult() (reconcile.Result, error) {
+	return result.OK()
+}
+
+type mongoDBArbitersOption struct {
+	mongoDBArbiters int
+}
+
+func (a mongoDBArbitersOption) ApplyOption(mdb *mdbv1.MongoDBCommunity) {
+	mdb.Status.CurrentMongoDBArbiters = a.mongoDBArbiters
+}
+
+func (a mongoDBArbitersOption) GetResult() (reconcile.Result, error) {
+	return result.OK()
+}
+
+type statefulSetArbitersOption struct {
+	arbiters int
+}
+
+func (s statefulSetArbitersOption) ApplyOption(mdb *mdbv1.MongoDBCommunity) {
+	mdb.Status.CurrentStatefulSetArbitersReplicas = s.arbiters
+}
+
+func (s statefulSetArbitersOption) GetResult() (reconcile.Result, error) {
 	return result.OK()
 }

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -474,7 +474,6 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Aut
 		arbitersCount = mdb.Status.CurrentMongoDBArbiters
 	}
 
-
 	return automationconfig.NewBuilder().
 		SetTopology(automationconfig.ReplicaSetTopology).
 		SetName(mdb.Name).

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,18 +1,21 @@
-# MongoDB Kubernetes Operator 0.7.2
+# MongoDB Kubernetes Operator 0.7.3
 
 ## Kubernetes Operator
 
-- Bug fixes
-  - Adds missing roles for Database Pods.
-  - Fixes OpenShift install.
+- Changes
+  - The Operator can correctly scale arbiters up and down. When arbiters are
+    enabled (this is, when `spec.arbiters > 0`), a new StatefulSet will be
+    created to hold the Pods that will act as arbiters. The new StatefulSet will
+    be named `<mongodb-resource>-arb`.
 
 ## MongoDBCommunity Resource
-* No changes
+
+- No changes.
 
 
 ## Updated Image Tags
 
-- mongodb-kubernetes-operator:0.7.2
+- mongodb-kubernetes-operator:0.7.3
 
 _All the images can be found in:_
 

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -135,17 +135,16 @@ type ReplicaSetMember struct {
 
 type ReplicaSetHorizons map[string]string
 
-func newReplicaSetMember(p Process, id int, horizons ReplicaSetHorizons, totalVotesSoFar int, numberArbiters int) ReplicaSetMember {
+// newReplicaSetMember returns a ReplicaSetMember.
+func newReplicaSetMember(p Process, id int, horizons ReplicaSetHorizons, isArbiter bool, isVotingMember bool) ReplicaSetMember {
 	// ensure that the number of voting members in the replica set is not more than 7
 	// as this is the maximum number of voting members.
-	votes := 1
-	priority := 1
+	votes := 0
+	priority := 0
 
-	isArbiter := totalVotesSoFar < numberArbiters
-
-	if totalVotesSoFar > maxVotingMembers {
-		votes = 0
-		priority = 0
+	if isVotingMember {
+		votes = 1
+		priority = 1
 	}
 
 	return ReplicaSetMember{

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -136,7 +136,7 @@ type ReplicaSetMember struct {
 type ReplicaSetHorizons map[string]string
 
 // newReplicaSetMember returns a ReplicaSetMember.
-func newReplicaSetMember(p Process, id int, horizons ReplicaSetHorizons, isArbiter bool, isVotingMember bool) ReplicaSetMember {
+func newReplicaSetMember(name string, id int, horizons ReplicaSetHorizons, isArbiter bool, isVotingMember bool) ReplicaSetMember {
 	// ensure that the number of voting members in the replica set is not more than 7
 	// as this is the maximum number of voting members.
 	votes := 0
@@ -149,7 +149,7 @@ func newReplicaSetMember(p Process, id int, horizons ReplicaSetHorizons, isArbit
 
 	return ReplicaSetMember{
 		Id:          id,
-		Host:        p.Name,
+		Host:        name,
 		Priority:    priority,
 		ArbiterOnly: isArbiter,
 		Votes:       votes,

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -256,7 +256,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 			fcv = b.fcv
 		}
 
-		// TODO: make a builder function for this struct
+		// TODO: Replace with a Builder for Process.
 		process := &Process{
 			Name:                        toProcessName(b.name, processIndex, isArbiter),
 			HostName:                    h,
@@ -273,6 +273,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		for _, mod := range b.processModifications {
 			mod(i, process)
 		}
+		processes[i] = *process
 
 		var horizon ReplicaSetHorizons
 		if b.replicaSetHorizons != nil {
@@ -287,8 +288,9 @@ func (b *Builder) Build() (AutomationConfig, error) {
 			// arbiters.
 			isVotingMember = false
 		}
-		members[i] = newReplicaSetMember(*process, replicaSetIndex, horizon, isArbiter, isVotingMember)
-		processes[i] = *process
+
+		// TODO: Replace with a Builder for ReplicaSetMember.
+		members[i] = newReplicaSetMember(process.Name, replicaSetIndex, horizon, isArbiter, isVotingMember)
 	}
 
 	if b.auth == nil {

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -42,7 +42,7 @@ func TestBuildAutomationConfig(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("my-rs-%d.my-ns.svc.cluster.local", i), p.HostName)
 		assert.Equal(t, DefaultMongoDBDataDir, p.Args26.Get("storage.dbPath").Data())
 		assert.Equal(t, "my-rs", p.Args26.Get("replication.replSetName").Data())
-		assert.Equal(t, toProcessName("my-rs", i), p.Name)
+		assert.Equal(t, toProcessName("my-rs", i, false), p.Name)
 		assert.Equal(t, "4.2.0", p.Version)
 		assert.Equal(t, "4.0", p.FeatureCompatibilityVersion)
 	}

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -101,7 +101,7 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 	assert.NoError(t, err)
 
 	rs = ac.ReplicaSets[0]
-	assert.Len(t, rs.Members, noMembers + noArbiters)
+	assert.Len(t, rs.Members, noMembers+noArbiters)
 	assert.False(t, rs.Members[0].ArbiterOnly)
 	assert.False(t, rs.Members[1].ArbiterOnly)
 	assert.False(t, rs.Members[2].ArbiterOnly)
@@ -124,7 +124,7 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 			assert.False(t, member.ArbiterOnly, "First members should not be arbiters")
 		} else {
 			assert.True(t, member.ArbiterOnly, "Last members should be arbiters")
-			assert.Equal(t, member.Id, 100 + i - noMembers)
+			assert.Equal(t, member.Id, 100+i-noMembers)
 		}
 	}
 }

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -64,11 +64,11 @@ func TestBuildAutomationConfig(t *testing.T) {
 
 func TestBuildAutomationConfigArbiters(t *testing.T) {
 	// Test no arbiter (field specified)
-	noArbiters := 0
-	noMembers := 4
+	numArbiters := 0
+	numMembers := 4
 	ac, err := NewBuilder().
-		SetMembers(noMembers).
-		SetArbiters(noArbiters).
+		SetMembers(numMembers).
+		SetArbiters(numArbiters).
 		Build()
 
 	assert.NoError(t, err)
@@ -80,7 +80,7 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 
 	// Test no arbiter (field NOT specified)
 	ac, err = NewBuilder().
-		SetMembers(noMembers).
+		SetMembers(numMembers).
 		Build()
 
 	assert.NoError(t, err)
@@ -91,17 +91,17 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 	}
 
 	// Test only one arbiter
-	noArbiters = 1
-	noMembers = 4
+	numArbiters = 1
+	numMembers = 4
 	ac, err = NewBuilder().
-		SetMembers(noMembers).
-		SetArbiters(noArbiters).
+		SetMembers(numMembers).
+		SetArbiters(numArbiters).
 		Build()
 
 	assert.NoError(t, err)
 
 	rs = ac.ReplicaSets[0]
-	assert.Len(t, rs.Members, noMembers+noArbiters)
+	assert.Len(t, rs.Members, numMembers+numArbiters)
 	assert.False(t, rs.Members[0].ArbiterOnly)
 	assert.False(t, rs.Members[1].ArbiterOnly)
 	assert.False(t, rs.Members[2].ArbiterOnly)
@@ -109,31 +109,31 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 	assert.True(t, rs.Members[4].ArbiterOnly)
 
 	// Test with multiple arbiters
-	noArbiters = 2
-	noMembers = 4
+	numArbiters = 2
+	numMembers = 4
 	ac, err = NewBuilder().
-		SetMembers(noMembers).
-		SetArbiters(noArbiters).
+		SetMembers(numMembers).
+		SetArbiters(numArbiters).
 		Build()
 
 	assert.NoError(t, err)
 
 	rs = ac.ReplicaSets[0]
 	for i, member := range rs.Members {
-		if i < noMembers {
+		if i < numMembers {
 			assert.False(t, member.ArbiterOnly, "First members should not be arbiters")
 		} else {
 			assert.True(t, member.ArbiterOnly, "Last members should be arbiters")
-			assert.Equal(t, member.Id, 100+i-noMembers)
+			assert.Equal(t, member.Id, 100+i-numMembers)
 		}
 	}
 
 	// Test arbiters should be able to vote
-	noArbiters = 2
-	noMembers = 10
+	numArbiters = 2
+	numMembers = 10
 	ac, err = NewBuilder().
-		SetMembers(noMembers).
-		SetArbiters(noArbiters).
+		SetMembers(numMembers).
+		SetArbiters(numArbiters).
 		Build()
 
 	assert.NoError(t, err)

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -127,6 +127,36 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 			assert.Equal(t, member.Id, 100+i-noMembers)
 		}
 	}
+
+	// Test arbiters should be able to vote
+	noArbiters = 2
+	noMembers = 10
+	ac, err = NewBuilder().
+		SetMembers(noMembers).
+		SetArbiters(noArbiters).
+		Build()
+
+	assert.NoError(t, err)
+
+	m := ac.ReplicaSets[0].Members
+
+	// First 5 data-bearing nodes have votes
+	assert.Equal(t, 1, m[0].Votes)
+	assert.Equal(t, 1, m[1].Votes)
+	assert.Equal(t, 1, m[2].Votes)
+	assert.Equal(t, 1, m[3].Votes)
+	assert.Equal(t, 1, m[4].Votes)
+
+	// From 6th data-bearing nodes, they won'thave any votes
+	assert.Equal(t, 0, m[5].Votes)
+	assert.Equal(t, 0, m[6].Votes)
+	assert.Equal(t, 0, m[7].Votes)
+	assert.Equal(t, 0, m[8].Votes)
+	assert.Equal(t, 0, m[9].Votes)
+
+	// Arbiters always have votes
+	assert.Equal(t, 1, m[10].Votes)
+	assert.Equal(t, 1, m[11].Votes)
 }
 
 func TestReplicaSetHorizons(t *testing.T) {

--- a/pkg/util/versions/versions.go
+++ b/pkg/util/versions/versions.go
@@ -13,8 +13,7 @@ func CalculateFeatureCompatibilityVersion(versionStr string) string {
 		return ""
 	}
 
-	baseVersion, _ := semver.Make("3.4.0")
-	if v1.GTE(baseVersion) {
+	if v1.GTE(semver.MustParse("3.4.0")) {
 		return fmt.Sprintf("%d.%d", v1.Major, v1.Minor)
 	}
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -42,6 +42,17 @@ func StatefulSetBecomesReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configura
 	return statefulSetIsReady(mdb, defaultOpts...)
 }
 
+// StatefulSetBecomesReady ensures that the underlying stateful set
+// reaches the running state.
+func ArbitersStatefulSetBecomesReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration) func(t *testing.T) {
+	defaultOpts := []wait.Configuration{
+		wait.RetryInterval(time.Second * 15),
+		wait.Timeout(time.Minute * 20),
+	}
+	defaultOpts = append(defaultOpts, opts...)
+	return arbitersStatefulSetIsReady(mdb, defaultOpts...)
+}
+
 // StatefulSetBecomesUnready ensures the underlying stateful set reaches
 // the unready state.
 func StatefulSetBecomesUnready(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration) func(t *testing.T) {
@@ -66,11 +77,23 @@ func StatefulSetIsReadyAfterScaleDown(mdb *mdbv1.MongoDBCommunity) func(t *testi
 	}
 }
 
-// StatefulSetIsReady ensures that the underlying stateful set
-// reaches the running state
+// statefulSetIsReady ensures that the underlying stateful set
+// reaches the running state.
 func statefulSetIsReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration) func(t *testing.T) {
 	return func(t *testing.T) {
 		err := wait.ForStatefulSetToBeReady(t, mdb, opts...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("StatefulSet %s/%s is ready!", mdb.Namespace, mdb.Name)
+	}
+}
+
+// arbitersStatefulSetIsReady ensures that the underlying stateful set
+// reaches the running state.
+func arbitersStatefulSetIsReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration) func(t *testing.T) {
+	return func(t *testing.T) {
+		err := wait.ForArbitersStatefulSetToBeReady(t, mdb, opts...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -379,12 +379,25 @@ func Status(mdb *mdbv1.MongoDBCommunity, expectedStatus mdbv1.MongoDBCommunitySt
 	}
 }
 
-// Scale update the MongoDB with a new number of members and updates the resource
+// Scale update the MongoDB with a new number of members and updates the resource.
 func Scale(mdb *mdbv1.MongoDBCommunity, newMembers int) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Logf("Scaling Mongodb %s, to %d members", mdb.Name, newMembers)
 		err := e2eutil.UpdateMongoDBResource(mdb, func(db *mdbv1.MongoDBCommunity) {
 			db.Spec.Members = newMembers
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// Scale update the MongoDB with a new number of arbiters and updates the resource.
+func ScaleArbiters(mdb *mdbv1.MongoDBCommunity, newArbiters int) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Logf("Scaling Mongodb %s, to %d members", mdb.Name, newArbiters)
+		err := e2eutil.UpdateMongoDBResource(mdb, func(db *mdbv1.MongoDBCommunity) {
+			db.Spec.Arbiters = newArbiters
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -42,7 +42,7 @@ func StatefulSetBecomesReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configura
 	return statefulSetIsReady(mdb, defaultOpts...)
 }
 
-// StatefulSetBecomesReady ensures that the underlying stateful set
+// ArbitersStatefulSetBecomesReady ensures that the underlying stateful set
 // reaches the running state.
 func ArbitersStatefulSetBecomesReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration) func(t *testing.T) {
 	defaultOpts := []wait.Configuration{

--- a/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -70,8 +70,12 @@ func TestReplicaSetArbiter(t *testing.T) {
 	t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb))
 	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 
+	t.Run("Scale MongoDB Resource Up", mongodbtests.ScaleArbiters(&mdb, 2))
+	t.Run("Arbiters Stateful Set Scaled Up Correctly", mongodbtests.ArbitersStatefulSetBecomesReady(&mdb))
+	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+
 	t.Run("Scale MongoDB Resource Up", mongodbtests.ScaleArbiters(&mdb, 3))
-	t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb))
+	t.Run("Arbiters Stateful Set Scaled Up Correctly", mongodbtests.ArbitersStatefulSetBecomesReady(&mdb))
 	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 
 	// t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))

--- a/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -66,4 +66,8 @@ func TestReplicaSetArbiter(t *testing.T) {
 	t.Run("Check that the stateful set becomes ready", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
 	t.Run("Check the number of arbiters", mongodbtests.AutomationConfigReplicaSetsHaveExpectedArbiters(&mdb, numberArbiters))
 
+	t.Run("Scale MongoDB Resource Up", mongodbtests.Scale(&mdb, 5))
+	t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb))
+	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+	// t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))
 }

--- a/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -69,5 +69,10 @@ func TestReplicaSetArbiter(t *testing.T) {
 	t.Run("Scale MongoDB Resource Up", mongodbtests.Scale(&mdb, 5))
 	t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb))
 	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+
+	t.Run("Scale MongoDB Resource Up", mongodbtests.ScaleArbiters(&mdb, 3))
+	t.Run("Stateful Set Scaled Up Correctly", mongodbtests.StatefulSetBecomesReady(&mdb))
+	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+
 	// t.Run("AutomationConfig's version has been increased", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 3))
 }

--- a/test/e2e/util/wait/wait.go
+++ b/test/e2e/util/wait/wait.go
@@ -149,7 +149,7 @@ func waitForStatefulSetConditionWithSpecificSts(t *testing.T, mdb *mdbv1.MongoDB
 			return false, err
 		}
 		t.Logf("Waiting for %s to have %d replicas. Current ready replicas: %d, Current updated replicas: %d, Current generation: %d, Observed Generation: %d\n",
-			mdb.Name, mdb.Spec.Members, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas, sts.Generation, sts.Status.ObservedGeneration)
+			name, mdb.Spec.Members, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas, sts.Generation, sts.Status.ObservedGeneration)
 		ready := condition(sts)
 		return ready, nil
 	})


### PR DESCRIPTION
# Summary

- Deploys arbiters to a new (different) StatefulSet to be able to scale both arbiters and members independently.
- RFC is here (private): https://github.com/10gen/ops-manager-kubernetes/pull/2064