### PR TITLE
CLOUDP-164942 fix data comparison code and add tests

### DIFF
--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -188,7 +188,6 @@ func CreateOrUpdateIfNeeded(getUpdateCreator GetUpdateCreator, secret corev1.Sec
 	// Check if the secret exists
 	oldSecret, err := getUpdateCreator.GetSecret(types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace})
 	if err != nil {
-
 		if apiErrors.IsNotFound(err) {
 			return getUpdateCreator.CreateSecret(secret)
 		}

--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -183,10 +183,10 @@ func HasOwnerReferences(secret corev1.Secret, ownerRefs []metav1.OwnerReference)
 	return true
 }
 
-// CreateOrUpdateIfNeeded creates a secret if it doesn't exists, or updates it if needed.
+// CreateOrUpdateIfNeeded creates a secret if it doesn't exist, or updates it if needed.
 func CreateOrUpdateIfNeeded(getUpdateCreator GetUpdateCreator, secret corev1.Secret) error {
 	// Check if the secret exists
-	olsSecret, err := getUpdateCreator.GetSecret(types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace})
+	oldSecret, err := getUpdateCreator.GetSecret(types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace})
 	if err != nil {
 
 		if apiErrors.IsNotFound(err) {
@@ -195,7 +195,8 @@ func CreateOrUpdateIfNeeded(getUpdateCreator GetUpdateCreator, secret corev1.Sec
 		return err
 	}
 
-	if reflect.DeepEqual(secret.StringData, dataToStringData(olsSecret.Data)) {
+	// Our secret builder never sets or uses secret.stringData, so we should only rely on secret.Data
+	if reflect.DeepEqual(secret.Data, oldSecret.Data) {
 		return nil
 	}
 

--- a/pkg/kube/secret/secret_builder.go
+++ b/pkg/kube/secret/secret_builder.go
@@ -51,7 +51,7 @@ func (b *builder) SetByteData(stringData map[string][]byte) *builder {
 	b.data = newStringDataBytes
 	return b
 }
-func (b *builder) SetStringData(stringData map[string]string) *builder {
+func (b *builder) SetStringMapToData(stringData map[string]string) *builder {
 	newStringDataBytes := make(map[string][]byte, len(stringData))
 	for k, v := range stringData {
 		newStringDataBytes[k] = []byte(v)


### PR DESCRIPTION
### All Submissions:
- fixes `CreateOrUpdateIfNeeded` which was comparing `secret.StringData` with `secret.Data` by converting one to the other. This does, most of the cases, not work because our internal `builder` only sets the `secret.Data` field hence making this comparison not working if we rely on fields we have set ourselves. That is the usual case
- adding tests to verify that behaviour

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
