### PR TITLE
fix(pkg/automationconfig): do not try to access non-declared split horizon dns records

### DIFF
--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -283,7 +283,7 @@ func (b *Builder) Build() (AutomationConfig, error) {
 		processes[i] = *process
 
 		var horizon ReplicaSetHorizons
-		if b.replicaSetHorizons != nil {
+		if b.replicaSetHorizons != nil && i < len(b.replicaSetHorizons) {
 			horizon = b.replicaSetHorizons[i]
 		}
 

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -159,6 +159,34 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 	assert.Equal(t, 1, m[11].Votes)
 }
 
+func TestReplicaSetHorizonsScaleDown(t *testing.T) {
+	var expected ReplicaSetHorizons
+
+	horizons := []ReplicaSetHorizons{
+		{"horizon": "test-horizon-0"},
+		{"horizon": "test-horizon-1"},
+		{"horizon": "test-horizon-2"},
+	}
+	ac, err := NewBuilder().
+		SetName("my-rs").
+		SetDomain("my-ns.svc.cluster.local").
+		SetMongoDBVersion("4.2.0").
+		SetMembers(4).
+		SetReplicaSetHorizons(horizons).
+		Build()
+
+	assert.NoError(t, err)
+
+	for i, member := range ac.ReplicaSets[0].Members {
+		if i >= len(horizons) {
+			expected = nil
+		} else {
+			expected = ReplicaSetHorizons{"horizon": fmt.Sprintf("test-horizon-%d", i)}
+		}
+		assert.Equal(t, expected, member.Horizons)
+	}
+}
+
 func TestReplicaSetHorizons(t *testing.T) {
 	ac, err := NewBuilder().
 		SetName("my-rs").

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -159,6 +159,46 @@ func TestBuildAutomationConfigArbiters(t *testing.T) {
 	assert.Equal(t, 1, m[11].Votes)
 }
 
+func TestReplicaSetMultipleHorizonsScaleDown(t *testing.T) {
+	var expected ReplicaSetHorizons
+
+	horizons := []ReplicaSetHorizons{
+		{
+			"internal": "test-horizon-0",
+			"external": "test-horizon-0",
+		},
+		{
+			"internal": "test-horizon-1",
+			"external": "test-horizon-1",
+		},
+		{
+			"internal": "test-horizon-2",
+			"external": "test-horizon-2",
+		},
+	}
+	ac, err := NewBuilder().
+		SetName("my-rs").
+		SetDomain("my-ns.svc.cluster.local").
+		SetMongoDBVersion("4.2.0").
+		SetMembers(4).
+		SetReplicaSetHorizons(horizons).
+		Build()
+
+	assert.NoError(t, err)
+
+	for i, member := range ac.ReplicaSets[0].Members {
+		if i >= len(horizons) {
+			expected = nil
+		} else {
+			expected = ReplicaSetHorizons{
+				"internal": fmt.Sprintf("test-horizon-%d", i),
+				"external": fmt.Sprintf("test-horizon-%d", i),
+			}
+		}
+		assert.Equal(t, expected, member.Horizons)
+	}
+}
+
 func TestReplicaSetHorizonsScaleDown(t *testing.T) {
 	var expected ReplicaSetHorizons
 


### PR DESCRIPTION
This PR tries to fix #889 by not to not try to access non-declared split horizon DNS records.

The issue occurs during scaling down, as the automation config is tried to be built with actual numbers of replicas with desired split-horizon dns records. Then a panic with out of range on the related slice is triggered.

Closes #889

Signed-off-by: maxgio92 <massimiliano.giovagnoli.1992@gmail.com>
