### PR TITLE
CLOUDP-137882: Use different mount path for prometheus TLS secret

### DIFF
--- a/controllers/mongodb_tls.go
+++ b/controllers/mongodb_tls.go
@@ -22,12 +22,13 @@ import (
 )
 
 const (
-	tlsCAMountPath             = "/var/lib/tls/ca/"
-	tlsCACertName              = "ca.crt"
-	tlsOperatorSecretMountPath = "/var/lib/tls/server/" //nolint
-	tlsSecretCertName          = "tls.crt"              //nolint
-	tlsSecretKeyName           = "tls.key"
-	tlsSecretPemName           = "tls.pem"
+	tlsCAMountPath               = "/var/lib/tls/ca/"
+	tlsCACertName                = "ca.crt"
+	tlsOperatorSecretMountPath   = "/var/lib/tls/server/"     //nolint
+	tlsPrometheusSecretMountPath = "/var/lib/tls/prometheus/" //nolint
+	tlsSecretCertName            = "tls.crt"
+	tlsSecretKeyName             = "tls.key"
+	tlsSecretPemName             = "tls.pem"
 )
 
 // validateTLSConfig will check that the configured ConfigMap and Secret exist and that they have the correct fields.
@@ -316,8 +317,7 @@ func buildTLSPrometheus(mdb mdbv1.MongoDBCommunity) podtemplatespec.Modification
 	// The same key-certificate pair is used for all servers
 	tlsSecretVolume := statefulset.CreateVolumeFromSecret("prom-tls-secret", mdb.PrometheusTLSOperatorSecretNamespacedName().Name)
 
-	// TODO: Is it ok to use the same `tlsOperatorSecretMountPath`
-	tlsSecretVolumeMount := statefulset.CreateVolumeMount(tlsSecretVolume.Name, tlsOperatorSecretMountPath, statefulset.WithReadOnly(true))
+	tlsSecretVolumeMount := statefulset.CreateVolumeMount(tlsSecretVolume.Name, tlsPrometheusSecretMountPath, statefulset.WithReadOnly(true))
 
 	// MongoDB expects both key and certificate to be provided in a single PEM file
 	// We are using a secret format where they are stored in separate fields, tls.crt and tls.key

--- a/controllers/prometheus.go
+++ b/controllers/prometheus.go
@@ -39,7 +39,7 @@ func getPrometheusModification(getUpdateCreator secret.GetUpdateCreator, mdb mdb
 		if err != nil {
 			return automationconfig.NOOP(), err
 		}
-		tlsPEMPath = tlsOperatorSecretMountPath + tlsOperatorSecretFileName(certKey)
+		tlsPEMPath = tlsPrometheusSecretMountPath + tlsOperatorSecretFileName(certKey)
 		scheme = "https"
 	} else {
 		scheme = "http"

--- a/release.json
+++ b/release.json
@@ -4,7 +4,7 @@
   "version-upgrade-hook": "1.0.6",
   "readiness-probe": "1.0.12",
   "mongodb-agent": {
-    "version": "12.0.10.7591-1",
-    "tools_version": "100.5.3"
+    "version": "12.0.14.7630-1",
+    "tools_version": "100.6.0"
   }
 }

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -29,8 +29,8 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	defer ctx.Teardown()
 
 	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", "")
-	mdb.Spec.Version = "4.0.6"
-	mdb.Spec.FeatureCompatibilityVersion = "4.0"
+	mdb.Spec.Version = "4.2.23"
+	mdb.Spec.FeatureCompatibilityVersion = "4.2"
 
 	_, err := setup.GeneratePasswordForUser(ctx, user, "")
 	if err != nil {
@@ -45,24 +45,24 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
 	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
-	t.Run("Test FeatureCompatibilityVersion is 4.0", tester.HasFCV("4.0", 3))
+	t.Run("Test FeatureCompatibilityVersion is 4.2", tester.HasFCV("4.2", 3))
 
 	// Upgrade version to 4.2.6 while keeping the FCV set to 4.0
 	t.Run("MongoDB is reachable while version is upgraded", func(t *testing.T) {
-		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
-		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
+		defer tester.StartBackgroundConnectivityTest(t, time.Second*20)()
+		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.4.11"))
 		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
 	})
 
 	t.Run("Test Basic Connectivity after upgrade has completed", tester.ConnectivitySucceeds())
-	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.0", tester.HasFCV("4.0", 3))
+	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", tester.HasFCV("4.2", 3))
 
 	// Downgrade version back to 4.0.6, checks that the FeatureCompatibilityVersion stayed at 4.0
 	t.Run("MongoDB is reachable while version is downgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
-		t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.0.6"))
+		t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.2.23"))
 		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
 	})
 
-	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.0", tester.HasFCV("4.0", 3))
+	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.2", tester.HasFCV("4.2", 3))
 }

--- a/test/e2e/prometheus/prometheus_test.go
+++ b/test/e2e/prometheus/prometheus_test.go
@@ -44,21 +44,23 @@ func TestPrometheus(t *testing.T) {
 
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, ctx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(&mdb))
-	t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
-	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 
-	t.Run("Test Prometheus endpoint is active", tester.PrometheusEndpointIsReachable("prom-user", "prom-password", false))
-	t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3))
-	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
+	mongodbtests.SkipTestIfLocal(t, "Ensure MongoDB with Prometheus configuration", func(t *testing.T) {
+		t.Run("Resource has TLS Mode", tester.HasTlsMode("requireSSL", 60, WithTls(mdb)))
+		t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds(WithTls(mdb)))
+		t.Run("Test Prometheus endpoint is active", tester.PrometheusEndpointIsReachable("prom-user", "prom-password", false))
+		t.Run("Ensure Authentication", tester.EnsureAuthenticationIsConfigured(3, WithTls(mdb)))
+		t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 1))
 
-	t.Run("Enabling HTTPS on the Prometheus endpoint", func(t *testing.T) {
-		err = e2eutil.UpdateMongoDBResource(&mdb, func(mdb *v1.MongoDBCommunity) {
-			mdb.Spec.Prometheus.TLSSecretRef.Name = "tls-certificate"
+		t.Run("Enabling HTTPS on the Prometheus endpoint", func(t *testing.T) {
+			err = e2eutil.UpdateMongoDBResource(&mdb, func(mdb *v1.MongoDBCommunity) {
+				mdb.Spec.Prometheus.TLSSecretRef.Name = "tls-certificate"
+			})
+			assert.NoError(t, err)
+
+			t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
+			t.Run("Test Prometheus HTTPS endpoint is active", tester.PrometheusEndpointIsReachable("prom-user", "prom-password", true))
+			t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 2))
 		})
-		assert.NoError(t, err)
-
-		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
-		t.Run("Test Prometheus HTTPS endpoint is active", tester.PrometheusEndpointIsReachable("prom-user", "prom-password", true))
 	})
-	t.Run("AutomationConfig has the correct version", mongodbtests.AutomationConfigVersionHasTheExpectedVersion(&mdb, 2))
 }

--- a/test/e2e/prometheus/prometheus_test.go
+++ b/test/e2e/prometheus/prometheus_test.go
@@ -23,13 +23,16 @@ func TestMain(m *testing.M) {
 }
 
 func TestPrometheus(t *testing.T) {
-	ctx, testConfig := setup.SetupWithTLS(t, "")
+	resourceName := "mdb0"
+	ctx, testConfig := setup.SetupWithTLS(t, resourceName)
 	defer ctx.Teardown()
 
-	mdb, user := e2eutil.NewTestMongoDB(ctx, "mdb0", testConfig.Namespace)
+	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, testConfig.Namespace)
+
+	mdb.Spec.Security.TLS = e2eutil.NewTestTLSConfig(false)
 	mdb.Spec.Prometheus = e2eutil.NewPrometheusConfig(mdb.Namespace)
 
-	_, err := setup.GeneratePasswordForUser(ctx, user, "")
+	_, err := setup.GeneratePasswordForUser(ctx, user, testConfig.Namespace)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This patch changes the prometheus TLS secret mount path to avoid the conflict with the MongoD server TLS certificate mount path.

closes #1127
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
