### PR TITLE
CLOUDP-135899: Handle image digests from RELATED_IMAGES_* env var

### DIFF
--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -5,12 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-    service.binding/type: 'mongodb'
-    service.binding/provider: 'community'
-    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
-    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
-    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
-    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:

--- a/controllers/construct/build_statefulset_test.go
+++ b/controllers/construct/build_statefulset_test.go
@@ -97,6 +97,20 @@ func TestMongod_Container(t *testing.T) {
 	})
 }
 
+func TestMongod_ContainerWithDigests(t *testing.T) {
+	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_4_3", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:1234af56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd")
+
+	c := container.New(mongodbContainer("4.3", []corev1.VolumeMount{}, mdbv1.NewMongodConfiguration()))
+
+	t.Run("Image is from RELATED_IMAGE env var", func(t *testing.T) {
+		assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator@sha256:1234af56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd", c.Image)
+	})
+
+	t.Run("Resource requirements are correct", func(t *testing.T) {
+		assert.Equal(t, resourcerequirements.Defaults(), c.Resources)
+	})
+}
+
 func assertStatefulSetIsBuiltCorrectly(t *testing.T, mdb mdbv1.MongoDBCommunity, sts *appsv1.StatefulSet) {
 	assert.Len(t, sts.Spec.Template.Spec.Containers, 2)
 	assert.Len(t, sts.Spec.Template.Spec.InitContainers, 2)
@@ -176,10 +190,10 @@ func assertContainsVolumeMountWithName(t *testing.T, mounts []corev1.VolumeMount
 }
 
 func TestContainerImage(t *testing.T) {
-	os.Setenv(MongodbImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator")
-	os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_1_0_0", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd")
-	os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_12_0_4_7554_1", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c")
-	os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_2_0_0_b20220912000000", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad")
+	_ = os.Setenv(MongodbImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator")
+	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_1_0_0", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd")
+	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_12_0_4_7554_1", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c")
+	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_2_0_0_b20220912000000", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad")
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator:0.0.1", ContainerImage(MongodbImageEnv, "0.0.1"))
 	// for 10.2.25.6008-1 there is no RELATED_IMAGE variable set, so we use version instead of digest
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator:10.2.25.6008-1", ContainerImage(MongodbImageEnv, "10.2.25.6008-1"))

--- a/controllers/construct/build_statefulset_test.go
+++ b/controllers/construct/build_statefulset_test.go
@@ -189,11 +189,19 @@ func assertContainsVolumeMountWithName(t *testing.T, mounts []corev1.VolumeMount
 	assert.True(t, found, "Mounts should have contained a mount with name %s, but didn't. Actual mounts: %v", name, mounts)
 }
 
+func TestReplaceImageTagOrDigest(t *testing.T) {
+	assert.Equal(t, "quay.io/mongodb/mongodb-agent:9876-54321", replaceImageTagOrDigest("quay.io/mongodb/mongodb-agent:1234-567", "9876-54321"))
+	assert.Equal(t, "quay.io/mongodb/mongodb-agent:9876-54321", replaceImageTagOrDigest("quay.io/mongodb/mongodb-agent@sha256:6a82abae27c1ba1133f3eefaad71ea318f8fa87cc57fe9355d6b5b817ff97f1a", "9876-54321"))
+	assert.Equal(t, "quay.io/mongodb/mongodb-enterprise-database:some-tag", replaceImageTagOrDigest("quay.io/mongodb/mongodb-enterprise-database:45678", "some-tag"))
+}
+
 func TestContainerImage(t *testing.T) {
 	_ = os.Setenv(MongodbImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator")
 	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_1_0_0", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd")
 	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_12_0_4_7554_1", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c")
 	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_2_0_0_b20220912000000", MongodbImageEnv), "quay.io/mongodb/mongodb-kubernetes-operator@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad")
+
+	// there is no related image for 0.0.1
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator:0.0.1", ContainerImage(MongodbImageEnv, "0.0.1"))
 	// for 10.2.25.6008-1 there is no RELATED_IMAGE variable set, so we use version instead of digest
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator:10.2.25.6008-1", ContainerImage(MongodbImageEnv, "10.2.25.6008-1"))
@@ -201,4 +209,19 @@ func TestContainerImage(t *testing.T) {
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd", ContainerImage(MongodbImageEnv, "1.0.0"))
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator@sha256:b631ee886bb49ba8d7b90bb003fe66051dadecbc2ac126ac7351221f4a7c377c", ContainerImage(MongodbImageEnv, "12.0.4.7554-1"))
 	assert.Equal(t, "quay.io/mongodb/mongodb-kubernetes-operator@sha256:f1a7f49cd6533d8ca9425f25cdc290d46bb883997f07fac83b66cc799313adad", ContainerImage(MongodbImageEnv, "2.0.0-b20220912000000"))
+
+	// env var has version already, so it is replaced
+	_ = os.Setenv(AgentImageEnv, "quay.io/mongodb/mongodb-agent:12.0.4.7554-1")
+	assert.Equal(t, "quay.io/mongodb/mongodb-agent:10.2.25.6008-1", ContainerImage(AgentImageEnv, "10.2.25.6008-1"))
+
+	// env var has version already, but there is related image with this version
+	_ = os.Setenv(fmt.Sprintf("RELATED_IMAGE_%s_12_0_4_7554_1", AgentImageEnv), "quay.io/mongodb/mongodb-agent@sha256:a48829ce36bf479dc25a4de79234c5621b67beee62ca98a099d0a56fdb04791c")
+	assert.Equal(t, "quay.io/mongodb/mongodb-agent@sha256:a48829ce36bf479dc25a4de79234c5621b67beee62ca98a099d0a56fdb04791c", ContainerImage(AgentImageEnv, "12.0.4.7554-1"))
+
+	_ = os.Setenv(AgentImageEnv, "quay.io/mongodb/mongodb-agent@sha256:608daf56296c10c9bd02cc85bb542a849e9a66aff0697d6359b449540696b1fd")
+	// env var has version already as digest, but there is related image with this version
+	assert.Equal(t, "quay.io/mongodb/mongodb-agent@sha256:a48829ce36bf479dc25a4de79234c5621b67beee62ca98a099d0a56fdb04791c", ContainerImage(AgentImageEnv, "12.0.4.7554-1"))
+	// env var has version already as digest, there is no related image with this version, so we use version instead of digest
+	assert.Equal(t, "quay.io/mongodb/mongodb-agent:1.2.3", ContainerImage(AgentImageEnv, "1.2.3"))
+
 }

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -284,8 +284,12 @@ func getMongoDBImage(version string) string {
 	if strings.HasSuffix(repoUrl, "/") {
 		repoUrl = strings.TrimRight(repoUrl, "/")
 	}
-	mongoImageName := os.Getenv(MongodbImageEnv)
-	return fmt.Sprintf("%s/%s:%s", repoUrl, mongoImageName, version)
+	mongoImageName := ContainerImage(MongodbImageEnv, version)
+	if strings.Contains(mongoImageName, "@sha256:") {
+		return mongoImageName
+	}
+
+	return fmt.Sprintf("%s/%s", repoUrl, mongoImageName)
 }
 
 func mongodbContainer(version string, volumeMounts []corev1.VolumeMount, additionalMongoDBConfig mdbv1.MongodConfiguration) container.Modification {
@@ -341,10 +345,5 @@ func ContainerImage(imageURLEnv string, version string) string {
 		return relatedImage
 	}
 
-	imageURL := os.Getenv(imageURLEnv)
-	if imageURL == "" {
-		panic(fmt.Sprintf("%s environment variable is not set!", imageURLEnv))
-	}
-
-	return fmt.Sprintf("%s:%s", imageURL, version)
+	return fmt.Sprintf("%s:%s", os.Getenv(imageURLEnv), version)
 }


### PR DESCRIPTION
In order to handle running operator in disconnected environments in OpenShift there is a need to use RELATED_IMAGES_* env variables when creating image URL. 

It will work by convention, e.g. for normal combination of `MONGODB_AGENT`, and version `X.Y.Z` if will first search for env var `RELATED_IMAGE_MONGODB_AGENT_X_Y_Z` and use it. If there is no such variable it will backoff to previous way of defining image, which is `${MONGODB_AGENT}:X.Y.Z`.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
