### PR TITLE
CLOUDP-145867: Bump kubernetes python dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/mongodb/sonar@0c21097a55a4426c8824f74cdcfbceb11b27bb68
 github-action-templates==0.0.4
 docker==4.3.1
-kubernetes==11.0.0
+kubernetes==23.3.0
 jinja2==2.11.3
 MarkupSafe==2.0.1
 PyYAML==5.4.1


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
