### PR TITLE
CLOUDP-131647: Update to stateful set ignored existing volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ diagnostics
 
 Pipfile
 Pipfile.lock
+.community-operator-dev

--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -23,10 +23,10 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 	mdb := newTestReplicaSetWithTLS()
 	mgr := client.NewManager(&mdb)
 
-	client := mdbClient.NewClient(mgr.GetClient())
-	err := createTLSSecret(client, mdb, "CERT", "KEY", "")
+	cli := mdbClient.NewClient(mgr.GetClient())
+	err := createTLSSecret(cli, mdb, "CERT", "KEY", "")
 	assert.NoError(t, err)
-	err = createTLSConfigMap(client, mdb)
+	err = createTLSConfigMap(cli, mdb)
 	assert.NoError(t, err)
 
 	r := NewReconciler(mgr)
@@ -37,14 +37,17 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 	err = mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
 	assert.NoError(t, err)
 
-	// Assert that all TLS volumes have been added.
+	assertStatefulsetVolumesAndVolumeMounts(t, sts, mdb.TLSOperatorCASecretNamespacedName().Name, mdb.TLSOperatorSecretNamespacedName().Name)
+}
+
+func assertStatefulsetVolumesAndVolumeMounts(t *testing.T, sts appsv1.StatefulSet, expectedTLSCASecretName string, expectedTLSOperatorSecretName string) {
 	assert.Len(t, sts.Spec.Template.Spec.Volumes, 7)
 	permission := int32(416)
 	assert.Contains(t, sts.Spec.Template.Spec.Volumes, corev1.Volume{
 		Name: "tls-ca",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  mdb.TLSOperatorCASecretNamespacedName().Name,
+				SecretName:  expectedTLSCASecretName,
 				DefaultMode: &permission,
 			},
 		},
@@ -53,7 +56,7 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 		Name: "tls-secret",
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  mdb.TLSOperatorSecretNamespacedName().Name,
+				SecretName:  expectedTLSOperatorSecretName,
 				DefaultMode: &permission,
 			},
 		},
@@ -79,6 +82,54 @@ func TestStatefulSet_IsCorrectlyConfiguredWithTLS(t *testing.T) {
 	mongodbContainer := sts.Spec.Template.Spec.Containers[1]
 	assert.Contains(t, mongodbContainer.VolumeMounts, tlsSecretVolumeMount)
 	assert.Contains(t, mongodbContainer.VolumeMounts, tlsCAVolumeMount)
+}
+
+func TestStatefulSet_IsCorrectlyConfiguredWithTLSAfterChangingExistingVolumes(t *testing.T) {
+	mdb := newTestReplicaSetWithTLS()
+	mgr := client.NewManager(&mdb)
+
+	cli := mdbClient.NewClient(mgr.GetClient())
+	err := createTLSSecret(cli, mdb, "CERT", "KEY", "")
+	assert.NoError(t, err)
+
+	tlsCAVolumeSecretName := mdb.TLSOperatorCASecretNamespacedName().Name
+	changedTLSCAVolumeSecretName := tlsCAVolumeSecretName + "-old"
+
+	err = createTLSSecretWithNamespaceAndName(cli, mdb.Namespace, changedTLSCAVolumeSecretName, "CERT", "KEY", "")
+	assert.NoError(t, err)
+
+	err = createTLSConfigMap(cli, mdb)
+	assert.NoError(t, err)
+
+	r := NewReconciler(mgr)
+	res, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
+	assertReconciliationSuccessful(t, res, err)
+
+	sts := appsv1.StatefulSet{}
+	err = mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
+	assert.NoError(t, err)
+
+	assertStatefulsetVolumesAndVolumeMounts(t, sts, tlsCAVolumeSecretName, mdb.TLSOperatorSecretNamespacedName().Name)
+
+	// updating sts tls-ca volume directly to simulate changing of underlying volume's secret
+	for i := range sts.Spec.Template.Spec.Volumes {
+		if sts.Spec.Template.Spec.Volumes[i].Name == "tls-ca" {
+			sts.Spec.Template.Spec.Volumes[i].VolumeSource.Secret.SecretName = changedTLSCAVolumeSecretName
+		}
+	}
+
+	err = mgr.GetClient().Update(context.TODO(), &sts)
+	assert.NoError(t, err)
+
+	assertStatefulsetVolumesAndVolumeMounts(t, sts, changedTLSCAVolumeSecretName, mdb.TLSOperatorSecretNamespacedName().Name)
+
+	res, err = r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
+	assertReconciliationSuccessful(t, res, err)
+
+	sts = appsv1.StatefulSet{}
+	err = mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: mdb.Name, Namespace: mdb.Namespace}, &sts)
+	assert.NoError(t, err)
+	assertStatefulsetVolumesAndVolumeMounts(t, sts, tlsCAVolumeSecretName, mdb.TLSOperatorSecretNamespacedName().Name)
 }
 
 func TestAutomationConfig_IsCorrectlyConfiguredWithTLS(t *testing.T) {
@@ -295,10 +346,10 @@ func createTLSConfigMap(c k8sClient.Client, mdb mdbv1.MongoDBCommunity) error {
 	return c.Create(context.TODO(), &configMap)
 }
 
-func createTLSSecret(c k8sClient.Client, mdb mdbv1.MongoDBCommunity, crt string, key string, pem string) error {
+func createTLSSecretWithNamespaceAndName(c k8sClient.Client, namespace string, name string, crt string, key string, pem string) error {
 	sBuilder := secret.Builder().
-		SetName(mdb.Spec.Security.TLS.CertificateKeySecret.Name).
-		SetNamespace(mdb.Namespace)
+		SetName(name).
+		SetNamespace(namespace)
 
 	if crt != "" {
 		sBuilder.SetField(tlsSecretCertName, crt)
@@ -312,6 +363,10 @@ func createTLSSecret(c k8sClient.Client, mdb mdbv1.MongoDBCommunity, crt string,
 
 	s := sBuilder.Build()
 	return c.Create(context.TODO(), &s)
+}
+
+func createTLSSecret(c k8sClient.Client, mdb mdbv1.MongoDBCommunity, crt string, key string, pem string) error {
+	return createTLSSecretWithNamespaceAndName(c, mdb.Namespace, mdb.Spec.Security.TLS.CertificateKeySecret.Name, crt, key, pem)
 }
 
 func createUserPasswordSecret(c k8sClient.Client, mdb mdbv1.MongoDBCommunity, userPasswordSecretName string, password string) error {

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+# MongoDB Kubernetes Operator 0.7.5
+
+## Upgrade breaking change notice
+Versions 0.7.3, 0.7.4 have an issue that breaks deployment of MongoDB replica set when:
+* TLS is enabled
+* Replica set was deployed using the operator with version <=0.7.2
+
+If above conditions are met, it is strongly advised to upgrade the MongoDB Kubernetes Operator to version 0.7.5 or higher.
+
+## Kubernetes Operator
+
+- Bug fixes
+  - Fixed ignoring changes to existing volumes in the StatefulSet, i.e. changes of the volumes' underlying secret. This could cause that TLS enabled MongoDB deployment was not able to locate TLS certificates when upgrading the operator to versions 0.7.3 or 0.7.4.   
+
+
 # MongoDB Kubernetes Operator 0.7.4
 
 ## Kubernetes Operator

--- a/pkg/kube/podtemplatespec/podspec_template_test.go
+++ b/pkg/kube/podtemplatespec/podspec_template_test.go
@@ -369,9 +369,9 @@ func TestAddVolumes(t *testing.T) {
 
 	p := New(volumeModification, volumesModification)
 	assert.Len(t, p.Spec.Volumes, 2)
-	assert.Equal(t, p.Spec.Volumes[0].Name, "new-volume")
-	assert.Equal(t, p.Spec.Volumes[1].Name, "new-volume-2")
-
+	assert.Equal(t, "new-volume", p.Spec.Volumes[0].Name)
+	assert.Equal(t, "new-volume-2", p.Spec.Volumes[1].Name)
+	assert.Equal(t, "new-host-path", p.Spec.Volumes[0].VolumeSource.HostPath.Path)
 }
 
 func int64Ref(i int64) *int64 {

--- a/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -41,7 +41,7 @@ func TestReplicaSetOperatorUpgrade(t *testing.T) {
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb, true))
 	t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
-	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet((mdb.Name))))
+	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet(mdb.Name)))
 	t.Run("Test Basic Connectivity with generated connection string secret",
 		tester.ConnectivitySucceeds(WithURI(mongodbtests.GetConnectionStringForUser(mdb, scramUser))))
 	t.Run("Test SRV Connectivity with generated connection string secret",
@@ -49,11 +49,68 @@ func TestReplicaSetOperatorUpgrade(t *testing.T) {
 	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
 	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 
-	// upgrade the uperator to master
+	// upgrade the operator to master
 	config := setup.LoadTestConfigFromEnv()
 	err = setup.DeployOperator(config, "mdb", false, false)
 	assert.NoError(t, err)
 
 	// Perform the basic tests
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb, true))
+}
+
+// TestReplicaSetOperatorUpgradeFrom0_7_2 is intended to be run locally not in CI.
+// It simulates deploying cluster using community operator 0.7.2 and then upgrading it using newer version.
+func TestReplicaSetOperatorUpgradeFrom0_7_2(t *testing.T) {
+	t.Skip("Supporting this test in CI requires installing also CRDs from release v0.7.2")
+	resourceName := "mdb-upg"
+	testConfig := setup.LoadTestConfigFromEnv()
+
+	// deploy operator and other components as it was at version 0.7.2
+	testConfig.OperatorImage = "quay.io/mongodb/mongodb-kubernetes-operator:0.7.2"
+	testConfig.VersionUpgradeHookImage = "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.3"
+	testConfig.ReadinessProbeImage = "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.6"
+	testConfig.AgentImage = "quay.io/mongodb/mongodb-agent:11.0.5.6963-1"
+
+	ctx := setup.SetupWithTestConfig(t, testConfig, true, resourceName)
+	defer ctx.Teardown()
+
+	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, "")
+	scramUser := mdb.GetScramUsers()[0]
+	mdb.Spec.Security.TLS = e2eutil.NewTestTLSConfig(false)
+
+	_, err := setup.GeneratePasswordForUser(ctx, user, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tester, err := FromResource(t, mdb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runTests := func(t *testing.T) {
+		t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
+		t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb, true))
+		t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
+		t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
+		t.Run("Has TLS Mode", tester.HasTlsMode("requireSSL", 60, WithTls(mdb)))
+		t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
+		t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet(mdb.Name)))
+		t.Run("Test Basic Connectivity with generated connection string secret",
+			tester.ConnectivitySucceeds(WithURI(mongodbtests.GetConnectionStringForUser(mdb, scramUser))))
+		t.Run("Test SRV Connectivity with generated connection string secret",
+			tester.ConnectivitySucceeds(WithURI(mongodbtests.GetSrvConnectionStringForUser(mdb, scramUser))))
+		t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
+	}
+
+	runTests(t)
+
+	// When running against local operator we could stop here,
+	// rescale helm operator deployment to zero and run local operator then.
+
+	testConfig = setup.LoadTestConfigFromEnv()
+	err = setup.DeployOperator(testConfig, resourceName, true, false)
+	assert.NoError(t, err)
+
+	runTests(t)
 }

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -83,6 +83,26 @@ func SetupWithTLS(t *testing.T, resourceName string) (*e2eutil.Context, TestConf
 	return ctx, config
 }
 
+func SetupWithTestConfig(t *testing.T, testConfig TestConfig, withTLS bool, resourceName string) *e2eutil.Context {
+	ctx, err := e2eutil.NewContext(t, envvar.ReadBool(performCleanupEnv))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if withTLS {
+		if err := deployCertManager(testConfig); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := DeployOperator(testConfig, resourceName, withTLS, false); err != nil {
+		t.Fatal(err)
+	}
+
+	return ctx
+}
+
 // GeneratePasswordForUser will create a secret with a password for the given user
 func GeneratePasswordForUser(ctx *e2eutil.Context, mdbu mdbv1.MongoDBUser, namespace string) (string, error) {
 	passwordKey := mdbu.PasswordSecretRef.Key


### PR DESCRIPTION
In 0.7.3 there were changes to TLS secrets. Upgrading from 0.7.2 to 0.7.3, 0.7.4 was broken because the underlying secret in stateful set volume wasn't updated. It was because the code for updating volumes explicitly ignored any updates to volumes if they already exist, even if they contain important changes.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
