### PR TITLE
Fix merging nil label selectors

### DIFF
--- a/pkg/util/merge/merge_statefulset.go
+++ b/pkg/util/merge/merge_statefulset.go
@@ -65,7 +65,7 @@ func LabelSelectors(originalLabelSelector, overrideLabelSelector *metav1.LabelSe
 	}
 	// we have only specified a label selector in the original
 	if originalLabelSelector == nil {
-		return originalLabelSelector
+		return overrideLabelSelector
 	}
 
 	// we have specified both, so we must merge them


### PR DESCRIPTION
Noticed an issue when the original stateful set label selectors are nil, merging with an override would always keep the label selectors `nil`. Added some unit tests for this code path as well.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
