### PR TITLE
Bumped go version in operator-ubi docker builder

### DIFF
--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -11,6 +11,8 @@ images:
       - operator_image
       - operator_image_dev
 
+    platform: linux/amd64
+
     stages:
       - name: operator-template-ubi
         task_type: dockerfile_template

--- a/pipeline.py
+++ b/pipeline.py
@@ -18,7 +18,7 @@ VALID_IMAGE_NAMES = frozenset(
     ]
 )
 
-GOLANG_TAG = "1.17"
+GOLANG_TAG = "1.18.5"
 DEFAULT_IMAGE_TYPE = "ubuntu"
 DEFAULT_NAMESPACE = "default"
 


### PR DESCRIPTION
In the recent go version bump #1065, the operator version was still built with go 1.17. 
This patch bumps also go version for the operator's docker builder.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
