### PR TITLE
CLOUDP-125628 security context update

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10.4'
+        python-version: 3.10.4
     - name: Cache Dependencies
       uses: actions/cache@v2
       with:
@@ -91,7 +91,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10.4'
+        python-version: 3.10.4
     - name: Cache Dependencies
       uses: actions/cache@v2
       with:

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10.4'
+        python-version: 3.10.4
     - name: Cache Dependencies
       uses: actions/cache@v2
       with:
@@ -173,7 +173,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10.4'
+        python-version: 3.10.4
     - name: Cache Dependencies
       uses: actions/cache@v2
       with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10.4'
+        python-version: 3.10.4
     - name: Cache Dependencies
       uses: actions/cache@v2
       with:
@@ -177,7 +177,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10.4'
+        python-version: 3.10.4
     - name: Cache Dependencies
       uses: actions/cache@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,8 @@ all: manager
 
 # Run unit tests
 TEST ?= ./pkg/... ./api/... ./cmd/... ./controllers/... ./test/e2e/util/mongotester/...
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test $(TEST) -coverprofile cover.out
+	go test $(TEST) -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -194,11 +194,6 @@ func AutomationAgentCommand() []string {
 }
 
 func mongodbAgentContainer(automationConfigSecretName string, volumeMounts []corev1.VolumeMount) container.Modification {
-	securityContext := container.NOOP()
-	managedSecurityContext := envvar.ReadBool(ManagedSecurityContextEnv)
-	if !managedSecurityContext {
-		securityContext = container.WithSecurityContext(container.DefaultSecurityContext())
-	}
 	return container.Apply(
 		container.WithName(AgentName),
 		container.WithImage(os.Getenv(AgentImageEnv)),
@@ -206,7 +201,6 @@ func mongodbAgentContainer(automationConfigSecretName string, volumeMounts []cor
 		container.WithReadinessProbe(DefaultReadiness()),
 		container.WithResourceRequirements(resourcerequirements.Defaults()),
 		container.WithVolumeMounts(volumeMounts),
-		securityContext,
 		container.WithCommand(AutomationAgentCommand()),
 		container.WithEnvs(
 			corev1.EnvVar{
@@ -309,12 +303,6 @@ exec mongod -f %s;
 		mongoDbCommand,
 	}
 
-	securityContext := container.NOOP()
-	managedSecurityContext := envvar.ReadBool(ManagedSecurityContextEnv)
-	if !managedSecurityContext {
-		securityContext = container.WithSecurityContext(container.DefaultSecurityContext())
-	}
-
 	return container.Apply(
 		container.WithName(MongodbName),
 		container.WithImage(getMongoDBImage(version)),
@@ -327,7 +315,5 @@ exec mongod -f %s;
 			},
 		),
 		container.WithVolumeMounts(volumeMounts),
-
-		securityContext,
 	)
 }

--- a/pkg/kube/container/containers.go
+++ b/pkg/kube/container/containers.go
@@ -183,12 +183,3 @@ func WithSecurityContext(context *corev1.SecurityContext) Modification {
 		container.SecurityContext = context
 	}
 }
-
-// DefaultSecurityContext returns the default security context for containers.
-// It sets RunAsUser = 2000 and RunAsNonRoot = true
-func DefaultSecurityContext() *corev1.SecurityContext {
-	runAsNonRoot := true
-	runAsUser := int64(2000)
-
-	return &corev1.SecurityContext{RunAsUser: &runAsUser, RunAsNonRoot: &runAsNonRoot}
-}

--- a/pkg/kube/podtemplatespec/podspec_template.go
+++ b/pkg/kube/podtemplatespec/podspec_template.go
@@ -160,10 +160,15 @@ func WithSecurityContext(securityContext corev1.PodSecurityContext) Modification
 	}
 }
 
-// DefaultPodSecurityContext returns the default pod security context with FsGroup = 2000
+// DefaultPodSecurityContext returns the default pod security context with:
+// - uid 2000
+// - fsGroup 2000
+// - runAsNonRoot set to true
 func DefaultPodSecurityContext() corev1.PodSecurityContext {
+	runAsNonRoot := true
+	runAsUser := int64(2000)
 	fsGroup := int64(2000)
-	return corev1.PodSecurityContext{FSGroup: &fsGroup}
+	return corev1.PodSecurityContext{RunAsUser: &runAsUser, RunAsNonRoot: &runAsNonRoot, FSGroup: &fsGroup}
 }
 
 // WithImagePullSecrets adds an ImagePullSecrets local reference with the given name


### PR DESCRIPTION
This Pull Request removes `securityContext` set on container level and moves all the previously used settings to the pod level. Note, that previously the pod level settings didn't make any effect as they were overriden by the container level.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
