### PR TITLE
feat: add liveness and readiness probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,6 +57,18 @@ spec:
         image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.6
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator
+        ports:
+        - containerPort: 9090
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         resources:
           limits:
             cpu: 1100m


### PR DESCRIPTION
This PR fixes https://github.com/mongodb/mongodb-kubernetes-operator/issues/536, although it got closed as stale by the bot.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
