### PR TITLE
Make mongod port configurable

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -295,7 +295,7 @@ func (m MongodConfiguration) GetDBDataDir() string {
 }
 
 // GetDBPort returns the port that should be used for the mongod process.
-// If not port is specified, the default port of 27017 will be used.
+// If port is not specified, the default port of 27017 will be used.
 func (m MongodConfiguration) GetDBPort() int {
 	// When passed as a number "net.port" is unmarshalled into a float64
 	return int(objx.New(m.Object).Get("net.port").Float64(defaultDBPort))

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -29,6 +29,8 @@ type Type string
 const (
 	ReplicaSet       Type   = "ReplicaSet"
 	defaultDBForUser string = "admin"
+	defaultDataDir          = "/data"
+	defaultDBPort           = 27017
 )
 
 type Phase string
@@ -276,6 +278,29 @@ func (m *MongodConfiguration) DeepCopy() *MongodConfiguration {
 	}
 }
 
+// NewMongodConfiguration returns an empty MongodConfiguration
+func NewMongodConfiguration() MongodConfiguration {
+	return MongodConfiguration{Object: map[string]interface{}{}}
+}
+
+// SetOption updated the MongodConfiguration with a new option
+func (m MongodConfiguration) SetOption(key string, value interface{}) MongodConfiguration {
+	m.Object = objx.New(m.Object).Set(key, value)
+	return m
+}
+
+// GetDBDataDir returns the db path which should be used.
+func (m MongodConfiguration) GetDBDataDir() string {
+	return objx.New(m.Object).Get("storage.dbPath").Str(defaultDataDir)
+}
+
+// GetDBPort returns the port that should be used for the mongod process.
+// If not port is specified, the default port of 27017 will be used.
+func (m MongodConfiguration) GetDBPort() int {
+	// When passed as a number "net.port" is unmarshalled into a float64
+	return int(objx.New(m.Object).Get("net.port").Float64(defaultDBPort))
+}
+
 type MongoDBUser struct {
 	// Name is the username of the user
 	Name string `json:"name"`
@@ -436,10 +461,10 @@ type MongoDBCommunity struct {
 	Status MongoDBCommunityStatus `json:"status,omitempty"`
 }
 
-func (m MongoDBCommunity) GetMongodConfiguration() map[string]interface{} {
-	mongodConfig := objx.New(map[string]interface{}{})
+func (m MongoDBCommunity) GetMongodConfiguration() MongodConfiguration {
+	mongodConfig := NewMongodConfiguration()
 	for k, v := range m.Spec.AdditionalMongodConfig.Object {
-		mongodConfig.Set(k, v)
+		mongodConfig.SetOption(k, v)
 	}
 	return mongodConfig
 }
@@ -608,7 +633,12 @@ func (m MongoDBCommunity) Hosts(clusterDomain string) []string {
 	}
 
 	for i := 0; i < m.Spec.Members; i++ {
-		hosts[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d", m.Name, i, m.ServiceName(), m.Namespace, clusterDomain, 27017)
+		hosts[i] = fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
+			m.Name, i,
+			m.ServiceName(),
+			m.Namespace,
+			clusterDomain,
+			m.GetMongodConfiguration().GetDBPort())
 	}
 	return hosts
 }

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -29,8 +29,6 @@ type Type string
 const (
 	ReplicaSet       Type   = "ReplicaSet"
 	defaultDBForUser string = "admin"
-	defaultDataDir          = "/data"
-	defaultDBPort           = 27017
 )
 
 type Phase string
@@ -291,14 +289,14 @@ func (m MongodConfiguration) SetOption(key string, value interface{}) MongodConf
 
 // GetDBDataDir returns the db path which should be used.
 func (m MongodConfiguration) GetDBDataDir() string {
-	return objx.New(m.Object).Get("storage.dbPath").Str(defaultDataDir)
+	return objx.New(m.Object).Get("storage.dbPath").Str(automationconfig.DefaultMongoDBDataDir)
 }
 
 // GetDBPort returns the port that should be used for the mongod process.
 // If port is not specified, the default port of 27017 will be used.
 func (m MongodConfiguration) GetDBPort() int {
 	// When passed as a number "net.port" is unmarshalled into a float64
-	return int(objx.New(m.Object).Get("net.port").Float64(defaultDBPort))
+	return int(objx.New(m.Object).Get("net.port").Float64(float64(automationconfig.DefaultDBPort)))
 }
 
 type MongoDBUser struct {

--- a/api/v1/mongodbcommunity_types_test.go
+++ b/api/v1/mongodbcommunity_types_test.go
@@ -17,6 +17,31 @@ func TestMongoDB_MongoURI(t *testing.T) {
 	mdb = newReplicaSet(5, "my-big-rs", "my-big-namespace")
 	assert.Equal(t, mdb.MongoURI(""), "mongodb://my-big-rs-0.my-big-rs-svc.my-big-namespace.svc.cluster.local:27017,my-big-rs-1.my-big-rs-svc.my-big-namespace.svc.cluster.local:27017,my-big-rs-2.my-big-rs-svc.my-big-namespace.svc.cluster.local:27017,my-big-rs-3.my-big-rs-svc.my-big-namespace.svc.cluster.local:27017,my-big-rs-4.my-big-rs-svc.my-big-namespace.svc.cluster.local:27017")
 	assert.Equal(t, mdb.MongoURI("my.cluster"), "mongodb://my-big-rs-0.my-big-rs-svc.my-big-namespace.svc.my.cluster:27017,my-big-rs-1.my-big-rs-svc.my-big-namespace.svc.my.cluster:27017,my-big-rs-2.my-big-rs-svc.my-big-namespace.svc.my.cluster:27017,my-big-rs-3.my-big-rs-svc.my-big-namespace.svc.my.cluster:27017,my-big-rs-4.my-big-rs-svc.my-big-namespace.svc.my.cluster:27017")
+	mdb = newReplicaSet(2, "my-rs", "my-namespace")
+	mdb.Spec.AdditionalMongodConfig.Object = map[string]interface{}{
+		"net.port": 40333.,
+	}
+	assert.Equal(t, mdb.MongoURI(""), "mongodb://my-rs-0.my-rs-svc.my-namespace.svc.cluster.local:40333,my-rs-1.my-rs-svc.my-namespace.svc.cluster.local:40333")
+	assert.Equal(t, mdb.MongoURI("my.cluster"), "mongodb://my-rs-0.my-rs-svc.my-namespace.svc.my.cluster:40333,my-rs-1.my-rs-svc.my-namespace.svc.my.cluster:40333")
+}
+
+func TestMongodConfiguration(t *testing.T) {
+	mc := NewMongodConfiguration()
+	assert.Equal(t, mc.Object, map[string]interface{}{})
+	assert.Equal(t, mc.GetDBDataDir(), defaultDataDir)
+	assert.Equal(t, mc.GetDBPort(), defaultDBPort)
+	mc.SetOption("net.port", 40333.)
+	assert.Equal(t, mc.GetDBPort(), 40333)
+	mc.SetOption("storage", map[string]interface{}{"dbPath": "/other/data/path"})
+	assert.Equal(t, mc.GetDBDataDir(), "/other/data/path")
+	assert.Equal(t, mc.Object, map[string]interface{}{
+		"net": map[string]interface{}{
+			"port": 40333.,
+		},
+		"storage": map[string]interface{}{
+			"dbPath": "/other/data/path",
+		},
+	})
 }
 
 func TestGetScramCredentialsSecretName(t *testing.T) {

--- a/api/v1/mongodbcommunity_types_test.go
+++ b/api/v1/mongodbcommunity_types_test.go
@@ -28,8 +28,8 @@ func TestMongoDB_MongoURI(t *testing.T) {
 func TestMongodConfiguration(t *testing.T) {
 	mc := NewMongodConfiguration()
 	assert.Equal(t, mc.Object, map[string]interface{}{})
-	assert.Equal(t, mc.GetDBDataDir(), defaultDataDir)
-	assert.Equal(t, mc.GetDBPort(), defaultDBPort)
+	assert.Equal(t, mc.GetDBDataDir(), "/data")
+	assert.Equal(t, mc.GetDBPort(), 27017)
 	mc.SetOption("net.port", 40333.)
 	assert.Equal(t, mc.GetDBPort(), 40333)
 	mc.SetOption("storage", map[string]interface{}{"dbPath": "/other/data/path"})

--- a/controllers/construct/build_statefulset_test.go
+++ b/controllers/construct/build_statefulset_test.go
@@ -61,7 +61,7 @@ func TestMultipleCalls_DoNotCauseSideEffects(t *testing.T) {
 }
 
 func TestMongod_Container(t *testing.T) {
-	c := container.New(mongodbContainer("4.2", []corev1.VolumeMount{}, map[string]interface{}{}))
+	c := container.New(mongodbContainer("4.2", []corev1.VolumeMount{}, mdbv1.NewMongodConfiguration()))
 
 	t.Run("Has correct Env vars", func(t *testing.T) {
 		assert.Len(t, c.Env, 1)
@@ -75,25 +75,6 @@ func TestMongod_Container(t *testing.T) {
 
 	t.Run("Resource requirements are correct", func(t *testing.T) {
 		assert.Equal(t, resourcerequirements.Defaults(), c.Resources)
-	})
-}
-
-func TestGetDbPath(t *testing.T) {
-	t.Run("Test default is used if unspecifed", func(t *testing.T) {
-		m := map[string]interface{}{}
-		path := GetDBDataDir(m)
-		assert.Equal(t, defaultDataDir, path)
-	})
-
-	t.Run("Test storage.dbPath is used if specified", func(t *testing.T) {
-		m := map[string]interface{}{
-			"storage": map[string]interface{}{
-				"dbPath": "/data/db",
-			},
-		}
-
-		path := GetDBDataDir(m)
-		assert.Equal(t, "/data/db", path)
 	})
 }
 

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/merge"
 	"os"
 
 	"github.com/imdario/mergo"
@@ -18,6 +17,7 @@ import (
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/container"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/functions"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/merge"
 
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/agent"
 
@@ -492,7 +492,8 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Aut
 		SetFCV(mdb.Spec.FeatureCompatibilityVersion).
 		SetOptions(automationconfig.Options{DownloadBase: "/var/lib/mongodb-mms-automation"}).
 		SetAuth(auth).
-		SetDataDir(construct.GetDBDataDir(mdb.GetMongodConfiguration())).
+		SetDataDir(mdb.GetMongodConfiguration().GetDBDataDir()).
+		SetPort(mdb.GetMongodConfiguration().GetDBPort()).
 		AddModifications(getMongodConfigModification(mdb)).
 		AddModifications(modifications...).
 		Build()
@@ -519,7 +520,7 @@ func buildService(mdb mdbv1.MongoDBCommunity, isArbiter bool) corev1.Service {
 		SetSelector(label).
 		SetServiceType(corev1.ServiceTypeClusterIP).
 		SetClusterIP("None").
-		SetPort(27017).
+		SetPort(int32(mdb.GetMongodConfiguration().GetDBPort())).
 		SetPortName("mongodb").
 		SetPublishNotReadyAddresses(true).
 		SetOwnerReferences(mdb.GetOwnerReferences()).

--- a/controllers/testdata/specify_net_port.yaml
+++ b/controllers/testdata/specify_net_port.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: example-mongodb
+  namespace: test-ns
+spec:
+  members: 3
+  type: ReplicaSet
+  version: "4.2.6"
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: my-user
+      db: admin
+      passwordSecretRef:
+        name: my-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: my-scram
+  additionalMongodConfig:
+    net.port: 40333

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -11,6 +11,7 @@ import (
 const (
 	Mongod                ProcessType = "mongod"
 	DefaultMongoDBDataDir string      = "/data"
+	DefaultDBPort         int         = 27017
 	DefaultAgentLogPath   string      = "/var/log/mongodb-mms-automation"
 )
 

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -17,7 +17,6 @@ const (
 	ReplicaSetTopology    Topology = "ReplicaSet"
 	maxVotingMembers      int      = 7
 	arbitersStartingIndex int      = 100
-	defaultPort           int      = 27017
 )
 
 type Modification func(*AutomationConfig)
@@ -63,7 +62,7 @@ func NewBuilder() *Builder {
 		backupVersions:       []BackupVersion{},
 		monitoringVersions:   []MonitoringVersion{},
 		processModifications: []func(int, *Process){},
-		port:                 defaultPort,
+		port:                 DefaultDBPort,
 		tlsConfig:            nil,
 		sslConfig:            nil,
 	}

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -17,6 +17,7 @@ const (
 	ReplicaSetTopology    Topology = "ReplicaSet"
 	maxVotingMembers      int      = 7
 	arbitersStartingIndex int      = 100
+	defaultPort           int      = 27017
 )
 
 type Modification func(*AutomationConfig)
@@ -50,6 +51,7 @@ type Builder struct {
 	sslConfig            *TLS
 	tlsConfig            *TLS
 	dataDir              string
+	port                 int
 }
 
 func NewBuilder() *Builder {
@@ -61,6 +63,7 @@ func NewBuilder() *Builder {
 		backupVersions:       []BackupVersion{},
 		monitoringVersions:   []MonitoringVersion{},
 		processModifications: []func(int, *Process){},
+		port:                 defaultPort,
 		tlsConfig:            nil,
 		sslConfig:            nil,
 	}
@@ -118,6 +121,11 @@ func (b *Builder) SetName(name string) *Builder {
 
 func (b *Builder) SetDataDir(dataDir string) *Builder {
 	b.dataDir = dataDir
+	return b
+}
+
+func (b *Builder) SetPort(port int) *Builder {
+	b.port = port
 	return b
 }
 
@@ -266,7 +274,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 			AuthSchemaVersion:           5,
 		}
 
-		process.SetPort(27017)
+		process.SetPort(b.port)
 		process.SetStoragePath(dataDir)
 		process.SetReplicaSetName(b.name)
 

--- a/pkg/util/merge/merge_automationconfigs_test.go
+++ b/pkg/util/merge/merge_automationconfigs_test.go
@@ -1,9 +1,10 @@
 package merge
 
 import (
+	"testing"
+
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMergeAutomationConfigs(t *testing.T) {
@@ -52,7 +53,6 @@ func TestMergeAutomationConfigs_NonExistentMember(t *testing.T) {
 		}).Build()
 
 	assert.NoError(t, err)
-
 
 	assert.False(t, override.Processes[0].Disabled)
 	assert.True(t, override.Processes[1].Disabled)

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -147,6 +147,19 @@ func ServiceHasOwnerReference(mdb *mdbv1.MongoDBCommunity, expectedOwnerReferenc
 	}
 }
 
+func ServiceUsesCorrectPort(mdb *mdbv1.MongoDBCommunity, expectedPort int32) func(t *testing.T) {
+	return func(t *testing.T) {
+		serviceNamespacedName := types.NamespacedName{Name: mdb.ServiceName(), Namespace: mdb.Namespace}
+		svc := corev1.Service{}
+		err := e2eutil.TestClient.Get(context.TODO(), serviceNamespacedName, &svc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, svc.Spec.Ports, 1)
+		assert.Equal(t, svc.Spec.Ports[0], corev1.ServicePort{Port: expectedPort, Name: "mongodb"})
+	}
+}
+
 func AgentSecretsHaveOwnerReference(mdb *mdbv1.MongoDBCommunity, expectedOwnerReference metav1.OwnerReference) func(t *testing.T) {
 	checkSecret := func(t *testing.T, resourceNamespacedName types.NamespacedName) {
 		secret := corev1.Secret{}

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -156,7 +156,7 @@ func ServiceUsesCorrectPort(mdb *mdbv1.MongoDBCommunity, expectedPort int32) fun
 			t.Fatal(err)
 		}
 		assert.Len(t, svc.Spec.Ports, 1)
-		assert.Equal(t, svc.Spec.Ports[0], corev1.ServicePort{Port: expectedPort, Name: "mongodb"})
+		assert.Equal(t, svc.Spec.Ports[0].Port, expectedPort)
 	}
 }
 

--- a/test/e2e/replica_set_mongod_config/replica_set_mongod_config_test.go
+++ b/test/e2e/replica_set_mongod_config/replica_set_mongod_config_test.go
@@ -41,13 +41,11 @@ func TestReplicaSet(t *testing.T) {
 	settings := []string{
 		"storage.wiredTiger.engineConfig.journalCompressor",
 		"storage.dbPath",
-		"net.port",
 	}
 
-	values := []interface{}{
+	values := []string{
 		"zlib",
 		"/some/path/db",
-		40333.,
 	}
 
 	// Override the journal compressor and dbPath settings
@@ -55,6 +53,9 @@ func TestReplicaSet(t *testing.T) {
 	for i := range settings {
 		mongodConfig.Set(settings[i], values[i])
 	}
+
+	// Override the net.port setting
+	mongodConfig.Set("net.port", 40333.)
 
 	mdb.Spec.AdditionalMongodConfig.Object = mongodConfig
 
@@ -66,5 +67,6 @@ func TestReplicaSet(t *testing.T) {
 	for i := range settings {
 		t.Run(fmt.Sprintf("Mongod setting %s has been set", settings[i]), tester.EnsureMongodConfig(settings[i], values[i]))
 	}
+	t.Run("Mongod setting net.port has been set", tester.EnsureMongodConfig("net.port", int32(40333)))
 	t.Run("Service has the correct port", mongodbtests.ServiceUsesCorrectPort(&mdb, 40333))
 }


### PR DESCRIPTION
This addresses #839 and moves `mongod` configurations handled by the operator to the `MongodConfiguration` type.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you signed all of your commits?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
