### PR TITLE
Create local kind cluster with specified name

### DIFF
--- a/docs/build_operator_locally.md
+++ b/docs/build_operator_locally.md
@@ -4,7 +4,7 @@ This document contains a quickstart guide to build and deploy the operator local
 
 
 ## Prerequisites
-This guide assumes that you have already installed the following tools:
+This guide assumes that you have already prepared [Python virtual env](contributing.md#python-environment) and installed the following tools:
 
 * [Kind](https://kind.sigs.k8s.io/)
 * [Docker](https://www.docker.com/)
@@ -16,20 +16,22 @@ This guide assumes that you have already installed the following tools:
 1. Create a local kubernetes cluster and start a local registry by running
 
 ```sh
-./scripts/dev/setup_kind_cluster.sh
+./scripts/dev/setup_kind_cluster.sh -n test-cluster
 ```
 
-2. Set the kind kubernetes context if you have not already done so:
-```bash
-export KUBECONFIG=~/.kube/kind
+Alternatively create a local cluster and set current kubectl context to it.
+```sh
+./scripts/dev/setup_kind_cluster.sh -en test-cluster
 ```
 
-3. Run the following to get kind credentials:
+3. Run the following to get kind credentials and switch current context to the newly created cluster:
 
 ```sh
-kind export kubeconfig
-# check it worked by running:
-kubectl cluster-info --context kind-kind --kubeconfig $KUBECONFIG
+kind export kubeconfig --name test-cluster
+# should return kind-test-cluster
+kubectl config current-context
+# should have test-cluster-control-plane node listed
+kubectl get nodes
 ```
 
 4. Build and deploy the operator:
@@ -38,7 +40,6 @@ kubectl cluster-info --context kind-kind --kubeconfig $KUBECONFIG
 # builds all required images and then deploys the operator
 make all-images deploy
 ```
-
 
 Note: this will build and push the operator at `repo_url/mongodb-kubernetes-operator`, where `repo_url` is extracted from the [dev config file](./contributing.md#developing-locally)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -90,6 +90,9 @@ The build process consists of multiple Docker images being built. You need to sp
 where you want the locally built images to be pushed. The Docker registry needs to be
 accessible from your Kubernetes cluster.
 
+### Local kind cluster
+For local testing you can use a [local Kind cluster](build_operator_locally.md#steps).
+
 ## Test Namespace
 
 You can change the namespace used for tests, if you are using `Kind`, for
@@ -99,6 +102,7 @@ instance, you can leave this as `mongodb`.
 
 The test runner is a Python script, in order to use it a virtualenv needs to be
 created.
+**Python 3.9 is not supported yet. Please use Python 3.8.**
   
 ### Pip
 ```sh
@@ -200,14 +204,11 @@ replica_set_scale
 The tests should run individually using the runner like this:
 
 ```sh
-make e2e-k8s test=<test-name>
+make e2e-k8s test=replica_set
 ```
 
 This will run the `replica_set` E2E test which is a simple test which installs a
 MongoDB Replica Set and asserts that the deployed server can be connected to.
-
-
- 
 
 ### Run the test locally with go test & Telepresence
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/mongodb/sonar@96d13ff76a29349d07d2d6baa95e057495f00adf
+git+https://github.com/mongodb/sonar@94ed8a31e3f28c1d8a4b2ce96a341662c3f74c62
 github-action-templates==0.0.4
 docker==4.3.1
 kubernetes==11.0.0

--- a/scripts/dev/setup_kind_cluster.sh
+++ b/scripts/dev/setup_kind_cluster.sh
@@ -1,6 +1,36 @@
 #!/usr/bin/env bash
 set -Eeou pipefail
 
+function usage() {
+  echo "Deploy local registry and create kind cluster configured to use this registry. Local Docker registry is deployed at localhost:5000.
+
+Usage:
+  setup_kind_cluster.sh [-n <cluster_name>]
+  setup_kind_cluster.sh [-h]
+  setup_kind_cluster.sh [-n <cluster_name>] [-e]
+
+Options:
+  -n <cluster_name>   (optional) Set kind cluster name to <cluster_name>. Creates kubeconfig in ~/.kube/<cluster_name>. The default name is 'kind' if not set.
+  -e                  (optional) Export newly created kind cluster's credentials to ~/.kube/<cluster_name> and set current kubectl context.
+  -h                  (optional) Shows this screen.
+"
+  exit 0
+}
+
+cluster_name=${CLUSTER_NAME:-"kind"}
+export_kubeconfig=0
+while getopts ':n:he' opt; do
+    case $opt in
+      (n)   cluster_name=$OPTARG;;
+      (e)   export_kubeconfig=1;;
+      (h)   usage;;
+      (*)   usage;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+kubeconfig_path="$HOME/.kube/${cluster_name}"
+
 # create the kind network early unless it already exists.
 # it would normally be created automatically by kind but we
 # need it earlier to get the IP address of our registry.
@@ -21,7 +51,7 @@ fi
 ip="$(docker inspect kind-registry -f '{{.NetworkSettings.Networks.kind.IPAddress}}')"
 
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --kubeconfig ~/.kube/kind --config=-
+cat <<EOF | kind create cluster --name "${cluster_name}" --kubeconfig "${kubeconfig_path}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
@@ -32,7 +62,7 @@ EOF
 
 # Document the local registry (from  https://kind.sigs.k8s.io/docs/user/local-registry/)
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
-cat <<EOF | kubectl apply -f -
+cat <<EOF | kubectl apply --kubeconfig "${kubeconfig_path}" -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,3 +73,7 @@ data:
     host: "localhost:${reg_port}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
+
+if [[ "${export_kubeconfig}" == "1" ]]; then
+  kind export kubeconfig --name "${cluster_name}"
+fi


### PR DESCRIPTION
Improved `scripts/dev/setup_kind_cluster.sh`:
  * added switch: -n <cluster_name> to specify kind cluster's
    name. 
  * added switch: -e to export kind credentials after creating cluster

Example usage: 
`scripts/dev/setup_kind_cluster.sh -en test-cluster` - creates test-cluster in Kind and sets current kubectl context to it.

Improved docs.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
