### PR TITLE
Tool for editing cluster config secret

### DIFF
--- a/scripts/dev/edit_cluster_config.sh
+++ b/scripts/dev/edit_cluster_config.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# This script is intended for editing the raw cluster configuration that is used by the automation agents.
+# For example if we want to test new features implemented by the automation agent, we can check its behavior by configuring new settings directly in the raw cluster config.
+# Steps to do that:
+# 1. Deploy replica set, named here "my-replica-set" in "mongodb" namespace.
+# 2. Stop the operator, e.g. by scaling operator deployment to 0. Without this step the operator will overwrite any changes made to the cluster config in the secret.
+# 3. Edit the cluster config by running: ./edit_cluster_config.sh mongodb my-replica-set, or EDITOR=my-editor ./edit_cluster_config.sh mongodb my-replica-set (if you don't want to use vim)
+# 4. It will download the cluster config from the secret and open it in the editor.
+# 5. Make some changes to the cluster config, e.g. add new settings. Remember to increment version field, otherwise the changes won't be applied.
+# 6. Save the changes and exit the editor. The config will be checked if it's correct json and will be uploaded to the secret.
+# 8. Observe the changes made by the mongodb-agent. Be aware, that starting the operator again will overwrite the changes.
+
 namespace=$1
 replicaset_name=$2
 secret_name=${replicaset_name}-config
@@ -12,6 +23,7 @@ if [[ "${namespace}" == "" || "${replicaset_name}" == "" ]]; then
   echo "Usage:"
   printf "\t%s <namespace> <replicaset_name>\n" "$(basename "$0")"
   printf "\tEDITOR=<custom editor> %s <namespace> <replicaset_name> to edit cluster config with a different editor.\n" "$(basename "$0")"
+
   exit 1
 fi
 

--- a/scripts/dev/edit_cluster_config.sh
+++ b/scripts/dev/edit_cluster_config.sh
@@ -2,19 +2,73 @@
 
 namespace=$1
 replicaset_name=$2
+secret_name=${replicaset_name}-config
 
-cluster_config_file=$(mktemp ./edit_cluster_config.sh.cluster_config.json.XXXXX)
-cluster_config_file_base64="edit_cluster_config.sh.${cluster_config_file}.base64"
+if [[ "${namespace}" == "" || "${replicaset_name}" == "" ]]; then
+  echo "Edit automation config secret for given replicaset."
+  echo "It looks for the secret named '<replicaset_name>-secret' in the given namespace."
+  echo "Requires jq to be installed and uses current kubectl context."
+  echo
+  echo "Usage:"
+  printf "\t%s <namespace> <replicaset_name>\n" "$(basename "$0")"
+  printf "\tEDITOR=<custom editor> %s <namespace> <replicaset_name> to edit cluster config with a different editor.\n" "$(basename "$0")"
+  exit 1
+fi
 
-kubectl get secret "${replicaset_name}-config" -n "${namespace}" -o json | jq -r '.data."cluster-config.json"' | base64 -D | jq . -r >"${cluster_config_file}"
+cluster_config_file=$(mktemp ./edit_cluster_config.sh.cluster_config.XXXXX)
+# rename to have .json extension for syntax highlighting in the editor
+mv "${cluster_config_file}" "${cluster_config_file}.json"
+cluster_config_file="${cluster_config_file}.json"
+cluster_config_file_base64="${cluster_config_file}.base64"
+
+function cleanup() {
+  rm -f "${cluster_config_file}" "${cluster_config_file_base64}"
+}
+trap cleanup EXIT
+
+function get_secret() {
+  local namespace=$1
+  local secret_name=$2
+  kubectl get secret "${secret_name}" -n "${namespace}" -o json | jq -r '.data."cluster-config.json"' | base64 -D
+}
+
+echo "Saving config to a temporary file: ${cluster_config_file}"
+get_secret "${namespace}" "${secret_name}" | jq . -r >"${cluster_config_file}"
+error_code=$?
+
+if [[ ${error_code} != 0 ]]; then
+  echo "Cluster config is invalid, edit without parsing with jq:"
+  get_secret "${namespace}" "${secret_name}" >"${cluster_config_file}"
+fi
 
 if [[ "${EDITOR}" == "" ]]; then
   EDITOR=vim
 fi
 
-${EDITOR} "${cluster_config_file}"
+old_config=$(cat "${cluster_config_file}")
+while true; do
+  ${EDITOR} "${cluster_config_file}"
+  new_config=$(jq . < "${cluster_config_file}")
+  error_code=$?
+  if [[ ${error_code} != 0 ]]; then
+    read -n 1 -rsp $"Press any key to continue editing or ^C to abort..."
+    echo
+    continue
+  fi
+  break
+done
+
+if diff -q <(echo -n "${old_config}") <(echo -n "${new_config}"); then
+  echo "No changes made to cluster config."
+  exit 0
+else
+  echo "Cluster config was changed with following diff:"
+  diff --normal <(echo -n "${old_config}") <(echo -n "${new_config}")
+fi
+
 base64 < "${cluster_config_file}" > "${cluster_config_file_base64}"
 
+# shellcheck disable=SC2086
 patch=$(cat <<EOF | jq -rc
 [
  { "op"   : "replace",
@@ -25,7 +79,4 @@ patch=$(cat <<EOF | jq -rc
 EOF
 )
 
-kubectl patch secret -n mongodb mdb2-config --type='json' -p="${patch}"
-
-#rm "${secret_file}"
-#rm "${secret_file_new}"
+kubectl patch secret -n "${namespace}" "${secret_name}" --type='json' -p="${patch}"

--- a/scripts/dev/edit_cluster_config.sh
+++ b/scripts/dev/edit_cluster_config.sh
@@ -8,8 +8,8 @@
 # 3. Edit the cluster config by running: ./edit_cluster_config.sh mongodb my-replica-set, or EDITOR=my-editor ./edit_cluster_config.sh mongodb my-replica-set (if you don't want to use vim)
 # 4. It will download the cluster config from the secret and open it in the editor.
 # 5. Make some changes to the cluster config, e.g. add new settings. Remember to increment version field, otherwise the changes won't be applied.
-# 6. Save the changes and exit the editor. The config will be checked if it's correct json and will be uploaded to the secret.
-# 8. Observe the changes made by the mongodb-agent. Be aware, that starting the operator again will overwrite the changes.
+# 6. Save the changes and exit the editor. The config will be checked if it's a correct json and will be uploaded to the secret.
+# 7. Observe the changes made by the mongodb-agent. Be aware, that starting the operator again will overwrite the changes.
 
 namespace=$1
 replicaset_name=$2

--- a/scripts/dev/edit_cluster_config.sh
+++ b/scripts/dev/edit_cluster_config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+namespace=$1
+replicaset_name=$2
+
+cluster_config_file=$(mktemp ./edit_cluster_config.sh.cluster_config.json.XXXXX)
+cluster_config_file_base64="edit_cluster_config.sh.${cluster_config_file}.base64"
+
+kubectl get secret "${replicaset_name}-config" -n "${namespace}" -o json | jq -r '.data."cluster-config.json"' | base64 -D | jq . -r >"${cluster_config_file}"
+
+if [[ "${EDITOR}" == "" ]]; then
+  EDITOR=vim
+fi
+
+${EDITOR} "${cluster_config_file}"
+base64 < "${cluster_config_file}" > "${cluster_config_file_base64}"
+
+patch=$(cat <<EOF | jq -rc
+[
+ { "op"   : "replace",
+   "path" : "/data/cluster-config.json",
+   "value" : "$(cat ${cluster_config_file_base64})"
+ }
+]
+EOF
+)
+
+kubectl patch secret -n mongodb mdb2-config --type='json' -p="${patch}"
+
+#rm "${secret_file}"
+#rm "${secret_file_new}"


### PR DESCRIPTION
With `scripts/dev/edit_cluster_config.sh` we can easily edit the cluster config in the secret that is mounted into mongodb-agents' pods. 
It's handy when there is a need to tinker with the automation agent directly. 

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
