### PR TITLE
Update mongodb.com_v1_hostpath.yaml

### DIFF
--- a/config/samples/arbitrary_statefulset_configuration/mongodb.com_v1_hostpath.yaml
+++ b/config/samples/arbitrary_statefulset_configuration/mongodb.com_v1_hostpath.yaml
@@ -32,33 +32,33 @@ spec:
               runAsUser: 0
               runAsGroup: 0
             name: change-dir-permissions
-        volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes:
-            - ReadWriteOnce
-            resources:
-              requests:
-                storage: 8G
-            selector:
-              matchLabels:
-                # We set this labels when creating the volume
-                # (see below)
-                type: data
-            storageClassName: default
-        - metadata:
-            name: logs-volume
-          spec:
-            accessModes:
-            - ReadWriteOnce
-            resources:
-              requests:
-                storage: 8G
-            selector:
-              matchLabels:
-                type: logs
-            storageClassName: default
+      volumeClaimTemplates:
+      - metadata:
+          name: data-volume
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 8G
+          selector:
+            matchLabels:
+              # We set this labels when creating the volume
+              # (see below)
+              type: data
+          storageClassName: default
+      - metadata:
+          name: logs-volume
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 8G
+          selector:
+            matchLabels:
+              type: logs
+          storageClassName: default
   type: ReplicaSet
   users:
     - name: my-user


### PR DESCRIPTION
volumeClaimTemplates should under statefulSet.spec, not statefulSet.spec.template

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
