### PR TITLE
Fixes arbiters not reaching running phase.

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -642,10 +642,13 @@ func (m MongoDBCommunity) GetScramUsers() []scram.User {
 // IsStillScaling returns true if this resource is currently scaling,
 // considering both arbiters and regular members.
 func (m MongoDBCommunity) IsStillScaling() bool {
-	return scale.IsStillScaling(m) || scale.IsStillScaling(automationConfigReplicasScaler{
-		current: m.CurrentArbiters(),
-		desired: m.DesiredArbiters(),
-	})
+	arbiters := automationConfigReplicasScaler{
+		current:                m.CurrentArbiters(),
+		desired:                m.DesiredArbiters(),
+		forceIndividualScaling: true,
+	}
+
+	return scale.IsStillScaling(m) || scale.IsStillScaling(arbiters)
 }
 
 // AutomationConfigMembersThisReconciliation determines the correct number of
@@ -664,7 +667,7 @@ func (m MongoDBCommunity) AutomationConfigMembersThisReconciliation() int {
 //
 // Will not update arbiters until members have reached desired number.
 func (m MongoDBCommunity) AutomationConfigArbitersThisReconciliation() int {
-	if m.AutomationConfigMembersThisReconciliation() < m.Spec.Members {
+	if scale.IsStillScaling(m) {
 		return m.Status.CurrentMongoDBArbiters
 	}
 

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -744,15 +744,6 @@ func (m MongoDBCommunity) ServiceName() string {
 	return m.Name + "-svc"
 }
 
-// ArbiterServiceName returns the name of the Service for the Arbiters for this resource.
-func (m MongoDBCommunity) ArbiterServiceName() string {
-	serviceName := m.Spec.StatefulSetConfiguration.SpecWrapper.Spec.ServiceName
-	if serviceName != "" {
-		return serviceName + "-arb-svc"
-	}
-	return m.Name + "-arb-svc"
-}
-
 func (m MongoDBCommunity) AutomationConfigSecretName() string {
 	return m.Name + "-config"
 }

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -5,12 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-    service.binding/type: 'mongodb'
-    service.binding/provider: 'community'
-    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
-    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
-    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
-    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -5,6 +5,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    service.binding/type: 'mongodb'
+    service.binding/provider: 'community'
+    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
+    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
+    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
+    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -335,13 +335,9 @@ func (r *ReplicaSetReconciler) deployStatefulSet(mdb mdbv1.MongoDBCommunity) (bo
 		return false, errors.Errorf("error creating/updating StatefulSet: %s", err)
 	}
 
-	if mdb.Spec.Arbiters > 0 {
-		r.log.Info("Creating/Updating StatefulSet for Arbiters")
-		if err := r.createOrUpdateStatefulSet(mdb, true); err != nil {
-			return false, errors.Errorf("error creating/updating StatefulSet: %s", err)
-		}
-	} else {
-		r.log.Info("Arbiters set to 0, not creating another STS")
+	r.log.Info("Creating/Updating StatefulSet for Arbiters")
+	if err := r.createOrUpdateStatefulSet(mdb, true); err != nil {
+		return false, errors.Errorf("error creating/updating StatefulSet: %s", err)
 	}
 
 	currentSts, err := r.client.GetStatefulSet(mdb.NamespacedName())

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -149,19 +149,10 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	r.log.Debug("Ensuring the service exists")
-	if err := r.ensureService(mdb, false); err != nil {
+	if err := r.ensureService(mdb); err != nil {
 		return status.Update(r.client.Status(), &mdb,
 			statusOptions().
 				withMessage(Error, fmt.Sprintf("Error ensuring the service (members) exists: %s", err)).
-				withFailedPhase(),
-		)
-	}
-
-	r.log.Debug("Ensuring the service for Arbiters exists")
-	if err := r.ensureService(mdb, true); err != nil {
-		return status.Update(r.client.Status(), &mdb,
-			statusOptions().
-				withMessage(Error, fmt.Sprintf("Error ensuring the service (arbiters) exists: %s", err)).
 				withFailedPhase(),
 		)
 	}
@@ -454,16 +445,13 @@ func (r *ReplicaSetReconciler) deployMongoDBReplicaSet(mdb mdbv1.MongoDBCommunit
 //
 // The Service definition is built from the `mdb` resource. If `isArbiter` is set to true, the Service
 // will be created for the arbiters Statefulset.
-func (r *ReplicaSetReconciler) ensureService(mdb mdbv1.MongoDBCommunity, isArbiter bool) error {
+func (r *ReplicaSetReconciler) ensureService(mdb mdbv1.MongoDBCommunity) error {
 	name := mdb.ServiceName()
-	if isArbiter {
-		name = mdb.ArbiterServiceName()
-	}
 
 	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: mdb.Namespace}}
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), r.client, svc, func() error {
 		resourceVersion := svc.ResourceVersion // Save resourceVersion for later
-		*svc = buildService(mdb, isArbiter)
+		*svc = buildService(mdb)
 		svc.ResourceVersion = resourceVersion
 		return nil
 	})
@@ -520,7 +508,7 @@ func (r ReplicaSetReconciler) ensureAutomationConfig(mdb mdbv1.MongoDBCommunity)
 
 func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Auth, currentAc automationconfig.AutomationConfig, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
 	domain := getDomain(mdb.ServiceName(), mdb.Namespace, os.Getenv(clusterDomain))
-	arbiterDomain := getDomain(mdb.ArbiterServiceName(), mdb.Namespace, os.Getenv(clusterDomain))
+	arbiterDomain := getDomain(mdb.ServiceName(), mdb.Namespace, os.Getenv(clusterDomain))
 
 	zap.S().Debugw("AutomationConfigMembersThisReconciliation", "mdb.AutomationConfigMembersThisReconciliation()", mdb.AutomationConfigMembersThisReconciliation())
 
@@ -552,16 +540,9 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Aut
 
 // buildService creates a Service that will be used for the Replica Set StatefulSet
 // that allows all the members of the STS to see each other.
-//
-// If `isArbiter` is true, the function will create a Service suitable for the
-// Arbiter's StatefulSet.
-func buildService(mdb mdbv1.MongoDBCommunity, isArbiter bool) corev1.Service {
+func buildService(mdb mdbv1.MongoDBCommunity) corev1.Service {
 	label := make(map[string]string)
-
 	name := mdb.ServiceName()
-	if isArbiter {
-		name = mdb.ArbiterServiceName()
-	}
 
 	label["app"] = name
 
@@ -725,7 +706,7 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 func buildArbitersModificationFunction(mdb mdbv1.MongoDBCommunity) statefulset.Modification {
 	return statefulset.Apply(
 		statefulset.WithReplicas(mdb.StatefulSetArbitersThisReconciliation()),
-		statefulset.WithServiceName(mdb.ArbiterServiceName()),
+		statefulset.WithServiceName(mdb.ServiceName()),
 		statefulset.WithName(mdb.Name+"-arb"),
 	)
 }

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -225,7 +225,6 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	if mdb.IsStillScaling() {
-		r.log.Debug("*** MongoDB resource is still scaling")
 		return status.Update(r.client.Status(), &mdb, statusOptions().
 			withMongoDBMembers(mdb.AutomationConfigMembersThisReconciliation()).
 			withMessage(Info, fmt.Sprintf("Performing scaling operation, currentMembers=%d, desiredMembers=%d",
@@ -235,8 +234,6 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 			withMongoDBArbiters(mdb.AutomationConfigArbitersThisReconciliation()).
 			withPendingPhase(10),
 		)
-	} else {
-		r.log.Debug("*** MongoDB resource is NOT scaling")
 	}
 
 	res, err := status.Update(r.client.Status(), &mdb,

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 - Changes
   - Adds an optional field `users[i].connectionStringSecretName` for deterministically setting the name of the connection string secret created by the operator for every configured user.
 
+- Bug fixes
+  - Allows for *arbiters* to be set using `spec.arbiters` attribute. Fixes a condition where *arbiters* could not be added to the Replica Set.
 
 ## Updated Image Tags
 

--- a/docs/deploy-configure.md
+++ b/docs/deploy-configure.md
@@ -136,7 +136,11 @@ To scale a replica set:
 
 ## Add Arbiters to a Replica Set
 
-To add [arbiters](https://www.mongodb.com/docs/manual/core/replica-set-arbiter/) to your replica set, add the `spec.arbiters` field to your MongoDBCommunity resource definition. 
+To add [arbiters](https://www.mongodb.com/docs/manual/core/replica-set-arbiter/) to
+your replica set, add the `spec.arbiters` field to your MongoDBCommunity
+resource definition. This attribute configures the absolute amount of arbiters
+in this Replica Set, this is, the amount of `mongod` instances will be
+`spec.members` + `spec.arbiters`.
 
 The value of the `spec.arbiters` field must be:
 
@@ -173,7 +177,7 @@ To add arbiters:
      members: 3
      type: ReplicaSet
      arbiters: 3
-     version: "4.2.7"
+     version: "4.4.13"
    ```
 
    If necessary, update the value of the `spec.members` field to ensure that you have at least one member that is not an arbiter:
@@ -187,7 +191,7 @@ To add arbiters:
      members: 5
      type: ReplicaSet
      arbiters: 3
-     version: "4.2.7"
+     version: "4.4.13"
    ```
 
 2. Reapply the configuration to Kubernetes:

--- a/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -65,14 +65,6 @@ func TestReplicaSetArbiter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tester, err := FromResource(t, mdb)
-	if err != nil {
-		t.Fatal(err)
-	}
-	scramUser := mdb.GetScramUsers()[0]
-	expectedCnxStr := fmt.Sprintf("mongodb+srv://%s-user:%s@%s-svc.%s.svc.cluster.local/admin?replicaSet=mdb2&ssl=false", mdb.Name, pwd, mdb.Name, mdb.Namespace)
-	cnxStrSrv := mongodbtests.GetSrvConnectionStringForUser(mdb, scramUser)
-
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Check that the stateful set becomes ready", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
 	t.Run("Check the number of arbiters", mongodbtests.AutomationConfigReplicaSetsHaveExpectedArbiters(&mdb, numberArbiters))
@@ -83,6 +75,13 @@ func TestReplicaSetArbiter(t *testing.T) {
 	t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 
 	t.Run("Test SRV Connectivity with generated connection string secret", func(t *testing.T) {
+		tester, err := FromResource(t, mdb)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scramUser := mdb.GetScramUsers()[0]
+		expectedCnxStr := fmt.Sprintf("mongodb+srv://%s-user:%s@%s-svc.%s.svc.cluster.local/admin?replicaSet=mdb2&ssl=false", mdb.Name, pwd, mdb.Name, mdb.Namespace)
+		cnxStrSrv := mongodbtests.GetSrvConnectionStringForUser(mdb, scramUser)
 		assert.Equal(t, expectedCnxStr, cnxStrSrv)
 		tester.ConnectivitySucceeds(WithURI(cnxStrSrv))
 	})

--- a/test/e2e/util/wait/wait.go
+++ b/test/e2e/util/wait/wait.go
@@ -118,8 +118,8 @@ func ForStatefulSetToBeUnready(t *testing.T, mdb *mdbv1.MongoDBCommunity, opts .
 // have reached the ready status.
 func ForArbitersStatefulSetToBeReady(t *testing.T, mdb *mdbv1.MongoDBCommunity, opts ...Configuration) error {
 	options := newOptions(opts...)
-	return waitForStatefulSetConditionWithSpecificSts(t, mdb, MembersStatefulSet, options, func(sts appsv1.StatefulSet) bool {
-		return statefulset.IsReady(sts, mdb.Spec.Members)
+	return waitForStatefulSetConditionWithSpecificSts(t, mdb, ArbitersStatefulSet, options, func(sts appsv1.StatefulSet) bool {
+		return statefulset.IsReady(sts, mdb.Spec.Arbiters)
 	})
 }
 

--- a/test/e2e/util/wait/wait.go
+++ b/test/e2e/util/wait/wait.go
@@ -149,7 +149,7 @@ func waitForStatefulSetConditionWithSpecificSts(t *testing.T, mdb *mdbv1.MongoDB
 			return false, err
 		}
 		t.Logf("Waiting for %s to have %d replicas. Current ready replicas: %d, Current updated replicas: %d, Current generation: %d, Observed Generation: %d\n",
-			name, mdb.Spec.Members, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas, sts.Generation, sts.Status.ObservedGeneration)
+			name, *sts.Spec.Replicas, sts.Status.ReadyReplicas, sts.Status.UpdatedReplicas, sts.Generation, sts.Status.ObservedGeneration)
 		ready := condition(sts)
 		return ready, nil
 	})


### PR DESCRIPTION
# Summary

Fixes arbiters by using the same service to handle both regular (data-bearing) statefulset and arbiters statefulset. Now arbiters can be scaled from 0 (PSS->PSA) or starting from scratch. The e2e test has been fixed (wait.go), and I've added clarification on the docs about how arbiters work.