### PR TITLE
CLOUDP-127632 AllowPrivilegeEscalation set to false

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # MongoDB Kubernetes Operator 0.7.5
 
+- Changes
+  - The Operator uses now `allowPrivilegeEscalation` set to `false` for all containers.
+
 ## Upgrade breaking change notice
 Versions 0.7.3, 0.7.4 have an issue that breaks deployment of MongoDB replica set when:
 * TLS is enabled

--- a/pkg/kube/container/containers.go
+++ b/pkg/kube/container/containers.go
@@ -188,5 +188,6 @@ func WithSecurityContext(context corev1.SecurityContext) Modification {
 // - readOnlyRootFilesystem set to true
 func DefaultSecurityContext() corev1.SecurityContext {
 	readOnlyRootFilesystem := true
-	return corev1.SecurityContext{ReadOnlyRootFilesystem: &readOnlyRootFilesystem}
+	allowPrivilegeEscalation := false
+	return corev1.SecurityContext{ReadOnlyRootFilesystem: &readOnlyRootFilesystem, AllowPrivilegeEscalation: &allowPrivilegeEscalation}
 }


### PR DESCRIPTION
This Pull Request introduces the `allowPrivilegeEscalation=false` setting on each container-level `SecurityContext`.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
