### PR TITLE
Use AMD64 platform for docker 

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -117,6 +117,7 @@ images:
       - agent_image
       - agent_image_dev
 
+    platform: linux/amd64
     stages:
       - name: agent-ubi-context
         task_type: docker_build
@@ -214,6 +215,7 @@ images:
       - readiness_probe_image
       - readiness_probe_image_dev
 
+    platform: linux/amd64
     stages:
       - name: readiness-init-context-build
         task_type: docker_build
@@ -290,6 +292,7 @@ images:
       - version_post_start_hook_image
       - version_post_start_hook_image_dev
 
+    platform: linux/amd64
     stages:
       - name: version-post-start-hook-init-context-build
         task_type: docker_build


### PR DESCRIPTION
* Make sure that we build and use amd64 images. Even if we are building on other machines locally (m1,darwin).
* Building images i.e. for e2e tests are now independent of your current platform (`make all-images` + `make e2e-k8s test=replica_set_change_version`) and can use the image build by our machine. In my case M1

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
