### PR TITLE
Minor improvements to local testing on M1 macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DOCKERFILE ?= operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,crdVersions=v1"
 RELEASE_NAME_HELM ?= mongodb-kubernetes-operator
-TEST_NAMESPACE ?= mongodb
+TEST_NAMESPACE ?= $(NAMESPACE)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -124,7 +124,7 @@ cleanup-e2e:
 	kubectl delete mdbc,all,secrets -l e2e-test=true -n ${TEST_NAMESPACE} || true
 	# Most of the tests use StatefulSets, which in turn use stable storage. In order to
 	# avoid interleaving tests with each other, we need to drop them all.
-	kubectl delete pvc --all || true
+	kubectl delete pvc --all -n $(NAMESPACE) || true
 
 # Generate code
 generate: controller-gen

--- a/inventories/e2e-inventory.yaml
+++ b/inventories/e2e-inventory.yaml
@@ -8,6 +8,7 @@ images:
       template_context: scripts/dev/templates
     inputs:
       - e2e_image
+    platform: linux/amd64
     stages:
       - name: e2e-template
         task_type: dockerfile_template


### PR DESCRIPTION
* E2E image wasn't built for linux/amd64 on M1
* cleanup-e2e should use current $NAMESPACE for every kubectl command

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
