### PR TITLE
only add "ent" suffix if it does not exist in the version name already

### DIFF
--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -273,7 +273,9 @@ func (b *Builder) Build() (AutomationConfig, error) {
 
 	mongoDBVersion := b.mongodbVersion
 	if b.isEnterprise {
-		mongoDBVersion = mongoDBVersion + "-ent"
+		if !strings.HasSuffix(mongoDBVersion, "-ent") {
+			mongoDBVersion = mongoDBVersion + "-ent"
+		}
 	}
 
 	for i, h := range hostnames {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


In enterprise we can have image tags that already contain the `-ent` suffix. In this case we would like to be safe and support images that support `-ent` and not.