### PR TITLE
[log] fix log output for pods that don't exist yet

### DIFF
--- a/cmd/versionhook/main.go
+++ b/cmd/versionhook/main.go
@@ -59,7 +59,7 @@ func main() {
 		logger.Infof("Pod should be deleted")
 		if err := deletePod(); err != nil {
 			// We should not raise an error if the Pod could not be deleted. It can have even
-			// worst consequences: Pod being restarted with the same version, and the agent
+			// worse consequences: Pod being restarted with the same version, and the agent
 			// killing it immediately after.
 			logger.Errorf("Could not manually trigger restart of this Pod because of: %s", err)
 			logger.Errorf("Make sure the Pod is restarted in order for the upgrade process to continue")

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -76,7 +76,7 @@ type MongoDBStatefulSetOwner interface {
 	GetUpdateStrategyType() appsv1.StatefulSetUpdateStrategyType
 	// HasSeparateDataAndLogsVolumes returns whether or not the volumes for data and logs would need to be different.
 	HasSeparateDataAndLogsVolumes() bool
-	// GetAgentScramKeyfileSecretNamespacedName returns the NamespacedName of the secret which stores the keyfile for the agent.
+	// GetAgentKeyfileSecretNamespacedName returns the NamespacedName of the secret which stores the keyfile for the agent.
 	GetAgentKeyfileSecretNamespacedName() types.NamespacedName
 	// DataVolumeName returns the name that the data volume should have
 	DataVolumeName() string
@@ -86,7 +86,7 @@ type MongoDBStatefulSetOwner interface {
 	// GetMongodConfiguration returns the MongoDB configuration for each member.
 	GetMongodConfiguration() mdbv1.MongodConfiguration
 
-	// NeedsAutomationConfigVolume returns whether the statefuslet needs to have a volume for the automationconfig.
+	// NeedsAutomationConfigVolume returns whether the statefulset needs to have a volume for the automationconfig.
 	NeedsAutomationConfigVolume() bool
 }
 

--- a/pkg/agent/agent_readiness.go
+++ b/pkg/agent/agent_readiness.go
@@ -81,7 +81,11 @@ func GetAllDesiredMembersAndArbitersPodState(namespacedName types.NamespacedName
 		p, err := podGetter.GetPod(podNamespacedName)
 		if err != nil {
 			if apiErrors.IsNotFound(err) {
+				// we can skip below iteration and check for our goal state since the pod is not available yet
 				podState.Found = false
+				podState.ReachedGoalState = false
+				podStates[i] = podState
+				continue
 			} else {
 				return nil, err
 			}


### PR DESCRIPTION
### Changes:
* When checking whether our agents are ready or not we log when a Pod is not ready. There is a logging bug when the pod is not running yet. This means we are checking the goal state of a pod that does not exist yet. This will lead to the following output:
```
DEBUG   agent/agent_readiness.go:102    The Pod '' doesn't have annotation 'agent.mongodb.com/version' yet  {"ReplicaSet": "default/mdb0"}
```
*  When the pod is not around (yet) there is no goalState that needed to be checked, so we can skip that check where the wrong log came from.
*  Fixes some comments

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
