### PR TITLE
Pass optional string in secret methods

### DIFF
--- a/pkg/authentication/scram/mock_types_test.go
+++ b/pkg/authentication/scram/mock_types_test.go
@@ -11,21 +11,21 @@ type mockSecretGetUpdateCreateDeleter struct {
 	secrets map[client.ObjectKey]corev1.Secret
 }
 
-func (c mockSecretGetUpdateCreateDeleter) DeleteSecret(objectKey client.ObjectKey) error {
+func (c mockSecretGetUpdateCreateDeleter) DeleteSecret(objectKey client.ObjectKey, path ...string) error {
 	delete(c.secrets, objectKey)
 	return nil
 }
 
-func (c mockSecretGetUpdateCreateDeleter) UpdateSecret(s corev1.Secret) error {
+func (c mockSecretGetUpdateCreateDeleter) UpdateSecret(s corev1.Secret, path ...string) error {
 	c.secrets[types.NamespacedName{Name: s.Name, Namespace: s.Namespace}] = s
 	return nil
 }
 
-func (c mockSecretGetUpdateCreateDeleter) CreateSecret(secret corev1.Secret) error {
+func (c mockSecretGetUpdateCreateDeleter) CreateSecret(secret corev1.Secret, path ...string) error {
 	return c.UpdateSecret(secret)
 }
 
-func (c mockSecretGetUpdateCreateDeleter) GetSecret(objectKey client.ObjectKey) (corev1.Secret, error) {
+func (c mockSecretGetUpdateCreateDeleter) GetSecret(objectKey client.ObjectKey, path ...string) (corev1.Secret, error) {
 	if s, ok := c.secrets[objectKey]; !ok {
 		return corev1.Secret{}, notFoundError()
 	} else {

--- a/pkg/automationconfig/automation_config_secret_test.go
+++ b/pkg/automationconfig/automation_config_secret_test.go
@@ -83,7 +83,7 @@ type mockSecretGetUpdateCreator struct {
 	secret *corev1.Secret
 }
 
-func (m *mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey) (corev1.Secret, error) {
+func (m *mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey, path ...string) (corev1.Secret, error) {
 	if m.secret != nil {
 		if objectKey.Name == m.secret.Name && objectKey.Namespace == m.secret.Namespace {
 			return *m.secret, nil
@@ -92,12 +92,12 @@ func (m *mockSecretGetUpdateCreator) GetSecret(objectKey client.ObjectKey) (core
 	return corev1.Secret{}, notFoundError()
 }
 
-func (m *mockSecretGetUpdateCreator) UpdateSecret(secret corev1.Secret) error {
+func (m *mockSecretGetUpdateCreator) UpdateSecret(secret corev1.Secret, path ...string) error {
 	m.secret = &secret
 	return nil
 }
 
-func (m *mockSecretGetUpdateCreator) CreateSecret(secret corev1.Secret) error {
+func (m *mockSecretGetUpdateCreator) CreateSecret(secret corev1.Secret, path ...string) error {
 	if m.secret == nil {
 		m.secret = &secret
 		return nil

--- a/pkg/kube/client/client.go
+++ b/pkg/kube/client/client.go
@@ -95,7 +95,7 @@ func (c client) GetPod(objectKey k8sClient.ObjectKey) (corev1.Pod, error) {
 }
 
 // GetSecret provides a thin wrapper and client.Client to access corev1.Secret types
-func (c client) GetSecret(objectKey k8sClient.ObjectKey) (corev1.Secret, error) {
+func (c client) GetSecret(objectKey k8sClient.ObjectKey, path ...string) (corev1.Secret, error) {
 	s := corev1.Secret{}
 	if err := c.Get(context.TODO(), objectKey, &s); err != nil {
 		return corev1.Secret{}, err
@@ -104,17 +104,17 @@ func (c client) GetSecret(objectKey k8sClient.ObjectKey) (corev1.Secret, error) 
 }
 
 // UpdateSecret provides a thin wrapper and client.Client to update corev1.Secret types
-func (c client) UpdateSecret(secret corev1.Secret) error {
+func (c client) UpdateSecret(secret corev1.Secret, path ...string) error {
 	return c.Update(context.TODO(), &secret)
 }
 
 // CreateSecret provides a thin wrapper and client.Client to create corev1.Secret types
-func (c client) CreateSecret(secret corev1.Secret) error {
+func (c client) CreateSecret(secret corev1.Secret, path ...string) error {
 	return c.Create(context.TODO(), &secret)
 }
 
 // DeleteSecret provides a thin wrapper and client.Client to delete corev1.Secret types
-func (c client) DeleteSecret(key k8sClient.ObjectKey) error {
+func (c client) DeleteSecret(key k8sClient.ObjectKey, path ...string) error {
 	s := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.Name,

--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -13,19 +13,19 @@ import (
 )
 
 type Getter interface {
-	GetSecret(objectKey client.ObjectKey) (corev1.Secret, error)
+	GetSecret(objectKey client.ObjectKey, path ...string) (corev1.Secret, error)
 }
 
 type Updater interface {
-	UpdateSecret(secret corev1.Secret) error
+	UpdateSecret(secret corev1.Secret, path ...string) error
 }
 
 type Creator interface {
-	CreateSecret(secret corev1.Secret) error
+	CreateSecret(secret corev1.Secret, path ...string) error
 }
 
 type Deleter interface {
-	DeleteSecret(objectKey client.ObjectKey) error
+	DeleteSecret(objectKey client.ObjectKey, path ...string) error
 }
 
 type GetUpdater interface {

--- a/pkg/kube/secret/secret_test.go
+++ b/pkg/kube/secret/secret_test.go
@@ -15,7 +15,7 @@ type secretGetter struct {
 	secret corev1.Secret
 }
 
-func (c secretGetter) GetSecret(objectKey client.ObjectKey) (corev1.Secret, error) {
+func (c secretGetter) GetSecret(objectKey client.ObjectKey, path ...string) (corev1.Secret, error) {
 	if c.secret.Name == objectKey.Name && c.secret.Namespace == objectKey.Namespace {
 		return c.secret, nil
 	}
@@ -95,14 +95,14 @@ type secretGetUpdater struct {
 	secret corev1.Secret
 }
 
-func (c secretGetUpdater) GetSecret(objectKey client.ObjectKey) (corev1.Secret, error) {
+func (c secretGetUpdater) GetSecret(objectKey client.ObjectKey, path ...string) (corev1.Secret, error) {
 	if c.secret.Name == objectKey.Name && c.secret.Namespace == objectKey.Namespace {
 		return c.secret, nil
 	}
 	return corev1.Secret{}, notFoundError()
 }
 
-func (c *secretGetUpdater) UpdateSecret(s corev1.Secret) error {
+func (c *secretGetUpdater) UpdateSecret(s corev1.Secret, path ...string) error {
 	c.secret = s
 	return nil
 }


### PR DESCRIPTION
This is needed for vault secret backend, if in future we need to pass more params,
we can consider wrapping it in a struct

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
