### PR TITLE
Compatibility with Restricted PodSecurityPolicy (Operator Only)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,4 +67,7 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsUser: 2000
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: mongodb-kubernetes-operator


### PR DESCRIPTION
Setting the `RuntimeDefault` seccomp profile is required for running the operator under the Restricted policy of [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).

Note that this PR only enables running the operator itself under the Restricted policy, and not the MongoDB StatefulSets created by the operator. For the latter, further changes are required: https://github.com/mongodb/mongodb-kubernetes-operator/issues/833

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you signed all of your commits?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
