### PR TITLE
Merge labels and annotations

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -142,8 +142,6 @@ jobs:
           distro: ubi
         - test-name: replica_set_mount_connection_string
           distro: ubi
-        - test-name: replica_set_operator_upgrade
-          distro: ubi
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -265,6 +265,8 @@ type OverrideProcess struct {
 type StatefulSetConfiguration struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	SpecWrapper StatefulSetSpecWrapper `json:"spec"`
+	// +optional
+	MetadataWrapper StatefulSetMetadataWrapper `json:"metadata"`
 }
 
 // StatefulSetSpecWrapper is a wrapper around StatefulSetSpec with a custom implementation
@@ -287,6 +289,21 @@ func (m *StatefulSetSpecWrapper) UnmarshalJSON(data []byte) error {
 func (m *StatefulSetSpecWrapper) DeepCopy() *StatefulSetSpecWrapper {
 	return &StatefulSetSpecWrapper{
 		Spec: m.Spec,
+	}
+}
+
+// StatefulSetMetadataWrapper is a wrapper around Labels and Annotations
+type StatefulSetMetadataWrapper struct {
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+func (m *StatefulSetMetadataWrapper) DeepCopy() *StatefulSetMetadataWrapper {
+	return &StatefulSetMetadataWrapper{
+		Labels:      m.Labels,
+		Annotations: m.Annotations,
 	}
 }
 

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -5,12 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-    service.binding/type: 'mongodb'
-    service.binding/provider: 'community'
-    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
-    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
-    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
-    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:
@@ -320,6 +314,19 @@ spec:
                 description: StatefulSetConfiguration holds the optional custom StatefulSet
                   that should be merged into the operator created one.
                 properties:
+                  metadata:
+                    description: StatefulSetMetadataWrapper is a wrapper around Labels
+                      and Annotations
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/config/samples/arbitrary_statefulset_configuration/mongodb.com_v1_metadata.yaml
+++ b/config/samples/arbitrary_statefulset_configuration/mongodb.com_v1_metadata.yaml
@@ -1,0 +1,59 @@
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: mdb0
+spec:
+  members: 3
+  type: ReplicaSet
+  version: "4.2.6"
+  security:
+    authentication:
+      modes: [ "SCRAM" ]
+  users:
+    - name: my-user
+      db: admin
+      passwordSecretRef: # a reference to the secret that will be used to generate the user's password
+        name: my-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+      scramCredentialsSecretName: my-scram
+  additionalMongodConfig:
+    storage.wiredTiger.engineConfig.journalCompressor: zlib
+
+  statefulSet:
+    metadata:
+      annotations:
+        statefulSetAnnotationTest: testValue
+      labels:
+        statefulSetLabelTest: testValue
+    spec:
+      selector:
+        matchLabels:
+          podTemplateLabelTest: testValue
+
+      template:
+        metadata:
+          annotations:
+            podTemplateAnnotationTest: testValue
+          labels:
+            podTemplateLabelTest: testValue
+
+      volumeClaimTemplates:
+        - metadata:
+            name: data-volume
+            annotations:
+              pvcTemplateAnnotationTest: testValue
+            labels:
+              pvcTemplateLabelTest: testValue
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-user-password
+type: Opaque
+stringData:
+  password: <your-password-here>

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -696,6 +696,10 @@ func buildStatefulSetModificationFunction(mdb mdbv1.MongoDBCommunity) statefulse
 		),
 
 		statefulset.WithCustomSpecs(mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec),
+		statefulset.WithMetadata(
+			mdb.Spec.StatefulSetConfiguration.MetadataWrapper.Labels,
+			mdb.Spec.StatefulSetConfiguration.MetadataWrapper.Annotations,
+		),
 	)
 }
 

--- a/pkg/kube/statefulset/statefulset.go
+++ b/pkg/kube/statefulset/statefulset.go
@@ -306,6 +306,13 @@ func WithCustomSpecs(spec appsv1.StatefulSetSpec) Modification {
 	}
 }
 
+func WithMetadata(labels map[string]string, annotations map[string]string) Modification {
+	return func(set *appsv1.StatefulSet) {
+		set.Labels = merge.StringToStringMap(set.Labels, labels)
+		set.Annotations = merge.StringToStringMap(set.Annotations, annotations)
+	}
+}
+
 func findVolumeClaimIndexByName(name string, pvcs []corev1.PersistentVolumeClaim) int {
 	for idx, pvc := range pvcs {
 		if pvc.Name == name {

--- a/pkg/util/merge/merge_statefulset.go
+++ b/pkg/util/merge/merge_statefulset.go
@@ -170,6 +170,9 @@ func PersistentVolumeClaim(defaultPvc corev1.PersistentVolumeClaim, overridePvc 
 		defaultPvc.Namespace = overridePvc.Namespace
 	}
 
+	defaultPvc.Labels = StringToStringMap(defaultPvc.Labels, overridePvc.Labels)
+	defaultPvc.Annotations = StringToStringMap(defaultPvc.Annotations, overridePvc.Annotations)
+
 	if overridePvc.Spec.VolumeMode != nil {
 		defaultPvc.Spec.VolumeMode = overridePvc.Spec.VolumeMode
 	}

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -28,6 +28,13 @@ func TestLabels() map[string]string {
 	}
 }
 
+// TestAnnotations create an annotations map
+func TestAnnotations() map[string]string {
+	return map[string]string{
+		"e2e-test-annotated": "true",
+	}
+}
+
 func TestDataDir() string {
 	return envvar.GetEnvOrDefault(testDataDirEnv, "/workspace/testdata")
 }

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 	"testing"
 	"time"
 
@@ -215,6 +217,7 @@ func containsVolume(volumes []corev1.PersistentVolume, volumeName string) bool {
 	}
 	return false
 }
+
 func HasExpectedPersistentVolumes(volumes []corev1.PersistentVolume) func(t *testing.T) {
 	return func(t *testing.T) {
 		volumeList, err := getPersistentVolumesList()
@@ -226,6 +229,77 @@ func HasExpectedPersistentVolumes(volumes []corev1.PersistentVolume) func(t *tes
 		for _, v := range volumes {
 			assert.True(t, containsVolume(actualVolumes, v.Name))
 		}
+	}
+}
+func HasExpectedMetadata(mdb *mdbv1.MongoDBCommunity, expectedLabels map[string]string, expectedAnnotations map[string]string) func(t *testing.T) {
+	return func(t *testing.T) {
+		namespace := mdb.Namespace
+
+		statefulSetList := appsv1.StatefulSetList{}
+		err := e2eutil.TestClient.Client.List(context.TODO(), &statefulSetList, client.InNamespace(namespace))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, statefulSetList.Items)
+		for _, s := range statefulSetList.Items {
+			containsMetadata(t, &s.ObjectMeta, expectedLabels, expectedAnnotations, "statefulset "+s.Name)
+		}
+
+		volumeList := corev1.PersistentVolumeList{}
+		err = e2eutil.TestClient.Client.List(context.TODO(), &volumeList, client.InNamespace(namespace))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, volumeList.Items)
+		for _, s := range volumeList.Items {
+			volName := s.Name
+			if strings.HasPrefix(volName, "data-volume-") || strings.HasPrefix(volName, "logs-volume-") {
+				containsMetadata(t, &s.ObjectMeta, expectedLabels, expectedAnnotations, "volume "+volName)
+			}
+		}
+
+		podList := corev1.PodList{}
+		err = e2eutil.TestClient.Client.List(context.TODO(), &podList, client.InNamespace(namespace))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, podList.Items)
+	EachPod:
+		for _, s := range podList.Items {
+			// only consider pod owner by the stateful set (as opposite to the controller replica set)
+			for _, owner := range s.OwnerReferences {
+				if owner.Kind == "ReplicaSet" {
+					continue EachPod
+				}
+			}
+			// Ignore non-owned pods
+			if len(s.OwnerReferences) == 0 {
+				continue EachPod
+			}
+
+			// Ensure we are considering pods owned by a stateful set
+			hasStatefulSetOwner := false
+			for _, owner := range s.OwnerReferences {
+				if owner.Kind == "StatefulSet" {
+					hasStatefulSetOwner = true
+				}
+			}
+			if !hasStatefulSetOwner {
+				continue EachPod
+			}
+
+			containsMetadata(t, &s.ObjectMeta, expectedLabels, expectedAnnotations, "pod "+s.Name)
+		}
+	}
+}
+
+func containsMetadata(t *testing.T, metadata *metav1.ObjectMeta, expectedLabels map[string]string, expectedAnnotations map[string]string, msg string) {
+	labels := metadata.Labels
+	for k, v := range expectedLabels {
+		assert.Contains(t, labels, k, msg+" has label "+k)
+		value := labels[k]
+		assert.Equal(t, v, value, msg+" has label "+k+" with value "+v)
+	}
+
+	annotations := metadata.Annotations
+	for k, v := range expectedAnnotations {
+		assert.Contains(t, annotations, k, msg+" has annotation "+k)
+		value := annotations[k]
+		assert.Equal(t, v, value, msg+" has annotation "+k+" with value "+v)
 	}
 }
 

--- a/test/e2e/replica_set_custom_annotations_test/replica_set_custom_annotations_test.go
+++ b/test/e2e/replica_set_custom_annotations_test/replica_set_custom_annotations_test.go
@@ -1,0 +1,77 @@
+package replica_set_custom_annotations_test
+
+import (
+	"fmt"
+	v1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	code, err := e2eutil.RunTest(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func TestReplicaSetCustomAnnotations(t *testing.T) {
+	ctx := setup.Setup(t)
+	defer ctx.Teardown()
+
+	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
+	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+		Labels:      e2eutil.TestLabels(),
+		Annotations: e2eutil.TestAnnotations(),
+	}
+	mdb.Spec.StatefulSetConfiguration.SpecWrapper.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "data-volume",
+				Labels:      e2eutil.TestLabels(),
+				Annotations: e2eutil.TestAnnotations(),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "logs-volume",
+				Labels:      e2eutil.TestLabels(),
+				Annotations: e2eutil.TestAnnotations(),
+			},
+		},
+	}
+	mdb.Spec.StatefulSetConfiguration.MetadataWrapper = v1.StatefulSetMetadataWrapper{
+		Labels:      e2eutil.TestLabels(),
+		Annotations: e2eutil.TestAnnotations(),
+	}
+	scramUser := mdb.GetScramUsers()[0]
+
+	_, err := setup.GeneratePasswordForUser(ctx, user, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tester, err := FromResource(t, mdb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
+	t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
+	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
+	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet((mdb.Name))))
+	t.Run("Test Basic Connectivity with generated connection string secret",
+		tester.ConnectivitySucceeds(WithURI(mongodbtests.GetConnectionStringForUser(mdb, scramUser))))
+	t.Run("Test SRV Connectivity with generated connection string secret",
+		tester.ConnectivitySucceeds(WithURI(mongodbtests.GetSrvConnectionStringForUser(mdb, scramUser))))
+	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
+	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
+	t.Run("Cluster has the expected labels and annotations", mongodbtests.HasExpectedMetadata(&mdb, e2eutil.TestLabels(), e2eutil.TestAnnotations()))
+}


### PR DESCRIPTION
Merge labels and annotations on created StatefulSets, Pods, and PersistentVolumeClaims.

In order to accommodate for labels and annotations on the statefulset, the custom MongoDbCommunity resource definition had to be updated. A new optional 'metadata' field for a new 'MetadataWrapper' object has been added.

I tested on a locally deployed mongoDbCommunity in kind.
I ran the added e2e test only locally

### All Submissions:

* [x] Have you opened an Issue before filing this PR? #982
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

closes #982
closes #908
