### PR TITLE
remove panic of missing health status.json

### DIFF
--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -51,7 +51,7 @@ func isPodReady(conf config.Config) (bool, error) {
 	healthStatus, err := parseHealthStatus(conf.HealthStatusReader)
 	if err != nil {
 		logger.Errorf("There was problem parsing health status file: %s", err)
-		return false, err
+		return false, nil
 	}
 
 	// The 'statuses' file can be empty only for OM Agents


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

## Reason
We panic on purpose on errors to have the information in the pod description.

But we always panic due to missing the health status file, since the file will can be missing during early of the pod startup. Making this a red herring in the describe.


```
│   Warning  Unhealthy  15m   kubelet            Readiness probe failed: panic: open /var/log/mongodb-mms-automation/agent-health-status.json: no such file │
│  or directory                                                                                                                                             │
│                                                                                                                                                           │
│ goroutine 1 [running]:                                                                                                                                    │
│ main.main()                                                                                                                                               │
│            /build/main.go:217 +0x19a                                                                                                                      │
│   Warning  Unhealthy  12m (x10 over 15m)  kubelet  Readiness probe failed:
```