### PR TITLE
CLOUDP-132991 fix `fcv` format validation to prevent system downtime and irrecoverable system state

### DIFF
--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -237,6 +237,18 @@ func (b *Builder) Build() (AutomationConfig, error) {
 	members := make([]ReplicaSetMember, b.members+b.arbiters)
 	processes := make([]Process, b.members+b.arbiters)
 
+	if b.fcv != "" {
+		_, err := semver.Make(fmt.Sprintf("%s.0", b.fcv))
+
+		if err != nil {
+			return AutomationConfig{}, fmt.Errorf("invalid feature compatibility version: %s", err)
+		}
+	}
+
+	if err := b.setFeatureCompatibilityVersionIfUpgradeIsHappening(); err != nil {
+		return AutomationConfig{}, fmt.Errorf("can't build the automation config: %s", err)
+	}
+
 	dataDir := DefaultMongoDBDataDir
 	if b.dataDir != "" {
 		dataDir = b.dataDir

--- a/pkg/automationconfig/automation_config_test.go
+++ b/pkg/automationconfig/automation_config_test.go
@@ -468,6 +468,12 @@ func TestAreEqual(t *testing.T) {
 	})
 }
 
+func TestValidateFCV(t *testing.T) {
+	_, err := NewBuilder().SetFCV("4.2.4").Build()
+
+	assert.Error(t, err)
+}
+
 func createAutomationConfig(name, mongodbVersion, domain string, opts Options, auth Auth, members, acVersion int) AutomationConfig {
 	ac, _ := NewBuilder().
 		SetName(name).


### PR DESCRIPTION
### What problem does this PR solve?

This PR closes closes #1072.

Changing the featureCompatibilityVersion to an invalid value causes all mongodb-agent containers to remain in an unready state. When a valid CR is applied in an attempt to recover state, the operator is unable to create the replica set due to the previously invalid value and the CR deployment eventually fails and has to be manually redeployed.

It is very important to resolve this issue as it greatly hurts the availability of the cluster because the entire cluster has to be deleted and then redeployed which causes a very long system downtime. This cannot be afforded as high availability is central to MongoDB’s guarantees.
```go
func (b *Builder) setFeatureCompatibilityVersionIfUpgradeIsHappening() error {
	// If we are upgrading, we can't increase featureCompatibilityVersion
	// as that will make the agent never reach goal state
	if len(b.previousAC.Processes) > 0 && b.fcv == "" {

		// Create a x.y.0 version from FCV x.y
		previousFCV := b.previousAC.Processes[0].FeatureCompatibilityVersion
		previousFCVsemver, err := semver.Make(fmt.Sprintf("%s.0", previousFCV))
		if err != nil {
			return fmt.Errorf("can't compute semver version from previous FeatureCompatibilityVersion %s", previousFCV)
		}

		currentVersionSemver, err := semver.Make(b.mongodbVersion)
		if err != nil {
			return fmt.Errorf("current MongoDB version is not a valid semver version: %s", b.mongodbVersion)
		}

		// We would increase FCV here.
		// Note: in theory this will also catch upgrade like 4.2.0 -> 4.2.1 but we don't care about those
		// as they would not change the FCV
		if currentVersionSemver.GT(previousFCVsemver) {
			b.fcv = previousFCV
		}
	}
	return nil
}
```

The mongodb-agent containers in all pods remain in an unready state. The operator keeps requeuing reconciliation requests. When a valid CR is applied, the operator fails to build the automation config and the deployment eventually fails. It seems that `semver.Make(fmt.Sprintf("%s.0", previousFCV))` in the above code fails to compute a semver version from the invalid FCV.

### What changes were made?

To prevent this behaviour, we compute the semver version of the current FeatureCompatibilityVersion so that we are able to identify invalid input.

```go
if b.fcv != "" {
	_, err := semver.Make(fmt.Sprintf("%s.0", b.fcv))

	if err != nil {
		return AutomationConfig{}, fmt.Errorf("invalid feature compatibility version: %s", err)
	}
}
```
### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

This is a simple fix and we suppose no test above is needed.

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).