### PR TITLE
Fix Secret creation with username with rfc-1123 non-allowed-chars.

### DIFF
--- a/pkg/authentication/scram/scram.go
+++ b/pkg/authentication/scram/scram.go
@@ -3,6 +3,7 @@ package scram
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -339,5 +340,6 @@ func convertMongoDBUserToAutomationConfigUser(secretGetUpdateCreateDeleter secre
 
 // GetConnectionStringSecretName returns the name of the secret where the operator stores the connection string for current user
 func (u User) GetConnectionStringSecretName(mdb Configurable) string {
-	return fmt.Sprintf("%s-%s-%s", mdb.NamespacedName().Name, u.Database, u.Username)
+	username := strings.ReplaceAll(u.Username, "_", "-")
+	return fmt.Sprintf("%s-%s-%s", mdb.NamespacedName().Name, u.Database, username)
 }

--- a/pkg/authentication/scram/scram.go
+++ b/pkg/authentication/scram/scram.go
@@ -3,6 +3,7 @@ package scram
 import (
 	"encoding/base64"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -338,8 +339,24 @@ func convertMongoDBUserToAutomationConfigUser(secretGetUpdateCreateDeleter secre
 	return acUser, nil
 }
 
-// GetConnectionStringSecretName returns the name of the secret where the operator stores the connection string for current user
+// GetConnectionStringSecretName returns the name of the secret where the
+// operator stores the connection string for current user.
 func (u User) GetConnectionStringSecretName(mdb Configurable) string {
-	username := strings.ReplaceAll(u.Username, "_", "-")
-	return fmt.Sprintf("%s-%s-%s", mdb.NamespacedName().Name, u.Database, username)
+	return fmt.Sprintf("%s-%s-%s", mdb.NamespacedName().Name, u.Database, normalizeUsername(u.Username))
+}
+
+// normalizeUsername returns a string that conforms to RFC-1123, by replacing
+// non-allowed characters with `-`.
+//
+// The MongoDB username can contain the chars in `acceptedChars` variable, as
+// documented here: https://docs.mongodb.com/manual/reference/connection-string/.
+func normalizeUsername(username string) string {
+	acceptedChars := `[:\/\?#\[\]@_]`
+	re := regexp.MustCompile(acceptedChars)
+	username = re.ReplaceAllString(username, "-")
+
+	// Remove duplicate `-` resulting from contiguous non-allowed chars.
+	re = regexp.MustCompile(`\-+`)
+	username = re.ReplaceAllString(username, "-")
+	return strings.Trim(username, "-")
 }

--- a/pkg/authentication/scram/scram_test.go
+++ b/pkg/authentication/scram/scram_test.go
@@ -48,8 +48,15 @@ func newMockedSecretGetUpdateCreateDeleter(secrets ...corev1.Secret) secret.GetU
 	}
 	return mockSecretGetUpdateCreateDeleter
 }
+
 func notFoundError() error {
 	return &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+}
+
+func TestUsernameCanHaveAnUnderscore(t *testing.T) {
+	user := buildMongoDBUser("name_with_underscores")
+	mdb := buildConfigurable("mdb")
+	assert.Equal(t, "mdb-admin-name-with-underscores-user", user.GetConnectionStringSecretName(mdb))
 }
 
 func TestReadExistingCredentials(t *testing.T) {
@@ -74,7 +81,6 @@ func TestReadExistingCredentials(t *testing.T) {
 		_, _, err := readExistingCredentials(newMockedSecretGetUpdateCreateDeleter(scramCredsSecret), mdbObjectKey, "different-username")
 		assert.Error(t, err)
 	})
-
 }
 
 func TestComputeScramCredentials_ComputesSameStoredAndServerKey_WithSameSalt(t *testing.T) {
@@ -136,7 +142,6 @@ func TestEnsureScramCredentials(t *testing.T) {
 		assert.NotEmpty(t, scram256Creds.ServerKey)
 		assert.Equal(t, 15000, scram256Creds.IterationCount)
 	})
-
 }
 
 func TestConvertMongoDBUserToAutomationConfigUser(t *testing.T) {

--- a/pkg/authentication/scram/scram_test.go
+++ b/pkg/authentication/scram/scram_test.go
@@ -53,10 +53,14 @@ func notFoundError() error {
 	return &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
 }
 
-func TestUsernameCanHaveAnUnderscore(t *testing.T) {
-	user := buildMongoDBUser("name_with_underscores")
+func TestUsernameIsTransformedAndValid(t *testing.T) {
+	user := buildMongoDBUser("name_with@weird?chars")
 	mdb := buildConfigurable("mdb")
-	assert.Equal(t, "mdb-admin-name-with-underscores-user", user.GetConnectionStringSecretName(mdb))
+	assert.Equal(t, "mdb-admin-name-with-weird-chars-user", user.GetConnectionStringSecretName(mdb))
+}
+
+func TestUsernameCanHaveAn(t *testing.T) {
+	assert.Equal(t, "normalize-username-with-no-allowed-chars-only", normalizeUsername("?_normalize/_-username/?@with/[]?no]?/:allowed:chars[only?"))
 }
 
 func TestReadExistingCredentials(t *testing.T) {


### PR DESCRIPTION
- Fixes #879 

Username with underscore in name will prevent Secret from being created.

Open questions:

- Should we add other characters to be replaced as well?