### PR TITLE
[CLOUDP-132990] cleanup leftover resources for scram secrets

### DIFF
--- a/controllers/mongodb_cleanup.go
+++ b/controllers/mongodb_cleanup.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// cleanupScramSecrets cleans up old scram secrets based on the last successful applied mongodb spec.
+func (r *ReplicaSetReconciler) cleanupScramSecrets(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
+	secretsToDelete := getScramSecretsToDelete(currentMDB, lastAppliedMDBSpec)
+
+	for _, s := range secretsToDelete {
+		if err := r.client.DeleteSecret(types.NamespacedName{
+			Name:      s,
+			Namespace: namespace,
+		}); err != nil {
+			r.log.Warnf("Could not cleanup old secret %s", s)
+		} else {
+			r.log.Debugf("Sucessfully cleaned up secret: %s", s)
+		}
+	}
+}
+
+func getScramSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec) []string {
+	type user struct {
+		db   string
+		name string
+	}
+	m := map[user]string{}
+	var secretsToDelete []string
+
+	for _, mongoDBUser := range currentMDB.Users {
+		m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = mongoDBUser.GetScramCredentialsSecretName()
+	}
+
+	for _, mongoDBUser := range lastAppliedMDBSpec.Users {
+		currentScramSecretName, ok := m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}]
+		if !ok { // not used anymore
+			secretsToDelete = append(secretsToDelete, mongoDBUser.GetScramCredentialsSecretName())
+		} else if currentScramSecretName != mongoDBUser.GetScramCredentialsSecretName() { // have changed
+			secretsToDelete = append(secretsToDelete, mongoDBUser.GetScramCredentialsSecretName())
+		}
+	}
+	return secretsToDelete
+}

--- a/controllers/mongodb_cleanup_test.go
+++ b/controllers/mongodb_cleanup_test.go
@@ -1,0 +1,96 @@
+package controllers
+
+import (
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReplicaSetReconcilerCleanupScramSecrets(t *testing.T) {
+	lastApplied := newScramReplicaSet(mdbv1.MongoDBUser{
+		Name: "testUser",
+		PasswordSecretRef: mdbv1.SecretKeyReference{
+			Name: "password-secret-name",
+		},
+		ScramCredentialsSecretName: "scram-credentials",
+	})
+
+	t.Run("no change same resource", func(t *testing.T) {
+		actual := getScramSecretsToDelete(lastApplied.Spec, lastApplied.Spec)
+
+		var expected []string
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("new user new secret", func(t *testing.T) {
+		current := newScramReplicaSet(
+			mdbv1.MongoDBUser{
+				Name: "testUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ScramCredentialsSecretName: "scram-credentials",
+			},
+			mdbv1.MongoDBUser{
+				Name: "newUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ScramCredentialsSecretName: "scram-credentials-2",
+			},
+		)
+
+		var expected []string
+		actual := getScramSecretsToDelete(current.Spec, lastApplied.Spec)
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("old user new secret", func(t *testing.T) {
+		current := newScramReplicaSet(mdbv1.MongoDBUser{
+			Name: "testUser",
+			PasswordSecretRef: mdbv1.SecretKeyReference{
+				Name: "password-secret-name",
+			},
+			ScramCredentialsSecretName: "scram-credentials-2",
+		})
+
+		expected := []string{"scram-credentials-scram-credentials"}
+		actual := getScramSecretsToDelete(current.Spec, lastApplied.Spec)
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("removed one user and changed secret of the other", func(t *testing.T) {
+		lastApplied = newScramReplicaSet(
+			mdbv1.MongoDBUser{
+				Name: "testUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ScramCredentialsSecretName: "scram-credentials",
+			},
+			mdbv1.MongoDBUser{
+				Name: "anotherUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ScramCredentialsSecretName: "another-scram-credentials",
+			},
+		)
+
+		current := newScramReplicaSet(mdbv1.MongoDBUser{
+			Name: "testUser",
+			PasswordSecretRef: mdbv1.SecretKeyReference{
+				Name: "password-secret-name",
+			},
+			ScramCredentialsSecretName: "scram-credentials-2",
+		})
+
+		expected := []string{"scram-credentials-scram-credentials", "another-scram-credentials-scram-credentials"}
+		actual := getScramSecretsToDelete(current.Spec, lastApplied.Spec)
+
+		assert.Equal(t, expected, actual)
+	})
+
+}

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -137,7 +137,8 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 	r.log.Infof("Reconciling MongoDB")
 
 	r.log.Debug("Validating MongoDB.Spec")
-	if err := r.validateSpec(mdb); err != nil {
+	err, lastAppliedSpec := r.validateSpec(mdb)
+	if err != nil {
 		return status.Update(r.client.Status(), &mdb,
 			statusOptions().
 				withMessage(Error, fmt.Sprintf("error validating new Spec: %s", err)).
@@ -251,6 +252,10 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	if err := r.updateConnectionStringSecrets(mdb, os.Getenv(clusterDomain)); err != nil {
 		r.log.Errorf("Could not update connection string secrets: %s", err)
+	}
+
+	if lastAppliedSpec != nil {
+		r.cleanupScramSecrets(mdb.Spec, *lastAppliedSpec, mdb.Namespace)
 	}
 
 	if err := r.updateLastSuccessfulConfiguration(mdb); err != nil {
@@ -585,20 +590,22 @@ func (r *ReplicaSetReconciler) buildService(mdb mdbv1.MongoDBCommunity, portMana
 // validateSpec checks if the MongoDB resource Spec is valid.
 // If there has not yet been a successful configuration, the function runs the initial Spec validations. Otherwise,
 // it checks that the attempted Spec is valid in relation to the Spec that resulted from that last successful configuration.
-func (r ReplicaSetReconciler) validateSpec(mdb mdbv1.MongoDBCommunity) error {
+// The validation also returns the lastSuccessFulConfiguration Spec as mdbv1.MongoDBCommunitySpec.
+func (r ReplicaSetReconciler) validateSpec(mdb mdbv1.MongoDBCommunity) (error, *mdbv1.MongoDBCommunitySpec) {
+
 	lastSuccessfulConfigurationSaved, ok := mdb.Annotations[lastSuccessfulConfiguration]
 	if !ok {
 		// First version of Spec
-		return validation.ValidateInitalSpec(mdb, r.log)
+		return validation.ValidateInitialSpec(mdb, r.log), nil
 	}
 
 	lastSpec := mdbv1.MongoDBCommunitySpec{}
 	err := json.Unmarshal([]byte(lastSuccessfulConfigurationSaved), &lastSpec)
 	if err != nil {
-		return err
+		return err, &lastSpec
 	}
 
-	return validation.ValidateUpdate(mdb, lastSpec, r.log)
+	return validation.ValidateUpdate(mdb, lastSpec, r.log), &lastSpec
 }
 
 func getCustomRolesModification(mdb mdbv1.MongoDBCommunity) (automationconfig.Modification, error) {

--- a/controllers/validation/validation.go
+++ b/controllers/validation/validation.go
@@ -10,8 +10,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// ValidateInitalSpec checks if the resource's initial Spec is valid.
-func ValidateInitalSpec(mdb mdbv1.MongoDBCommunity, log *zap.SugaredLogger) error {
+// ValidateInitialSpec checks if the resource's initial Spec is valid.
+func ValidateInitialSpec(mdb mdbv1.MongoDBCommunity, log *zap.SugaredLogger) error {
 	return validateSpec(mdb, log)
 }
 


### PR DESCRIPTION
closes #1074

## Changes
- rely on the `lastSuccessfulConfiguration` and prepare so that it can be used during the whole reconciliation 
- add a method before finishing reconciliation, but after updating the automation config, to check for leftover resources, in this case scram secrets

## Automatic Verification
- my provided unit tests
 
## Manual Verificaiton
- re-create issue  #1074
- do the name change as provided in the issue
- verify with `kubectl get secrets` that the old secret got deleted
- verify given the log message in the operator i.e. 
```
2023-01-25T16:15:54.211+0100    DEBUG   controllers/mongodb_cleanup.go:19       Sucessfully cleaned up secret: another-scram-name-7-scram-credentials   {"ReplicaSet": "mongodb/example-mongodb-leak"}
```
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
