### PR TITLE
Release MongoDB Kubernetes Operator v0.8.0

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,7 +54,7 @@ spec:
           value: mongodb-community-server
         - name: MONGODB_REPO_URL
           value: docker.io/mongodb
-        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.9
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.8.0
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,11 +45,11 @@ spec:
         - name: OPERATOR_NAME
           value: mongodb-kubernetes-operator
         - name: AGENT_IMAGE
-          value: quay.io/mongodb/mongodb-agent:12.0.15.7646-1
+          value: quay.io/mongodb/mongodb-agent:12.0.21.7698-1
         - name: VERSION_UPGRADE_HOOK_IMAGE
-          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.6
+          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.7
         - name: READINESS_PROBE_IMAGE
-          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.13
+          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.14
         - name: MONGODB_IMAGE
           value: mongodb-community-server
         - name: MONGODB_REPO_URL

--- a/deploy/openshift/operator_openshift.yaml
+++ b/deploy/openshift/operator_openshift.yaml
@@ -56,7 +56,7 @@ spec:
           value: mongo
         - name: MONGODB_REPO_URL
           value: docker.io
-        image: quay.io/mongodb/mongodb-kubernetes-operator:0.7.9
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.8.0
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator
         resources:

--- a/deploy/openshift/operator_openshift.yaml
+++ b/deploy/openshift/operator_openshift.yaml
@@ -47,11 +47,11 @@ spec:
         - name: OPERATOR_NAME
           value: mongodb-kubernetes-operator
         - name: AGENT_IMAGE
-          value: quay.io/mongodb/mongodb-agent:12.0.15.7646-1
+          value: quay.io/mongodb/mongodb-agent:12.0.21.7698-1
         - name: READINESS_PROBE_IMAGE
-          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.13
+          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.14
         - name: VERSION_UPGRADE_HOOK_IMAGE
-          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.6
+          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.7
         - name: MONGODB_IMAGE
           value: mongo
         - name: MONGODB_REPO_URL

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -26,8 +26,10 @@
 
 ## Updated Image Tags
 
-
 - mongodb-kubernetes-operator:0.8.0
+- mongodb-agent:12.0.21.7698-1
+- mongodb-kubernetes-readinessprobe:1.0.14
+- mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.7
 
 _All the images can be found in:_
 

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -11,7 +11,8 @@
       - `cp config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml helm-charts/charts/community-operator-crds/templates/mongodbcommunity.mongodb.com_mongodbcommunity.yaml`
       - commit changes to the [helm-charts submodule](https://github.com/mongodb/helm-charts) and create a PR against it ([similar to this one](https://github.com/mongodb/helm-charts/pull/163)).
       - do not merge helm-charts PR until release PR is merged and the images are pushed to quay.io.
-    * Commit all changes
+      - do not commit the submodule change in the release pr of the community repository.
+    * Commit all changes (except for the submodule change)
     * Create a PR with the title `Release MongoDB Kubernetes Operator v<operator-version>` (the title must match this pattern).
     * Wait for the tests to pass and merge the PR.
       * Upon approval, all new images for this release will be built and released, and a GitHub release draft will be created.

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
   "golang-builder-image": "golang:1.20",
-  "mongodb-kubernetes-operator": "0.7.9",
+  "mongodb-kubernetes-operator": "0.8.0",
   "version-upgrade-hook": "1.0.7",
   "readiness-probe": "1.0.14",
   "mongodb-agent": {


### PR DESCRIPTION
Charts PR: https://github.com/mongodb/helm-charts/pull/224
Internal release checklist: https://docs.google.com/document/d/1tohopsobTh56toxzn2WjqbtcMXzoRUZf06btYHshkQQ/edit

## Changes since 0.7.9
git log --left-right --graph --cherry-pick --oneline origin/release-0.8.0...v0.7.9 
```
< 1c14567 Release MongoDB Kubernetes Operator v0.8.0
< 22ada53 CLOUDP-172223 daily rebuilds support for versionhook and readiness images && making both ubi based  (#1284) <--- is in release note 
< ffc7abe Upgrade to go version 1.20 (#1287)   <--- not necessary
< c9a4933 Bump github.com/stretchr/testify from 1.8.1 to 1.8.2 (#1249)  <--- not necessary
< d1f2a26 Bump github.com/imdario/mergo from 0.3.13 to 0.3.15 (#1246)  <--- not necessary
< 247672a CLOUDP-169740 Small doc correction (#1279) <--- not necessary
< 0cdc8c5 only add ent if it does not exist (#1277) <--- is in release note 
< 0948b7e CLOUDP-169740 Enable use of the EA images (#1271) <--- is in release note 
< c9f9b95 Upgrade tools and Agent version (#1275)  <--- not necessary
< 1f07f6f Member options to configure vote/tag/priority via automationConfig (#1270)  <--- not necessary
< 129f6ec (DOCSP-12369): Added warning about persistent volumes issue. (#1272)  <--- not necessary
< 4c04e60 merge pointer and value receivers to a common kind (#1205)  <--- not necessary
< 2b7f78f Add member option type for configuring (#1268)
< 64b242d CLOUDP-169740 Use the official Community Server images (#1257) <--- is in release note 
< 03e8684 Pin helm-chart to 0.7.9 release (#1260)  <--- not necessary
```

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
