### PR TITLE
CLOUDP-105593: Agent image to ubi8-minimal

### DIFF
--- a/scripts/dev/templates/agent/Dockerfile.ubi
+++ b/scripts/dev/templates/agent/Dockerfile.ubi
@@ -8,5 +8,5 @@ RUN microdnf install -y  --disableplugin=subscription-manager curl \
     && microdnf upgrade -y  \
     && rm -rf /var/lib/apt/lists/*
 
-RUN microdnf remove perl-IO-Socket-SSL procps
+RUN microdnf remove perl-IO-Socket-SSL
 {% endblock -%}

--- a/scripts/dev/templates/agent/Dockerfile.ubi
+++ b/scripts/dev/templates/agent/Dockerfile.ubi
@@ -1,10 +1,12 @@
 {% extends "Dockerfile.template" %}
 
-{% set base_image = "registry.access.redhat.com/ubi7/ubi" %}
+{% set base_image = "registry.access.redhat.com/ubi8/ubi-minimal" %}
 
 {% block packages -%}
-RUN yum install -y  --disableplugin=subscription-manager -q curl \
-    hostname nss_wrapper --exclude perl-IO-Socket-SSL procps \
-    && yum upgrade -y -q \
+RUN microdnf install -y  --disableplugin=subscription-manager curl \
+    hostname nss_wrapper tar gzip\
+    && microdnf upgrade -y  \
     && rm -rf /var/lib/apt/lists/*
+
+RUN microdnf remove perl-IO-Socket-SSL procps
 {% endblock -%}

--- a/scripts/dev/templates/agent/Dockerfile.ubi
+++ b/scripts/dev/templates/agent/Dockerfile.ubi
@@ -4,7 +4,7 @@
 
 {% block packages -%}
 RUN microdnf install -y  --disableplugin=subscription-manager curl \
-    hostname nss_wrapper tar gzip\
+    hostname nss_wrapper tar gzip procps\
     && microdnf upgrade -y  \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Updates the agent image to use ubi8-minimal instead of ubi7.

