### PR TITLE
Fixed operator's version in manager.yaml

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,7 +54,7 @@ spec:
           value: mongo
         - name: MONGODB_REPO_URL
           value: docker.io
-        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.4
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.5
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator
         resources:


### PR DESCRIPTION
In the last release operator was not bumped in manager.yaml. 

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
