### PR TITLE
CLOUDP-130487 fixed operator crash in face of incomplete TLS config

### DIFF
--- a/controllers/validation/validation.go
+++ b/controllers/validation/validation.go
@@ -36,6 +36,10 @@ func validateSpec(mdb mdbv1.MongoDBCommunity) error {
 		return err
 	}
 
+	if err := validateTLSSpec(mdb); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -115,6 +119,15 @@ func validateAuthModeSpec(mdb mdbv1.MongoDBCommunity) error {
 	}
 	if len(mapModes) != len(allModes) {
 		return fmt.Errorf("some authentication modes are declared twice or more")
+	}
+
+	return nil
+}
+
+// Validate TLS specification
+func validateTLSSpec(mdb mdbv1.MongoDBCommunity) error {
+	if mdb.Spec.Security.TLS.Enabled && mdb.Spec.Security.TLS.CaConfigMap == nil && mdb.Spec.Security.TLS.CaCertificateSecret == nil {
+		return fmt.Errorf("CaCertificateSecretRef/CaConfigMapRef not found.")
 	}
 
 	return nil


### PR DESCRIPTION
### What problem does this PR solve?

When TLS is enabled with an incomplete configuration (i.e. none of `caConfigMapRef` and `caCertificateSecretRef` is specified), the operator crashes. Upon inspection of the operator error log, we find that the crash happens when the operator is `Ensuring TLS is correctly configured` as it results in a segmentation fault due to a nil pointer reference. 

It seems that this null pointer exception occurs while ensuring that the CA cert is configured during TLS config validation when the following condition is checked:

```go
if mdb.Spec.Security.TLS.CaCertificateSecret != nil {
	caResourceName = mdb.TLSCaCertificateSecretNamespacedName()
	caData, err = secret.ReadStringData(secretGetter, caResourceName)
} else {
	caResourceName = mdb.TLSConfigMapNamespacedName()
	caData, err = configmap.ReadData(cmGetter, caResourceName)
}
```

Since `Spec.Security.TLS.CaCertificateSecret` is set to nil, `mdb.TLSConfigMapNamespacedName` is called:

```go
func (m MongoDBCommunity) TLSConfigMapNamespacedName() types.NamespacedName {
	return types.NamespacedName{Name: m.Spec.Security.TLS.CaConfigMap.Name, Namespace: m.Namespace}
}
```

However, `Spec.Security.TLS.CaConfigMap` is also nil, so when the `Name` field is accessed a runtime error occurs as a nil pointer is dereferenced.

### What changes were made and how does it work?

Currently, there is no [validation](https://github.com/mongodb/mongodb-kubernetes-operator/blob/e868003ba070f9a28a891b96355769a8616fa02c/controllers/validation/validation.go#L26) for TLS spec:

```go
func validateSpec(mdb mdbv1.MongoDBCommunity) error {
	if err := validateUsers(mdb); err != nil {
		return err
	}


	if err := validateArbiterSpec(mdb); err != nil {
		return err
	}


	if err := validateAuthModeSpec(mdb); err != nil {
		return err
	}


	return nil
}
```

I think we can include the following condition in the above code along with the function definition in controllers/validation/validation.go:

```go
if err := validateTLSSpec(mdb); err != nil {
	return err
}
```
```go
// Validate TLS specification
func validateTLSSpec(mdb mdbv1.MongoDBCommunity) error {
        if mdb.Spec.Security.TLS.Enabled && mdb.Spec.Security.TLS.CaConfigMap == nil && mdb.Spec.Security.TLS.CaCertificateSecret == nil {
		return fmt.Errorf("CaCertificateSecretRef/CaConfigMapRef not found.")
	}

	return nil
}
```
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

This is a simple fix and we suppose no test above is needed.

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [x] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
