### PR TITLE
[testing] [local] optionally skip connectivity tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ generate: controller-gen ## Generate code
 
 TEST ?= ./pkg/... ./api/... ./cmd/... ./controllers/... ./test/e2e/util/mongotester/...
 test: generate fmt vet manifests ## Run unit tests
-	go test $(TEST) -coverprofile cover.out
+	go test $(options) $(TEST) -coverprofile cover.out
 
 manager: generate fmt vet ## Build manager binary
 	go build -o bin/manager ./cmd/manager/main.go
@@ -120,7 +120,7 @@ e2e-telepresence: cleanup-e2e install ## Run e2e tests locally using go build wh
 	telepresence connect; \
 	telepresence status; \
 	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \
-	go test -v -timeout=30m -failfast ./test/e2e/$(test); \
+	go test -v -timeout=30m -failfast $(options) ./test/e2e/$(test) ; \
 	telepresence quit
 
 e2e-k8s: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes.
@@ -128,7 +128,7 @@ e2e-k8s: cleanup-e2e install e2e-image ## Run e2e test by deploying test image i
 
 e2e: cleanup-e2e install ## Run e2e test locally. e.g. make e2e test=replica_set cleanup=true
 	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \
-	go test -v -short -timeout=30m -failfast ./test/e2e/$(test)
+	go test -v -short -timeout=30m -failfast $(options) ./test/e2e/$(test)
 
 e2e-gh: ## Trigger a Github Action of the given test
 	scripts/dev/run_e2e_gh.sh $(test)

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ install-chart:
 
 install-chart-with-tls-enabled:
 	$(HELM) upgrade --install --set createResource=true $(STRING_SET_VALUES) $(RELEASE_NAME_HELM) $(HELM_CHART) --namespace $(NAMESPACE) --create-namespace
-
 install-rbac:
 	$(HELM) template $(STRING_SET_VALUES) -s templates/database_roles.yaml $(HELM_CHART) | kubectl apply -f -
 	$(HELM) template $(STRING_SET_VALUES) -s templates/operator_roles.yaml $(HELM_CHART) | kubectl apply -f -
@@ -122,11 +121,8 @@ e2e-telepresence: cleanup-e2e install ## Run e2e tests locally using go build wh
 	go test -v -timeout=30m -failfast $(options) ./test/e2e/$(test) ; \
 	telepresence quit
 
-e2e-k8s: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes without cleanup of the resources.
-	python scripts/dev/e2e.py --test $(test)
-
-e2e-k8s-cleanup: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes with cleanup of the resources.
-	python scripts/dev/e2e.py --perform-cleanup  --test $(test)
+e2e-k8s: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes, you can provide e2e.py flags e.g. make e2e-k8s test=replica_set e2eflags="--perform-cleanup".
+	python scripts/dev/e2e.py $(e2eflags) --test $(test)
 
 e2e: cleanup-e2e install ## Run e2e test locally. e.g. make e2e test=replica_set cleanup=true
 	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,11 @@ e2e-telepresence: cleanup-e2e install ## Run e2e tests locally using go build wh
 	go test -v -timeout=30m -failfast $(options) ./test/e2e/$(test) ; \
 	telepresence quit
 
-e2e-k8s: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes.
-	python scripts/dev/e2e.py --perform-cleanup --test $(test)
+e2e-k8s: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes without cleanup of the resources.
+	python scripts/dev/e2e.py --test $(test)
+
+e2e-k8s-cleanup: cleanup-e2e install e2e-image ## Run e2e test by deploying test image in kubernetes with cleanup of the resources.
+	python scripts/dev/e2e.py --perform-cleanup  --test $(test)
 
 e2e: cleanup-e2e install ## Run e2e test locally. e.g. make e2e test=replica_set cleanup=true
 	eval $$(scripts/dev/get_e2e_env_vars.py $(cleanup)); \

--- a/test/e2e/util/mongotester/mongotester.go
+++ b/test/e2e/util/mongotester/mongotester.go
@@ -227,7 +227,10 @@ func (m *Tester) connectivityCheck(shouldSucceed bool, opts ...OptionApplier) fu
 				t.Logf("Was successfully able to connect, when we should not have been able to!")
 				return false, nil
 			}
-			t.Logf("Connectivity check was successful after %d attempt(s)", attempts)
+			// this information is only useful if we needed more than one attempt.
+			if attempts >= 2 {
+				t.Logf("Connectivity check was successful after %d attempt(s)", attempts)
+			}
 			return true, nil
 		})
 

--- a/test/e2e/util/mongotester/mongotester.go
+++ b/test/e2e/util/mongotester/mongotester.go
@@ -200,6 +200,12 @@ func (m *Tester) connectivityCheck(shouldSucceed bool, opts ...OptionApplier) fu
 
 	connectivityOpts := defaults()
 	return func(t *testing.T) {
+
+		// We can optionally skip connectivity tests locally
+		if testing.Short() {
+			t.Skip()
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), connectivityOpts.ContextTimeout)
 		defer cancel()
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

## Changes
- only log connection success if attempts were more than 1, otherwise its just noisy
- add a make target to not cleanup the environment, useful for debugging broken e2e tests
- adds `options` to our go test make targets i.e. ` make e2e-telepresence test=replica_set cleanup=false option=-short`
- adds a test skip option in our testing connectivity suite. Albeit we already have the function `SkipTestIfLocal` we would need a bit more of a refactor to properly support it. I thought adding this check is small enough to not warrant the method refactor


```
 > make e2e-telepresence test=replica_set cleanup=false options=-short
....
=== RUN   TestReplicaSet/AutomationConfig_has_the_correct_version
--- PASS: TestReplicaSet (189.24s)
    --- PASS: TestReplicaSet/Create_MongoDB_Resource (0.01s)
    --- PASS: TestReplicaSet/Basic_tests (125.03s)
        --- PASS: TestReplicaSet/Basic_tests/Secret_Was_Correctly_Created (5.00s)
        --- PASS: TestReplicaSet/Basic_tests/Stateful_Set_Reaches_Ready_State (105.02s)
        --- PASS: TestReplicaSet/Basic_tests/MongoDB_Reaches_Running_Phase (15.00s)
        --- PASS: TestReplicaSet/Basic_tests/Stateful_Set_Has_OwnerReference (0.00s)
        --- PASS: TestReplicaSet/Basic_tests/Service_Set_Has_OwnerReference (0.00s)
        --- PASS: TestReplicaSet/Basic_tests/Agent_Secrets_Have_OwnerReference (0.00s)
        --- PASS: TestReplicaSet/Basic_tests/Connection_string_secrets_are_configured (0.00s)
    --- PASS: TestReplicaSet/Keyfile_authentication_is_configured (10.04s)
    --- SKIP: TestReplicaSet/Test_Basic_Connectivity (0.00s)
    --- SKIP: TestReplicaSet/Test_SRV_Connectivity (0.00s)
    --- SKIP: TestReplicaSet/Test_Basic_Connectivity_with_generated_connection_string_secret (0.00s)
    --- SKIP: TestReplicaSet/Test_SRV_Connectivity_with_generated_connection_string_secret (0.00s)
    --- PASS: TestReplicaSet/Ensure_Authentication (20.05s)
        --- PASS: TestReplicaSet/Ensure_Authentication/Ensure_keyFile_authentication_is_configured (10.02s)
        --- PASS: TestReplicaSet/Ensure_Authentication/SCRAM-SHA-256_is_configured (10.03s)
    --- PASS: TestReplicaSet/AutomationConfig_has_the_correct_version (0.00s)
PASS
ok      github.com/mongodb/mongodb-kubernetes-operator/test/e2e/replica_set     189.792s
```