### PR TITLE
Fix validation of  references to CA certificate in TLS config

### DIFF
--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -371,7 +371,7 @@ func TestTLSConfig_ReferencesToCACertAreValidated(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			r := NewReconciler(kubeClient.NewManagerWithClient(cli))
+			r := NewReconciler(mgr)
 
 			_, err = r.validateTLSConfig(mdb)
 			if tc.expectedError != nil {

--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -341,7 +341,7 @@ func TestTLSConfig_ReferencesToCACertAreValidated(t *testing.T) {
 	tests := map[string]args{
 		"Success if reference to CA cert provided via secret": {
 			caConfigMap: &mdbv1.LocalObjectReference{
-				Name: "ccertificateKeySecret"},
+				Name: "certificateKeySecret"},
 			caCertificateSecret: nil,
 		},
 		"Success if reference to CA cert provided via config map": {
@@ -371,7 +371,7 @@ func TestTLSConfig_ReferencesToCACertAreValidated(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			r := NewReconciler(mgr)
+			r := NewReconciler(kubeClient.NewManagerWithClient(cli))
 
 			_, err = r.validateTLSConfig(mdb)
 			if tc.expectedError != nil {
@@ -401,7 +401,8 @@ func createTLSConfigMap(c k8sClient.Client, mdb mdbv1.MongoDBCommunity) error {
 func createTLSSecretWithNamespaceAndName(c k8sClient.Client, namespace string, name string, crt string, key string, pem string) error {
 	sBuilder := secret.Builder().
 		SetName(name).
-		SetNamespace(namespace)
+		SetNamespace(namespace).
+		SetField(tlsCACertName, "CERT")
 
 	if crt != "" {
 		sBuilder.SetField(tlsSecretCertName, crt)

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -73,7 +73,6 @@ func NewReconciler(mgr manager.Manager) *ReplicaSetReconciler {
 	mgrClient := mgr.GetClient()
 	secretWatcher := watch.New()
 	configMapWatcher := watch.New()
-
 	return &ReplicaSetReconciler{
 		client:           kubernetesClient.NewClient(mgrClient),
 		scheme:           mgr.GetScheme(),

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -87,6 +87,15 @@ func newScramReplicaSet(users ...mdbv1.MongoDBUser) mdbv1.MongoDBCommunity {
 }
 
 func newTestReplicaSetWithTLS() mdbv1.MongoDBCommunity {
+	return newTestReplicaSetWithTLSCaCertificateReferences(&mdbv1.LocalObjectReference{
+		Name: "caConfigMap",
+	},
+		&mdbv1.LocalObjectReference{
+			Name: "certificateKeySecret",
+		})
+}
+
+func newTestReplicaSetWithTLSCaCertificateReferences(caConfigMap, caCertificateSecret *mdbv1.LocalObjectReference) mdbv1.MongoDBCommunity {
 	return mdbv1.MongoDBCommunity{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "my-rs",
@@ -101,10 +110,9 @@ func newTestReplicaSetWithTLS() mdbv1.MongoDBCommunity {
 					Modes: []mdbv1.AuthMode{"SCRAM"},
 				},
 				TLS: mdbv1.TLS{
-					Enabled: true,
-					CaConfigMap: &mdbv1.LocalObjectReference{
-						Name: "caConfigMap",
-					},
+					Enabled:             true,
+					CaConfigMap:         caConfigMap,
+					CaCertificateSecret: caCertificateSecret,
 					CertificateKeySecret: mdbv1.LocalObjectReference{
 						Name: "certificateKeySecret",
 					},


### PR DESCRIPTION
Closes #1114 and #1054 on GH.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?

The issue has existed beforehand.

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?

Yes.

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

#1115 Exists, however, is incomplete and is mixing the TLS validations into an (at least in my opinion) undesired place of different validations. But maybe you/we would like to actually broaden the scope of validations, happy to hear your preferred choice.

* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


