### PR TITLE
[e2e] bump sts timeout, logs update, helm update 

### DIFF
--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -129,7 +129,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         "go",
                         "test",
                         "-v",
-                        "-timeout=40m",
+                        "-timeout=45m",
                         "-failfast",
                         f"./test/e2e/{args.test}",
                     ],

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -129,7 +129,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         "go",
                         "test",
                         "-v",
-                        "-timeout=30m",
+                        "-timeout=40m",
                         "-failfast",
                         f"./test/e2e/{args.test}",
                     ],

--- a/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
+++ b/test/e2e/feature_compatibility_version/feature_compatibility_version_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/wait"
-
 	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
 
 	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
@@ -51,7 +49,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while version is upgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*20)()
 		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.4.11"))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 	})
 
 	t.Run("Test Basic Connectivity after upgrade has completed", tester.ConnectivitySucceeds())
@@ -61,7 +59,7 @@ func TestFeatureCompatibilityVersion(t *testing.T) {
 	t.Run("MongoDB is reachable while version is downgraded", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be downgraded", mongodbtests.ChangeVersion(&mdb, "4.2.23"))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 	})
 
 	t.Run("Test FeatureCompatibilityVersion, after downgrade, is 4.2", tester.HasFCV("4.2", 3))

--- a/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
+++ b/test/e2e/feature_compatibility_version_upgrade/feature_compatibility_version_upgrade_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/wait"
-
 	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
 
 	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
@@ -53,7 +51,7 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 	t.Run("MongoDB is reachable", func(t *testing.T) {
 		defer tester.StartBackgroundConnectivityTest(t, time.Second*10)()
 		t.Run("Test Version can be upgraded", mongodbtests.ChangeVersion(&mdb, "4.2.6"))
-		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
+		t.Run("Stateful Set Reaches Ready State, after Upgrading", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("Test Basic Connectivity after upgrade has completed", tester.ConnectivitySucceeds())
 	})
 
@@ -66,7 +64,7 @@ func TestFeatureCompatibilityVersionUpgrade(t *testing.T) {
 			})
 			assert.NoError(t, err)
 		})
-		t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
+		t.Run("Stateful Set Reaches Ready State", mongodbtests.StatefulSetBecomesReady(&mdb))
 		t.Run("MongoDB Reaches Running Phase", mongodbtests.MongoDBReachesRunningPhase(&mdb))
 	})
 	t.Run("Test FeatureCompatibilityVersion, after upgrade, is 4.2", tester.HasFCV("4.2", 3))

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -86,8 +86,8 @@ func statefulSetIsReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration)
 		if err != nil {
 			t.Fatal(err)
 		}
-		elapsed := time.Since(start)
-		t.Logf("StatefulSet %s/%s is ready! It took %d seconds", mdb.Namespace, mdb.Name, elapsed)
+		elapsed := time.Since(start).Seconds()
+		t.Logf("StatefulSet %s/%s is ready! It took %f seconds", mdb.Namespace, mdb.Name, elapsed)
 	}
 }
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -36,7 +36,7 @@ func SkipTestIfLocal(t *testing.T, msg string, f func(t *testing.T)) {
 func StatefulSetBecomesReady(mdb *mdbv1.MongoDBCommunity, opts ...wait.Configuration) func(t *testing.T) {
 	defaultOpts := []wait.Configuration{
 		wait.RetryInterval(time.Second * 15),
-		wait.Timeout(time.Minute * 20),
+		wait.Timeout(time.Minute * 25),
 	}
 	defaultOpts = append(defaultOpts, opts...)
 	return statefulSetIsReady(mdb, defaultOpts...)

--- a/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
 	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
 	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
-	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/wait"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -82,7 +80,7 @@ func TestReplicaSetArbiter(t *testing.T) {
 			if len(testConfig.expectedErrorMessage) > 0 {
 				t.Run("Check status", mongodbtests.StatefulSetMessageIsReceived(&mdb, ctx, testConfig.expectedErrorMessage))
 			} else {
-				t.Run("Check that the stateful set becomes ready", mongodbtests.StatefulSetBecomesReady(&mdb, wait.Timeout(20*time.Minute)))
+				t.Run("Check that the stateful set becomes ready", mongodbtests.StatefulSetBecomesReady(&mdb))
 				t.Run("Check the number of arbiters", mongodbtests.AutomationConfigReplicaSetsHaveExpectedArbiters(&mdb, testConfig.numberOfArbiters))
 
 				if testConfig.numberOfArbiters != testConfig.scaleArbitersTo {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


## Changes
- bump helm-charts: https://github.com/mongodb/helm-charts/pull/193
- bump overall test limit from 30m to 45m (tests succeeding almost take 30minutes: https://github.com/mongodb/mongodb-kubernetes-operator/actions/runs/3891209152/jobs/6641225437 vs failures: https://github.com/mongodb/mongodb-kubernetes-operator/actions/runs/3894602279/jobs/6648879374).
- removes explicit sts timeout usage at they are matching the default opts
- bumping sts test timeout from 20 to 25 as this one is one of the longest running checks (https://github.com/mongodb/mongodb-kubernetes-operator/actions/runs/3543640187/jobs/5950896967)
- add log for sts elapsed time. This could be done properly but it takes more refactoring. Most of the flaky tests are the sts checks, as they take the most time. If we think it happens for the other functions we can refactor and make it common
- fix some comments
