### PR TITLE
CLOUDP-107815: Do not append stale command/args to containers

### DIFF
--- a/pkg/util/merge/merge.go
+++ b/pkg/util/merge/merge.go
@@ -97,8 +97,14 @@ func Container(defaultContainer, overrideContainer corev1.Container) corev1.Cont
 		merged.Image = overrideContainer.Image
 	}
 
-	merged.Command = StringSlices(defaultContainer.Command, overrideContainer.Command)
-	merged.Args = StringSlices(defaultContainer.Args, overrideContainer.Args)
+	merged.Command = defaultContainer.Command
+	if len(overrideContainer.Command) > 0 {
+		merged.Command = overrideContainer.Command
+	}
+	merged.Args = defaultContainer.Args
+	if len(overrideContainer.Args) > 0 {
+		merged.Args = overrideContainer.Args
+	}
 
 	if overrideContainer.WorkingDir != "" {
 		merged.WorkingDir = overrideContainer.WorkingDir

--- a/pkg/util/merge/merge_test.go
+++ b/pkg/util/merge/merge_test.go
@@ -182,11 +182,11 @@ func TestMergeContainer(t *testing.T) {
 		)
 		mergedContainer := Container(defaultContainer, overrideContainer)
 		assert.Equal(t, overrideContainer.Name, mergedContainer.Name, "Name was overridden, and should be used.")
-		assert.Equal(t, []string{"a", "b", "c", "d", "f", "e"}, mergedContainer.Command, "Command was specified in both, so results should be merged.")
+		assert.Equal(t, []string{"d", "f", "e"}, mergedContainer.Command, "Command was specified in both, so results should be merged.")
 		assert.Equal(t, overrideContainer.Image, mergedContainer.Image, "Image was overridden, and should be used.")
 		assert.Equal(t, defaultContainer.ImagePullPolicy, mergedContainer.ImagePullPolicy, "No ImagePullPolicy was specified in the override, so the default should be used.")
 		assert.Equal(t, overrideContainer.WorkingDir, mergedContainer.WorkingDir)
-		assert.Equal(t, []string{"arg0", "arg1", "arg3", "arg2"}, mergedContainer.Args, "Args were specified in both, so results should be merged.")
+		assert.Equal(t, []string{"arg3", "arg2"}, mergedContainer.Args, "Args were specified in both, so results should be merged.")
 
 		assert.Equal(t, overrideContainer.Resources, mergedContainer.Resources)
 
@@ -259,11 +259,9 @@ func TestMergeContainer(t *testing.T) {
 	t.Run("No Override Fields", func(t *testing.T) {
 		mergedContainer := Container(defaultContainer, corev1.Container{})
 		assert.Equal(t, defaultContainer.Name, mergedContainer.Name, "Name was not overridden, and should not be used.")
-		assert.Equal(t, defaultContainer.Command, mergedContainer.Command, "Command was not specified. The original Command should be used.")
 		assert.Equal(t, defaultContainer.Image, mergedContainer.Image, "Image was not overridden, and should not be used.")
 		assert.Equal(t, defaultContainer.ImagePullPolicy, mergedContainer.ImagePullPolicy, "No ImagePullPolicy was specified in the override, so the default should be used.")
 		assert.Equal(t, defaultContainer.WorkingDir, mergedContainer.WorkingDir)
-		assert.Equal(t, defaultContainer.Args, mergedContainer.Args, "Args were not specified. The original Args should be used.")
 
 		assert.Equal(t, defaultContainer.Resources, mergedContainer.Resources)
 

--- a/pkg/util/merge/merge_test.go
+++ b/pkg/util/merge/merge_test.go
@@ -182,11 +182,11 @@ func TestMergeContainer(t *testing.T) {
 		)
 		mergedContainer := Container(defaultContainer, overrideContainer)
 		assert.Equal(t, overrideContainer.Name, mergedContainer.Name, "Name was overridden, and should be used.")
-		assert.Equal(t, []string{"d", "f", "e"}, mergedContainer.Command, "Command was specified in both, so results should be merged.")
+		assert.Equal(t, []string{"d", "f", "e"}, mergedContainer.Command, "Command specified in the override container overrides the default container.")
 		assert.Equal(t, overrideContainer.Image, mergedContainer.Image, "Image was overridden, and should be used.")
 		assert.Equal(t, defaultContainer.ImagePullPolicy, mergedContainer.ImagePullPolicy, "No ImagePullPolicy was specified in the override, so the default should be used.")
 		assert.Equal(t, overrideContainer.WorkingDir, mergedContainer.WorkingDir)
-		assert.Equal(t, []string{"arg3", "arg2"}, mergedContainer.Args, "Args were specified in both, so results should be merged.")
+		assert.Equal(t, []string{"arg3", "arg2"}, mergedContainer.Args, "Args specified in the override container overrides the default container.")
 
 		assert.Equal(t, overrideContainer.Resources, mergedContainer.Resources)
 


### PR DESCRIPTION
### Summary:

Fixes:  https://github.com/mongodb/mongodb-kubernetes-operator/issues/818
This patch prevents the operator to merge command/args in containers.  It uses the one specified in the CR as the source of truth(if specified). The problem with the merging is highlighted in the linked issue. If a user removes a command/arg from a container the operator since it is currently merging the new commands/args with the old ones, it is keeping the removed args lurking around as well.


### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
