### PR TITLE
align image repo and dockerfile name

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -290,7 +290,7 @@ images:
 
         output:
           - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-readiness/$(inputs.params.release_version)/ubi/Dockerfile
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: readiness-init-build-release
         task_type: docker_build
@@ -394,7 +394,7 @@ images:
 
         output:
           - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-versionhook/$(inputs.params.release_version)/ubi/Dockerfile
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: version-post-start-hook-init-build-release
         task_type: docker_build


### PR DESCRIPTION
We need to align the dockerfile name to be of the image repo name, since some scripts expect that

![Screenshot 2023-05-15 at 17 39 01](https://github.com/mongodb/mongodb-kubernetes-operator/assets/23652004/37c3392b-0603-4b20-8c88-93dfc52cdc7f)



### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
