### PR TITLE
Fixed possibility of mutating passed service ports in service.Merge

### DIFF
--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -73,6 +73,10 @@ func Merge(dest corev1.Service, source corev1.Service) corev1.Service {
 		dest.ObjectMeta.Labels[k] = v
 	}
 
+	for k, v := range source.Spec.Selector {
+		dest.Spec.Selector[k] = v
+	}
+
 	cachedNodePorts := map[int32]int32{}
 	for _, port := range dest.Spec.Ports {
 		cachedNodePorts[port.Port] = port.NodePort

--- a/pkg/kube/service/service.go
+++ b/pkg/kube/service/service.go
@@ -73,9 +73,9 @@ func Merge(dest corev1.Service, source corev1.Service) corev1.Service {
 		dest.ObjectMeta.Labels[k] = v
 	}
 
-	var cachedNodePorts []int32
-	for _, nodePort := range dest.Spec.Ports {
-		cachedNodePorts = append(cachedNodePorts, nodePort.NodePort)
+	cachedNodePorts := map[int32]int32{}
+	for _, port := range dest.Spec.Ports {
+		cachedNodePorts[port.Port] = port.NodePort
 	}
 
 	if len(source.Spec.Ports) > 0 {
@@ -83,10 +83,10 @@ func Merge(dest corev1.Service, source corev1.Service) corev1.Service {
 		copy(portCopy, source.Spec.Ports)
 		dest.Spec.Ports = portCopy
 
-		for i, cachedNodePort := range cachedNodePorts {
+		for i := range dest.Spec.Ports {
 			// Source might not specify NodePort and we shouldn't override existing NodePort value
-			if source.Spec.Ports[i].NodePort == 0 {
-				dest.Spec.Ports[i].NodePort = cachedNodePort
+			if dest.Spec.Ports[i].NodePort == 0 {
+				dest.Spec.Ports[i].NodePort = cachedNodePorts[dest.Spec.Ports[i].Port]
 			}
 		}
 	}

--- a/pkg/util/merge/merge_service_spec.go
+++ b/pkg/util/merge/merge_service_spec.go
@@ -5,13 +5,70 @@ import (
 )
 
 // ServiceSpec merges two ServiceSpecs together.
-// The implementation does not override:
-// - labels/selectors
-// - cluster IPs
+// The implementation merges Selector instead of overriding it.
 func ServiceSpec(defaultSpec, overrideSpec corev1.ServiceSpec) corev1.ServiceSpec {
-	mergedSpec := overrideSpec
+	mergedSpec := defaultSpec
 	mergedSpec.Selector = StringToStringMap(defaultSpec.Selector, overrideSpec.Selector)
-	mergedSpec.ClusterIPs = defaultSpec.ClusterIPs
-	mergedSpec.ClusterIP = defaultSpec.ClusterIP
+
+	if len(overrideSpec.Ports) != 0 {
+		mergedSpec.Ports = overrideSpec.Ports
+	}
+
+	if len(overrideSpec.Type) != 0 {
+		mergedSpec.Type = overrideSpec.Type
+	}
+
+	if len(overrideSpec.LoadBalancerIP) != 0 {
+		mergedSpec.LoadBalancerIP = overrideSpec.LoadBalancerIP
+	}
+
+	if overrideSpec.LoadBalancerClass != nil {
+		mergedSpec.LoadBalancerClass = overrideSpec.LoadBalancerClass
+	}
+
+	if len(overrideSpec.ExternalName) != 0 {
+		mergedSpec.ExternalName = overrideSpec.ExternalName
+	}
+
+	if len(overrideSpec.ExternalTrafficPolicy) != 0 {
+		mergedSpec.ExternalTrafficPolicy = overrideSpec.ExternalTrafficPolicy
+	}
+
+	if overrideSpec.InternalTrafficPolicy != nil {
+		mergedSpec.InternalTrafficPolicy = overrideSpec.InternalTrafficPolicy
+	}
+
+	if overrideSpec.PublishNotReadyAddresses {
+		mergedSpec.PublishNotReadyAddresses = overrideSpec.PublishNotReadyAddresses
+	}
+
+	if overrideSpec.HealthCheckNodePort != 0 {
+		mergedSpec.HealthCheckNodePort = overrideSpec.HealthCheckNodePort
+	}
+
+	if len(overrideSpec.LoadBalancerSourceRanges) != 0 {
+		mergedSpec.LoadBalancerSourceRanges = overrideSpec.LoadBalancerSourceRanges
+	}
+
+	if len(overrideSpec.ExternalIPs) != 0 {
+		mergedSpec.ExternalIPs = overrideSpec.ExternalIPs
+	}
+
+	if overrideSpec.SessionAffinityConfig != nil {
+		mergedSpec.SessionAffinityConfig = overrideSpec.SessionAffinityConfig
+	}
+
+	if len(overrideSpec.SessionAffinity) != 0 {
+		mergedSpec.SessionAffinity = overrideSpec.SessionAffinity
+	}
+
+	if len(overrideSpec.ClusterIP) != 0 {
+		mergedSpec.ClusterIP = overrideSpec.ClusterIP
+	}
+
+	if len(overrideSpec.ClusterIPs) != 0 {
+		mergedSpec.ClusterIPs = overrideSpec.ClusterIPs
+	}
+
 	return mergedSpec
 }

--- a/pkg/util/merge/merge_test.go
+++ b/pkg/util/merge/merge_test.go
@@ -73,7 +73,7 @@ func TestMergeServices(t *testing.T) {
 				original: corev1.ServiceSpec{},
 				override: corev1.ServiceSpec{
 					Type:                     "LoadBalancer",
-					ExternalName:             "",
+					ExternalName:             "externalName",
 					ExternalTrafficPolicy:    "some-non-existing-policy",
 					HealthCheckNodePort:      123,
 					PublishNotReadyAddresses: true,
@@ -81,7 +81,7 @@ func TestMergeServices(t *testing.T) {
 			},
 			want: corev1.ServiceSpec{
 				Type:                     "LoadBalancer",
-				ExternalName:             "",
+				ExternalName:             "externalName",
 				ExternalTrafficPolicy:    "some-non-existing-policy",
 				HealthCheckNodePort:      123,
 				PublishNotReadyAddresses: true,
@@ -101,25 +101,11 @@ func TestMergeServices(t *testing.T) {
 				Selector: map[string]string{"test1": "true", "test2": "true"},
 			},
 		},
-		{
-			name: "Do not merge Cluster IPs",
-			args: args{
-				original: corev1.ServiceSpec{
-					ClusterIP: "10.0.0.1",
-				},
-				override: corev1.ServiceSpec{
-					ClusterIP: "192.168.0.1",
-				},
-			},
-			want: corev1.ServiceSpec{
-				ClusterIP: "10.0.0.1",
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ServiceSpec(tt.args.original, tt.args.override); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MergeStringSlices() = %v, want %v", got, tt.want)
+				t.Errorf("%v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixed is a bug in `service.Merge` code that mutated Spec.Ports[0].NodePort in spec passed from the outside. 

`service.Merge` is unused in the community codebase, hence no tests here. 

Additionally, incorporated changes from another (closed) PR: #1229

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
