### PR TITLE
Fix merging Args26 with shallow copy of mongod args

### DIFF
--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -94,7 +94,6 @@ func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		assert.NoError(t, err)
 		ac, err := buildAutomationConfig(mdb, automationconfig.Auth{}, automationconfig.AutomationConfig{}, tlsModification)
 		assert.NoError(t, err)
-
 		return ac
 	}
 

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -620,7 +620,7 @@ func getMongodConfigModification(mdb mdbv1.MongoDBCommunity) automationconfig.Mo
 		for i := range ac.Processes {
 			// Mergo requires both objects to have the same type
 			// TODO: handle this error gracefully, we may need to add an error as second argument for all modification functions
-			_ = mergo.Merge(&ac.Processes[i].Args26, objx.New(mdb.Spec.AdditionalMongodConfig.Object), mergo.WithOverride)
+			_ = mergo.Merge(&ac.Processes[i].Args26, objx.New(mdb.GetMongodConfiguration().Object), mergo.WithOverride)
 		}
 	}
 }

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -373,6 +373,21 @@ func TestAutomationConfigFCVIsNotIncreasedWhenUpgradingMinorVersion(t *testing.T
 
 }
 
+func TestAutomationConfig_Args26StoredAsNestedMap(t *testing.T) {
+	mdb, err := loadTestFixture("duplicate_additional_config.yaml")
+	assert.NoError(t, err)
+	mgr := client.NewManager(&mdb)
+	assert.NoError(t, generatePasswordsForAllUsers(mdb, mgr.Client))
+	r := NewReconciler(mgr)
+
+	ac, err := r.buildAutomationConfig(mdb)
+	assert.NoError(t, err)
+	for _, p := range ac.Processes {
+		assert.Equal(t, p.Args26.Get("deep.nested.value").String(), "first")
+		assert.Equal(t, p.Args26["deep"], map[string]interface{}{"nested": map[string]interface{}{"value": "first"}})
+	}
+}
+
 func TestAutomationConfig_CustomMongodConfig(t *testing.T) {
 	mdb := newTestReplicaSet()
 

--- a/controllers/testdata/duplicate_additional_config.yaml
+++ b/controllers/testdata/duplicate_additional_config.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: example-mongodb
+  namespace: test-ns
+spec:
+  members: 3
+  type: ReplicaSet
+  version: "4.2.6"
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: my-user
+      db: admin
+      passwordSecretRef:
+        name: my-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: my-scram
+  additionalMongodConfig:
+    deep:
+      nested.value: "first"


### PR DESCRIPTION
This patch ensures that args passed to the `mongod` processes end up in nested keys in the automation config json, and not under keys with dot notation. 

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
