### PR TITLE
Accepts `metrics.prometheus` endpoint.

### DIFF
--- a/.action_templates/jobs/tests.yaml
+++ b/.action_templates/jobs/tests.yaml
@@ -23,6 +23,8 @@ tests:
           distro: ubi
         - test-name: feature_compatibility_version_upgrade
           distro: ubi
+        - test-name: prometheus
+          distro: ubi
         - test-name: replica_set_tls
           distro: ubi
         - test-name: replica_set_tls_pem_file

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -105,6 +105,8 @@ jobs:
           distro: ubi
         - test-name: feature_compatibility_version_upgrade
           distro: ubi
+        - test-name: prometheus
+          distro: ubi
         - test-name: replica_set_tls
           distro: ubi
         - test-name: replica_set_tls_pem_file

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,6 +111,8 @@ jobs:
           distro: ubi
         - test-name: feature_compatibility_version_upgrade
           distro: ubi
+        - test-name: prometheus
+          distro: ubi
         - test-name: replica_set_tls
           distro: ubi
         - test-name: replica_set_tls_pem_file

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -107,9 +107,9 @@ type MongoDBCommunitySpec struct {
 	// by name. Currently Only the process.disabled field is supported.
 	AutomationConfigOverride *AutomationConfigOverride `json:"automationConfig,omitempty"`
 
-	// Metrics configurations.
+	// Prometheus configurations.
 	// +optional
-	Metrics *Metrics `json:"metrics,omitempty"`
+	Prometheus *Prometheus `json:"prometheus,omitempty"`
 }
 
 // ReplicaSetHorizonConfiguration holds the split horizon DNS settings for
@@ -130,10 +130,6 @@ type CustomRole struct {
 	// The authentication restrictions the server enforces on the role.
 	// +optional
 	AuthenticationRestrictions []AuthenticationRestriction `json:"authenticationRestrictions,omitempty"`
-}
-
-type Metrics struct {
-	Prometheus Prometheus `json:"prometheus,omitempty"`
 }
 
 type Prometheus struct {

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -106,6 +106,10 @@ type MongoDBCommunitySpec struct {
 	// AutomationConfigOverride is merged on top of the operator created automation config. Processes are merged
 	// by name. Currently Only the process.disabled field is supported.
 	AutomationConfigOverride *AutomationConfigOverride `json:"automationConfig,omitempty"`
+
+	// Metrics configurations.
+	// +optional
+	Metrics *Metrics `json:"metrics,omitempty"`
 }
 
 // ReplicaSetHorizonConfiguration holds the split horizon DNS settings for
@@ -126,6 +130,34 @@ type CustomRole struct {
 	// The authentication restrictions the server enforces on the role.
 	// +optional
 	AuthenticationRestrictions []AuthenticationRestriction `json:"authenticationRestrictions,omitempty"`
+}
+
+type Metrics struct {
+	Prometheus Prometheus `json:"prometheus,omitempty"`
+}
+
+type Prometheus struct {
+	// Port where metrics endpoint will bind to. Defaults to 9216.
+	// +optional
+	Port int `json:"port,omitempty"`
+
+	// HTTP Basic Auth Username for metrics endpoint.
+	Username string `json:"username"`
+
+	// Name of a Secret containing a HTTP Basic Auth Password.
+	PasswordSecretRef SecretKeyReference `json:"passwordSecretRef"`
+
+	// Indicates path to the metrics endpoint.
+	// +kubebuilder:validation:Pattern=^\/[a-z0-9]+$
+	MetricsPath string `json:"metricsPath,omitempty"`
+}
+
+func (p Prometheus) GetPasswordKey() string {
+	if p.PasswordSecretRef.Key != "" {
+		return p.PasswordSecretRef.Key
+	}
+
+	return "password"
 }
 
 // ConvertToAutomationConfigCustomRole converts between a custom role defined by the crd and a custom role

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -88,41 +88,37 @@ spec:
               members:
                 description: Members is the number of members in the replica set
                 type: integer
-              metrics:
-                description: Metrics configurations.
+              prometheus:
+                description: Prometheus configurations.
                 properties:
-                  prometheus:
+                  metricsPath:
+                    description: Indicates path to the metrics endpoint.
+                    pattern: ^\/[a-z0-9]+$
+                    type: string
+                  passwordSecretRef:
+                    description: Name of a Secret containing a HTTP Basic Auth Password.
                     properties:
-                      metricsPath:
-                        description: Indicates path to the metrics endpoint.
-                        pattern: ^\/[a-z0-9]+$
+                      key:
+                        description: Key is the key in the secret storing this password.
+                          Defaults to "password"
                         type: string
-                      passwordSecretRef:
-                        description: Name of a Secret containing a HTTP Basic Auth
-                          Password.
-                        properties:
-                          key:
-                            description: Key is the key in the secret storing this
-                              password. Defaults to "password"
-                            type: string
-                          name:
-                            description: Name is the name of the secret storing this
-                              user's password
-                            type: string
-                        required:
-                        - name
-                        type: object
-                      port:
-                        description: Port where metrics endpoint will bind to. Defaults
-                          to 9216.
-                        type: integer
-                      username:
-                        description: HTTP Basic Auth Username for metrics endpoint.
+                      name:
+                        description: Name is the name of the secret storing this user's
+                          password
                         type: string
                     required:
-                    - passwordSecretRef
-                    - username
+                    - name
                     type: object
+                  port:
+                    description: Port where metrics endpoint will bind to. Defaults
+                      to 9216.
+                    type: integer
+                  username:
+                    description: HTTP Basic Auth Username for metrics endpoint.
+                    type: string
+                required:
+                - passwordSecretRef
+                - username
                 type: object
               replicaSetHorizons:
                 description: ReplicaSetHorizons Add this parameter and values if you

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -88,6 +88,42 @@ spec:
               members:
                 description: Members is the number of members in the replica set
                 type: integer
+              metrics:
+                description: Metrics configurations.
+                properties:
+                  prometheus:
+                    properties:
+                      metricsPath:
+                        description: Indicates path to the metrics endpoint.
+                        pattern: ^\/[a-z0-9]+$
+                        type: string
+                      passwordSecretRef:
+                        description: Name of a Secret containing a HTTP Basic Auth
+                          Password.
+                        properties:
+                          key:
+                            description: Key is the key in the secret storing this
+                              password. Defaults to "password"
+                            type: string
+                          name:
+                            description: Name is the name of the secret storing this
+                              user's password
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      port:
+                        description: Port where metrics endpoint will bind to. Defaults
+                          to 9216.
+                        type: integer
+                      username:
+                        description: HTTP Basic Auth Username for metrics endpoint.
+                        type: string
+                    required:
+                    - passwordSecretRef
+                    - username
+                    type: object
+                type: object
               replicaSetHorizons:
                 description: ReplicaSetHorizons Add this parameter and values if you
                   need your database to be accessed outside of Kubernetes. This setting

--- a/config/samples/mongodb.com_v1_mongodbcommunity_prometheus.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_prometheus.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: example-prometheus
+spec:
+  members: 3
+  type: ReplicaSet
+  version: "5.0.6"
+
+  # You can expose metrics for Prometheus polling using the
+  # `metrics.prometheus` entry.
+  metrics:
+    prometheus:
+      # Metrics endpoint HTTP Basic Auth username
+      username: <username>
+
+      # Metrics endpoint HTTP Basic Auth password
+      passwordSecretRef:
+        name: metrics-endpoint-password
+
+      # Optional, defaults to `/metrics`
+      # metricsPath: /metrics
+
+      # Optional defaults to 9216
+      # port: 9216
+
+  security:
+    authentication:
+      modes: ["SCRAM"]
+
+  users:
+    - name: my-user
+      db: admin
+      passwordSecretRef:
+        name: my-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: my-scram
+
+# the user credentials will be generated from this secret
+# once the credentials are generated, this secret is no longer required
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-user-password
+type: Opaque
+stringData:
+  password: <your-user-password>
+
+# Secret holding the prometheus metrics endpoint HTTP Password.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-endpoint-password
+type: Opaque
+stringData:
+  password: <your-metrics-endpoint-password>

--- a/config/samples/mongodb.com_v1_mongodbcommunity_prometheus.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_prometheus.yaml
@@ -9,21 +9,20 @@ spec:
   version: "5.0.6"
 
   # You can expose metrics for Prometheus polling using the
-  # `metrics.prometheus` entry.
-  metrics:
-    prometheus:
-      # Metrics endpoint HTTP Basic Auth username
-      username: <username>
+  # `prometheus` entry.
+  prometheus:
+    # Metrics endpoint HTTP Basic Auth username
+    username: <username>
 
-      # Metrics endpoint HTTP Basic Auth password
-      passwordSecretRef:
-        name: metrics-endpoint-password
+    # Metrics endpoint HTTP Basic Auth password
+    passwordSecretRef:
+      name: metrics-endpoint-password
 
-      # Optional, defaults to `/metrics`
-      # metricsPath: /metrics
+    # Optional, defaults to `/metrics`
+    # metricsPath: /metrics
 
-      # Optional defaults to 9216
-      # port: 9216
+    # Optional defaults to 9216
+    # port: 9216
 
   security:
     authentication:

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -581,14 +581,14 @@ func (r ReplicaSetReconciler) buildAutomationConfig(mdb mdbv1.MongoDBCommunity) 
 	}
 
 	prometheusModification := automationconfig.NOOP()
-	if mdb.Spec.Metrics != nil {
-		secretNamespacedName := types.NamespacedName{Name: mdb.Spec.Metrics.Prometheus.PasswordSecretRef.Name, Namespace: mdb.Namespace}
+	if mdb.Spec.Prometheus != nil {
+		secretNamespacedName := types.NamespacedName{Name: mdb.Spec.Prometheus.PasswordSecretRef.Name, Namespace: mdb.Namespace}
 		r.secretWatcher.Watch(secretNamespacedName, mdb.NamespacedName())
 
-		password, err := secret.ReadKey(r.client, mdb.Spec.Metrics.Prometheus.GetPasswordKey(), secretNamespacedName)
+		password, err := secret.ReadKey(r.client, mdb.Spec.Prometheus.GetPasswordKey(), secretNamespacedName)
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
-				r.log.Infof("Could not read Secret %s. Prometheus will not be configured during this reconciliation, %s", mdb.Spec.Metrics.Prometheus.PasswordSecretRef.Name, err)
+				r.log.Infof("Could not read Secret %s. Prometheus will not be configured during this reconciliation, %s", mdb.Spec.Prometheus.PasswordSecretRef.Name, err)
 			} else {
 				return automationconfig.AutomationConfig{}, errors.Errorf("could not configure Prometheus modification: %s", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 )
 
 require (
+	cloud.google.com/go v0.54.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.54.0 h1:3ithwDMr7/3vpAMXiH+ZQnYbuIsh+OPhUPMFC9enmn0=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -661,6 +662,7 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -20,6 +20,7 @@ type AutomationConfig struct {
 	Processes   []Process    `json:"processes"`
 	ReplicaSets []ReplicaSet `json:"replicaSets"`
 	Auth        Auth         `json:"auth"`
+	Prometheus  *Prometheus  `json:"prometheus,omitempty"`
 
 	// TLSConfig and SSLConfig exist to allow configuration of older agents which accept the "ssl" field rather or "tls"
 	// only one of these should be set.
@@ -183,6 +184,31 @@ type Auth struct {
 	KeyFileWindows string `json:"keyfileWindows,omitempty"`
 	// AutoPwd is a required field when going from `Disabled=false` to `Disabled=true`
 	AutoPwd string `json:"autoPwd,omitempty"`
+}
+
+type Prometheus struct {
+	Enabled          bool   `json:"enabled"`
+	Username         string `json:"username"`
+	Password         string `json:"password"`
+	Scheme           string `json:"scheme"`
+	TLSPemPath       string `json:"tlsPemPath"`
+	TLSPemPassword   string `json:"tlsPemPassword"`
+	Mode             string `json:"mode"`
+	ListenAddress    string `json:"listenAddress"`
+	MetricsPath      string `json:"metricsPath"`
+	ServiceDiscovery string `json:"serviceDiscovery"`
+}
+
+func NewDefaultPrometheus(username string) Prometheus {
+	return Prometheus{
+		Enabled:          true,
+		Username:         username,
+		Scheme:           "http",
+		Mode:             "opsManager",
+		ListenAddress:    "0.0.0.0:9216",
+		MetricsPath:      "/metrics",
+		ServiceDiscovery: "file",
+	}
 }
 
 type CustomRole struct {

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"fmt"
+
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
 )
@@ -13,20 +14,20 @@ const (
 // PrometheusModification adds Prometheus configuration to the AutomationConfig.
 func PrometheusModification(mdb mdbv1.MongoDBCommunity, password string) automationconfig.Modification {
 	return func(config *automationconfig.AutomationConfig) {
-		if mdb.Spec.Metrics == nil {
+		if mdb.Spec.Prometheus == nil {
 			return
 		}
 
-		promConfig := automationconfig.NewDefaultPrometheus(mdb.Spec.Metrics.Prometheus.Username)
+		promConfig := automationconfig.NewDefaultPrometheus(mdb.Spec.Prometheus.Username)
 		promConfig.Scheme = "http"
 		promConfig.Password = password
 
-		if mdb.Spec.Metrics.Prometheus.Port > 0 {
-			promConfig.ListenAddress = fmt.Sprintf("%s:%d", listenAddress, mdb.Spec.Metrics.Prometheus.Port)
+		if mdb.Spec.Prometheus.Port > 0 {
+			promConfig.ListenAddress = fmt.Sprintf("%s:%d", listenAddress, mdb.Spec.Prometheus.Port)
 		}
 
-		if mdb.Spec.Metrics.Prometheus.MetricsPath != "" {
-			promConfig.MetricsPath = mdb.Spec.Metrics.Prometheus.MetricsPath
+		if mdb.Spec.Prometheus.MetricsPath != "" {
+			promConfig.MetricsPath = mdb.Spec.Prometheus.MetricsPath
 		}
 
 		config.Prometheus = &promConfig

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -1,0 +1,34 @@
+package monitoring
+
+import (
+	"fmt"
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
+)
+
+const (
+	listenAddress = "0.0.0.0"
+)
+
+// PrometheusModification adds Prometheus configuration to the AutomationConfig.
+func PrometheusModification(mdb mdbv1.MongoDBCommunity, password string) automationconfig.Modification {
+	return func(config *automationconfig.AutomationConfig) {
+		if mdb.Spec.Metrics == nil {
+			return
+		}
+
+		promConfig := automationconfig.NewDefaultPrometheus(mdb.Spec.Metrics.Prometheus.Username)
+		promConfig.Scheme = "http"
+		promConfig.Password = password
+
+		if mdb.Spec.Metrics.Prometheus.Port > 0 {
+			promConfig.ListenAddress = fmt.Sprintf("%s:%d", listenAddress, mdb.Spec.Metrics.Prometheus.Port)
+		}
+
+		if mdb.Spec.Metrics.Prometheus.MetricsPath != "" {
+			promConfig.MetricsPath = mdb.Spec.Metrics.Prometheus.MetricsPath
+		}
+
+		config.Prometheus = &promConfig
+	}
+}

--- a/release.json
+++ b/release.json
@@ -3,7 +3,7 @@
   "version-upgrade-hook": "1.0.4",
   "readiness-probe": "1.0.8",
   "mongodb-agent": {
-    "version": "11.0.11.7036-1",
+    "version": "11.12.0.7388-1",
     "tools_version": "100.5.1"
   }
 }

--- a/test/e2e/client.go
+++ b/test/e2e/client.go
@@ -20,6 +20,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+
+	// Needed for running tests on GCP
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // TestClient is the global client used by e2e tests.

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -159,7 +159,7 @@ func NewTestTLSConfig(optional bool) mdbv1.TLS {
 	}
 }
 
-func NewMetricsConfig(namespace string) *mdbv1.Metrics {
+func NewPrometheusConfig(namespace string) *mdbv1.Prometheus {
 	sec := secret.Builder().
 		SetName("prom-secret").
 		SetNamespace(namespace).
@@ -172,12 +172,10 @@ func NewMetricsConfig(namespace string) *mdbv1.Metrics {
 		}
 	}
 
-	return &mdbv1.Metrics{
-		Prometheus: mdbv1.Prometheus{
-			Username: "prom-user",
-			PasswordSecretRef: mdbv1.SecretKeyReference{
-				Name: "prom-secret",
-			},
+	return &mdbv1.Prometheus{
+		Username: "prom-user",
+		PasswordSecretRef: mdbv1.SecretKeyReference{
+			Name: "prom-secret",
 		},
 	}
 }

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/secret"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
@@ -154,6 +155,29 @@ func NewTestTLSConfig(optional bool) mdbv1.TLS {
 		},
 		CaCertificateSecret: &mdbv1.LocalObjectReference{
 			Name: "tls-ca-key-pair",
+		},
+	}
+}
+
+func NewMetricsConfig(namespace string) *mdbv1.Metrics {
+	sec := secret.Builder().
+		SetName("prom-secret").
+		SetNamespace(namespace).
+		SetField("password", "prom-password").
+		Build()
+	err := TestClient.Create(context.TODO(), &sec, &CleanupOptions{})
+	if err != nil {
+		if !apiErrors.IsAlreadyExists(err) {
+			panic(fmt.Sprintf("Error trying to create secret: %s", err))
+		}
+	}
+
+	return &mdbv1.Metrics{
+		Prometheus: mdbv1.Prometheus{
+			Username: "prom-user",
+			PasswordSecretRef: mdbv1.SecretKeyReference{
+				Name: "prom-secret",
+			},
 		},
 	}
 }

--- a/test/e2e/prometheus/prometheus_test.go
+++ b/test/e2e/prometheus/prometheus_test.go
@@ -1,0 +1,47 @@
+package prometheus
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
+
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+)
+
+func TestMain(m *testing.M) {
+	code, err := e2eutil.RunTest(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func TestReplicaSet(t *testing.T) {
+	ctx := setup.Setup(t)
+	defer ctx.Teardown()
+
+	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
+	mdb.Spec.Metrics = e2eutil.NewMetricsConfig(mdb.Namespace)
+
+	_, err := setup.GeneratePasswordForUser(ctx, user, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tester, err := FromResource(t, mdb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
+	t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
+	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
+	t.Run("Test Prometheus /metrics endpoint is active", tester.PrometheusEndpointIsReachable("prom-user", "prom-password"))
+	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
+	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
+}

--- a/test/e2e/prometheus/prometheus_test.go
+++ b/test/e2e/prometheus/prometheus_test.go
@@ -25,7 +25,7 @@ func TestReplicaSet(t *testing.T) {
 	defer ctx.Teardown()
 
 	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
-	mdb.Spec.Metrics = e2eutil.NewMetricsConfig(mdb.Namespace)
+	mdb.Spec.Prometheus = e2eutil.NewPrometheusConfig(mdb.Namespace)
 
 	_, err := setup.GeneratePasswordForUser(ctx, user, "")
 	if err != nil {


### PR DESCRIPTION
# Summary 

Using latest agent, we can pass a `spec.metrics.prometheus` configuration that will result in an automation_config change that *enables a `/metrics` endpoint that can be used with Prometheus.*

# Dependencies

We need to publish a new agent version before these changes are even recognized by the agents.