### PR TITLE
CLOUDP-132091: Add TLS and arbiters to operator upgrade test

### DIFF
--- a/.action_templates/jobs/tests.yaml
+++ b/.action_templates/jobs/tests.yaml
@@ -56,3 +56,5 @@ tests:
           distro: ubi
         - test-name: replica_set_mongod_port_change_with_arbiters
           distro: ubi
+        - test-name: replica_set_operator_upgrade
+          distro: ubi

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -138,6 +138,8 @@ jobs:
           distro: ubi
         - test-name: replica_set_mongod_port_change_with_arbiters
           distro: ubi
+        - test-name: replica_set_operator_upgrade
+          distro: ubi
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,6 +144,8 @@ jobs:
           distro: ubi
         - test-name: replica_set_mongod_port_change_with_arbiters
           distro: ubi
+        - test-name: replica_set_operator_upgrade
+          distro: ubi
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -505,8 +505,9 @@ type TLS struct {
 
 // LocalObjectReference is a reference to another Kubernetes object by name.
 // TODO: Replace with a type from the K8s API. CoreV1 has an equivalent
-// 	"LocalObjectReference" type but it contains a TODO in its
-// 	description that we don't want in our CRD.
+//
+//	"LocalObjectReference" type but it contains a TODO in its
+//	description that we don't want in our CRD.
 type LocalObjectReference struct {
 	Name string `json:"name"`
 }

--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -99,7 +99,7 @@ func hasDeadlockedSteps(health health.Status) bool {
 // there and find the last step which has "Started" non nil
 // (indeed this is not the perfect logic as sometimes the agent doesn't update the 'Started' as well - see
 // 'health-status-ok.json', but seems it works for finding deadlocks still
-//noinspection GoNilness
+// noinspection GoNilness
 func findCurrentStep(processStatuses map[string]health.MmsDirectorStatus) *health.StepStatus {
 	var currentPlan *health.PlanStatus
 	if len(processStatuses) == 0 {

--- a/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -58,7 +58,7 @@ func TestReplicaSetOperatorUpgrade(t *testing.T) {
 
 	// upgrade the operator to master
 	config := setup.LoadTestConfigFromEnv()
-	err = setup.DeployOperator(config, "mdb", true, false)
+	err = setup.DeployOperator(config, resourceName, true, false)
 	assert.NoError(t, err)
 
 	// Perform the basic tests

--- a/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -22,7 +22,8 @@ func TestMain(m *testing.M) {
 
 func TestReplicaSetOperatorUpgrade(t *testing.T) {
 	resourceName := "mdb0"
-	ctx, testConfig := setup.SetupWithDefaultOperator(t, resourceName, true)
+	testConfig := setup.LoadTestConfigFromEnv()
+	ctx := setup.SetupWithTestConfig(t, testConfig, true, true, resourceName)
 	defer ctx.Teardown()
 
 	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, testConfig.Namespace)
@@ -78,7 +79,7 @@ func TestReplicaSetOperatorUpgradeFrom0_7_2(t *testing.T) {
 	testConfig.ReadinessProbeImage = "quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.6"
 	testConfig.AgentImage = "quay.io/mongodb/mongodb-agent:11.0.5.6963-1"
 
-	ctx := setup.SetupWithTestConfig(t, testConfig, true, resourceName)
+	ctx := setup.SetupWithTestConfig(t, testConfig, true, false, resourceName)
 	defer ctx.Teardown()
 
 	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, "")

--- a/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -22,16 +22,16 @@ func TestMain(m *testing.M) {
 
 func TestReplicaSetOperatorUpgrade(t *testing.T) {
 	resourceName := "mdb0"
-	ctx, testConfig := setup.SetupWithTLS(t, resourceName)
+	ctx := setup.SetupWithDefaultOperator(t)
 	defer ctx.Teardown()
 
-	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, testConfig.Namespace)
+	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, "")
 	scramUser := mdb.GetScramUsers()[0]
 	mdb.Spec.Security.TLS = e2eutil.NewTestTLSConfig(false)
 	mdb.Spec.Arbiters = 1
 	mdb.Spec.Members = 2
 
-	_, err := setup.GeneratePasswordForUser(ctx, user, testConfig.Namespace)
+	_, err := setup.GeneratePasswordForUser(ctx, user, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -36,17 +36,22 @@ const (
 	Pem               tlsSecretType = "PEM"
 )
 
-func SetupWithDefaultOperator(t *testing.T) *e2eutil.Context {
+func SetupWithDefaultOperator(t *testing.T, resourceName string, withTLS bool) (*e2eutil.Context, TestConfig) {
 	ctx, err := e2eutil.NewContext(t, envvar.ReadBool(performCleanupEnv))
 
 	if err != nil {
 		t.Fatal(err)
 	}
 	config := LoadTestConfigFromEnv()
-	if err := DeployOperator(config, "mdb", false, true); err != nil {
+	if withTLS {
+		if err := deployCertManager(config); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := DeployOperator(config, resourceName, withTLS, true); err != nil {
 		t.Fatal(err)
 	}
-	return ctx
+	return ctx, config
 }
 
 func Setup(t *testing.T) *e2eutil.Context {

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -36,24 +36,6 @@ const (
 	Pem               tlsSecretType = "PEM"
 )
 
-func SetupWithDefaultOperator(t *testing.T, resourceName string, withTLS bool) (*e2eutil.Context, TestConfig) {
-	ctx, err := e2eutil.NewContext(t, envvar.ReadBool(performCleanupEnv))
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	config := LoadTestConfigFromEnv()
-	if withTLS {
-		if err := deployCertManager(config); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := DeployOperator(config, resourceName, withTLS, true); err != nil {
-		t.Fatal(err)
-	}
-	return ctx, config
-}
-
 func Setup(t *testing.T) *e2eutil.Context {
 	ctx, err := e2eutil.NewContext(t, envvar.ReadBool(performCleanupEnv))
 
@@ -88,7 +70,7 @@ func SetupWithTLS(t *testing.T, resourceName string) (*e2eutil.Context, TestConf
 	return ctx, config
 }
 
-func SetupWithTestConfig(t *testing.T, testConfig TestConfig, withTLS bool, resourceName string) *e2eutil.Context {
+func SetupWithTestConfig(t *testing.T, testConfig TestConfig, withTLS, defaultOperator bool, resourceName string) *e2eutil.Context {
 	ctx, err := e2eutil.NewContext(t, envvar.ReadBool(performCleanupEnv))
 
 	if err != nil {
@@ -101,7 +83,7 @@ func SetupWithTestConfig(t *testing.T, testConfig TestConfig, withTLS bool, reso
 		}
 	}
 
-	if err := DeployOperator(testConfig, resourceName, withTLS, false); err != nil {
+	if err := DeployOperator(testConfig, resourceName, withTLS, defaultOperator); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This patch enables the operator upgrade test in the e2e suite and adds TLS and arbiter settings to the resource in the test.
