### PR TITLE
[CLOUDP-113527] make mongo image and repo configurable for e2e tests

### DIFF
--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -5,12 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
-    service.binding/type: 'mongodb'
-    service.binding/provider: 'community'
-    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
-    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
-    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
-    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -5,6 +5,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.1
+    service.binding/type: 'mongodb'
+    service.binding/provider: 'community'
+    service.binding: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret'
+    service.binding/connectionString: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=connectionString.standardSrv'
+    service.binding/username: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=username'
+    service.binding/password: 'path={.metadata.name}-{.spec.users[0].db}-{.spec.users[0].name},objectType=Secret,sourceKey=password'
   creationTimestamp: null
   name: mongodbcommunity.mongodbcommunity.mongodb.com
 spec:

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -1,6 +1,8 @@
 {
   "namespace": "default",
   "repo_url": "quay.io/mongodb",
+  "mongodb_image_repo_url": "docker.io",
+  "mongodb_image_name": "mongo",
   "operator_image": "mongodb-kubernetes-operator",
   "operator_image_dev": "community-operator-dev",
   "e2e_image": "community-operator-e2e",

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -108,6 +108,14 @@ class DevConfig:
         return self._get_dev_image("readiness_probe_image_dev", "readiness_probe_image")
 
     @property
+    def mongodb_image_name(self) -> str:
+        return self._config.get("mongodb_image_name", "mongo")
+
+    @property
+    def mongodb_image_repo_url(self) -> str:
+        return self._config.get("mongodb_image_repo_url", "docker.io")
+
+    @property
     def agent_dev_image_ubi(self) -> str:
         return self._get_dev_image("agent_image_ubi_dev", "agent_image_ubi")
 

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -121,6 +121,14 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                             "value": f"{dev_config.repo_url}/{dev_config.readiness_probe_image_dev}:{args.tag}",
                         },
                         {
+                            "name": "MONGODB_IMAGE",
+                            "value": f"{dev_config.mongodb_image_name}",
+                        },
+                        {
+                            "name": "MONGODB_REPO_URL",
+                            "value": f"{dev_config.mongodb_image_repo_url}",
+                        },
+                        {
                             "name": "PERFORM_CLEANUP",
                             "value": f"{args.perform_cleanup}",
                         },
@@ -138,39 +146,38 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
         },
     }
     if not k8s_conditions.wait(
-        lambda: corev1.list_namespaced_pod(
-            dev_config.namespace,
-            field_selector=f"metadata.name=={TEST_POD_NAME}",
-        ),
-        lambda pod_list: len(pod_list.items) == 0,
-        timeout=30,
-        sleep_time=0.5,
+            lambda: corev1.list_namespaced_pod(
+                dev_config.namespace,
+                field_selector=f"metadata.name=={TEST_POD_NAME}",
+            ),
+            lambda pod_list: len(pod_list.items) == 0,
+            timeout=30,
+            sleep_time=0.5,
     ):
         raise Exception(
             "Execution timed out while waiting for the existing pod to be deleted"
         )
 
     if not k8s_conditions.call_eventually_succeeds(
-        lambda: corev1.create_namespaced_pod(dev_config.namespace, body=test_pod),
-        sleep_time=10,
-        timeout=60,
-        exceptions_to_ignore=ApiException,
+            lambda: corev1.create_namespaced_pod(dev_config.namespace, body=test_pod),
+            sleep_time=10,
+            timeout=60,
+            exceptions_to_ignore=ApiException,
     ):
         raise Exception("Could not create test pod!")
 
 
 def wait_for_pod_to_be_running(
-    corev1: client.CoreV1Api, name: str, namespace: str
+        corev1: client.CoreV1Api, name: str, namespace: str
 ) -> None:
     print("Waiting for pod to be running")
     if not k8s_conditions.wait(
-        lambda: corev1.read_namespaced_pod(name, namespace),
-        lambda pod: pod.status.phase == "Running",
-        sleep_time=5,
-        timeout=240,
-        exceptions_to_ignore=ApiException,
+            lambda: corev1.read_namespaced_pod(name, namespace),
+            lambda pod: pod.status.phase == "Running",
+            sleep_time=5,
+            timeout=240,
+            exceptions_to_ignore=ApiException,
     ):
-
         pod = corev1.read_namespaced_pod(name, namespace)
         raise Exception("Pod never got into Running state: {}".format(pod))
     print("Pod is running")
@@ -258,7 +265,7 @@ def prepare_and_run_test(args: argparse.Namespace, dev_config: DevConfig) -> Non
 
     # stream all of the pod output as the pod is running
     for line in corev1.read_namespaced_pod_log(
-        TEST_POD_NAME, dev_config.namespace, follow=True, _preload_content=False
+            TEST_POD_NAME, dev_config.namespace, follow=True, _preload_content=False
     ).stream():
         print(line.decode("utf-8").rstrip())
 
@@ -272,11 +279,11 @@ def main() -> int:
 
     corev1 = client.CoreV1Api()
     if not k8s_conditions.wait(
-        lambda: corev1.read_namespaced_pod(TEST_POD_NAME, dev_config.namespace),
-        lambda pod: pod.status.phase == "Succeeded",
-        sleep_time=5,
-        timeout=60,
-        exceptions_to_ignore=ApiException,
+            lambda: corev1.read_namespaced_pod(TEST_POD_NAME, dev_config.namespace),
+            lambda pod: pod.status.phase == "Succeeded",
+            sleep_time=5,
+            timeout=60,
+            exceptions_to_ignore=ApiException,
     ):
         return 1
     _delete_test_environment(args.config_file)

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -146,38 +146,39 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
         },
     }
     if not k8s_conditions.wait(
-            lambda: corev1.list_namespaced_pod(
-                dev_config.namespace,
-                field_selector=f"metadata.name=={TEST_POD_NAME}",
-            ),
-            lambda pod_list: len(pod_list.items) == 0,
-            timeout=30,
-            sleep_time=0.5,
+        lambda: corev1.list_namespaced_pod(
+            dev_config.namespace,
+            field_selector=f"metadata.name=={TEST_POD_NAME}",
+        ),
+        lambda pod_list: len(pod_list.items) == 0,
+        timeout=30,
+        sleep_time=0.5,
     ):
         raise Exception(
             "Execution timed out while waiting for the existing pod to be deleted"
         )
 
     if not k8s_conditions.call_eventually_succeeds(
-            lambda: corev1.create_namespaced_pod(dev_config.namespace, body=test_pod),
-            sleep_time=10,
-            timeout=60,
-            exceptions_to_ignore=ApiException,
+        lambda: corev1.create_namespaced_pod(dev_config.namespace, body=test_pod),
+        sleep_time=10,
+        timeout=60,
+        exceptions_to_ignore=ApiException,
     ):
         raise Exception("Could not create test pod!")
 
 
 def wait_for_pod_to_be_running(
-        corev1: client.CoreV1Api, name: str, namespace: str
+    corev1: client.CoreV1Api, name: str, namespace: str
 ) -> None:
     print("Waiting for pod to be running")
     if not k8s_conditions.wait(
-            lambda: corev1.read_namespaced_pod(name, namespace),
-            lambda pod: pod.status.phase == "Running",
-            sleep_time=5,
-            timeout=240,
-            exceptions_to_ignore=ApiException,
+        lambda: corev1.read_namespaced_pod(name, namespace),
+        lambda pod: pod.status.phase == "Running",
+        sleep_time=5,
+        timeout=240,
+        exceptions_to_ignore=ApiException,
     ):
+
         pod = corev1.read_namespaced_pod(name, namespace)
         raise Exception("Pod never got into Running state: {}".format(pod))
     print("Pod is running")
@@ -265,7 +266,7 @@ def prepare_and_run_test(args: argparse.Namespace, dev_config: DevConfig) -> Non
 
     # stream all of the pod output as the pod is running
     for line in corev1.read_namespaced_pod_log(
-            TEST_POD_NAME, dev_config.namespace, follow=True, _preload_content=False
+        TEST_POD_NAME, dev_config.namespace, follow=True, _preload_content=False
     ).stream():
         print(line.decode("utf-8").rstrip())
 
@@ -279,11 +280,11 @@ def main() -> int:
 
     corev1 = client.CoreV1Api()
     if not k8s_conditions.wait(
-            lambda: corev1.read_namespaced_pod(TEST_POD_NAME, dev_config.namespace),
-            lambda pod: pod.status.phase == "Succeeded",
-            sleep_time=5,
-            timeout=60,
-            exceptions_to_ignore=ApiException,
+        lambda: corev1.read_namespaced_pod(TEST_POD_NAME, dev_config.namespace),
+        lambda pod: pod.status.phase == "Succeeded",
+        sleep_time=5,
+        timeout=60,
+        exceptions_to_ignore=ApiException,
     ):
         return 1
     _delete_test_environment(args.config_file)

--- a/scripts/dev/get_e2e_env_vars.py
+++ b/scripts/dev/get_e2e_env_vars.py
@@ -29,8 +29,8 @@ def _get_e2e_test_envs(dev_config: DevConfig) -> Dict[str, str]:
         "READINESS_PROBE_IMAGE": f"{dev_config.repo_url}/{dev_config.readiness_probe_image}",
         "PERFORM_CLEANUP": "true" if cleanup else "false",
         "WATCH_NAMESPACE": dev_config.namespace,
-        "MONGODB_IMAGE": "mongo",
-        "MONGODB_REPO_URL": "docker.io",
+        "MONGODB_IMAGE": dev_config.mongodb_image_name,
+        "MONGODB_REPO_URL": dev_config.mongodb_image_repo_url,
         "HELM_CHART_PATH": os.path.abspath("./helm-charts/charts/community-operator"),
     }
 

--- a/test/e2e/replica_set_mongod_config/replica_set_mongod_config_test.go
+++ b/test/e2e/replica_set_mongod_config/replica_set_mongod_config_test.go
@@ -9,7 +9,7 @@ import (
 
 	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
 	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
-	setup "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
 	"github.com/stretchr/objx"
 )
 

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -157,6 +157,9 @@ func getHelmArgs(testConfig TestConfig, watchNamespace string, resourceName stri
 		helmArgs["agent.version"] = agentVersion
 		helmArgs["agent.name"] = agentName
 
+		helmArgs["mongodb.name"] = testConfig.MongoDBImage
+		helmArgs["mongodb.repo"] = testConfig.MongoDBRepoUrl
+
 		helmArgs["registry.versionUpgradeHook"] = versionUpgradeHookRegistry
 		helmArgs["registry.operator"] = operatorRegistry
 		helmArgs["registry.agent"] = agentRegistry

--- a/test/e2e/setup/test_config.go
+++ b/test/e2e/setup/test_config.go
@@ -26,6 +26,8 @@ type TestConfig struct {
 	AgentImage              string
 	ReadinessProbeImage     string
 	HelmChartPath           string
+	MongoDBImage            string
+	MongoDBRepoUrl          string
 }
 
 func LoadTestConfigFromEnv() TestConfig {
@@ -34,6 +36,8 @@ func LoadTestConfigFromEnv() TestConfig {
 		CertManagerNamespace:    envvar.GetEnvOrDefault(testCertManagerNamespaceEnvName, "cert-manager"),
 		CertManagerVersion:      envvar.GetEnvOrDefault(testCertManagerVersionEnvName, "v1.5.3"),
 		OperatorImage:           envvar.GetEnvOrDefault(operatorImageEnvName, "quay.io/mongodb/community-operator-dev:latest"),
+		MongoDBImage:            envvar.GetEnvOrDefault(construct.MongodbName, "mongo"),
+		MongoDBRepoUrl:          envvar.GetEnvOrDefault(construct.MongodbRepoUrl, "docker.io"),
 		VersionUpgradeHookImage: envvar.GetEnvOrDefault(construct.VersionUpgradeHookImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
 		AgentImage:              envvar.GetEnvOrDefault(construct.AgentImageEnv, "quay.io/mongodb/mongodb-agent:10.29.0.6830-1"), // TODO: better way to decide default agent image.
 		ClusterWide:             envvar.ReadBool(clusterWideEnvName),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


### How to test with your own e2e test run
- update your community `~/.community-operator-dev/config.json` with `mongodb_image_repo_url` and `mongodb_image_name`
```
{
  "namespace": "mongodb",
...
  "mongodb_image_name": "mongodb-enterprise-database",
  "mongodb_image_repo_url": "quay.io/mongodb",
  "e2e_image": "community-e2e",
...
}
```
- verify that these are sourced in our helping scripts:
```
mongodb-kubernetes-operator ❯ python scripts/dev/get_e2e_env_vars.py  | rg MONGODB_
export MONGODB_IMAGE=mongodb-enterprise-database
export MONGODB_REPO_URL=quay.io/mongodb
```
- run an e2e test which should use your local `~/.community-operator-dev/config.json` if not otherwise defined
```
make e2e-k8s test=feature_compatibility_version
```

- verify that the updated repo image is used in the sts
```
❯ k get sts mdb0 -oyaml | rg image | rg enter
        image: quay.io/mongodb/mongodb-enterprise-database:4.2.23
```
