### PR TITLE
Increased timeout when waiting to deploy operator in e2e tests

### DIFF
--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -213,7 +213,7 @@ func DeployOperator(config TestConfig, resourceName string, withTLS bool, defaul
 		return err
 	}
 
-	if err := wait.PollImmediate(time.Second, 30*time.Second, hasDeploymentRequiredReplicas(&dep)); err != nil {
+	if err := wait.PollImmediate(time.Second, 60*time.Second, hasDeploymentRequiredReplicas(&dep)); err != nil {
 		return errors.New("error building operator deployment: the deployment does not have the required replicas")
 	}
 	fmt.Println("Successfully installed the operator deployment")


### PR DESCRIPTION
One of the e2e tests (replica_set_operator_upgrade, ubi) is flaky. 
This is to try running e2e tests with increased timeout. 