### PR TITLE
changes to readiness - not rely on mongod health, readinessProbe is solely for the agent

### DIFF
--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -242,11 +242,8 @@ func isInReadyState(health health.Status) bool {
 			return true
 		}
 
-		timeMongoUp := time.Unix(processHealth.LastMongoUpTime, 0)
-		mongoUpThreshold := time.Now().Add(-mongodNotReadyIntervalMinutes)
-		mongoIsHealthy := timeMongoUp.After(mongoUpThreshold)
 		// The case in which the agent is too old to publish replication status is handled inside "IsReadyState"
-		return mongoIsHealthy && processHealth.IsReadyState()
+		return processHealth.IsReadyState()
 	}
 	return false
 }

--- a/cmd/readiness/readiness_test.go
+++ b/cmd/readiness/readiness_test.go
@@ -74,37 +74,6 @@ func TestNotReadyHealthFileHasNoProcesses(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNotReadyMongodIsDown(t *testing.T) {
-	t.Run("Mongod is down for 90 seconds", func(t *testing.T) {
-		ready, err := isPodReady(testConfigWithMongoUp("testdata/health-status-ok.json", time.Second*90))
-		assert.False(t, ready)
-		assert.NoError(t, err)
-	})
-	t.Run("Mongod is down for 1 hour", func(t *testing.T) {
-		ready, err := isPodReady(testConfigWithMongoUp("testdata/health-status-ok.json", time.Hour*1))
-		assert.False(t, ready)
-		assert.NoError(t, err)
-	})
-	t.Run("Mongod is down for 2 days", func(t *testing.T) {
-		ready, err := isPodReady(testConfigWithMongoUp("testdata/health-status-ok.json", time.Hour*48))
-		assert.False(t, ready)
-		assert.NoError(t, err)
-	})
-}
-
-func TestReadyMongodIsUp(t *testing.T) {
-	t.Run("Mongod is down for 30 seconds", func(t *testing.T) {
-		ready, err := isPodReady(testConfigWithMongoUp("testdata/health-status-ok.json", time.Second*30))
-		assert.True(t, ready)
-		assert.NoError(t, err)
-	})
-	t.Run("Mongod is down for 1 second", func(t *testing.T) {
-		ready, err := isPodReady(testConfigWithMongoUp("testdata/health-status-ok.json", time.Second*1))
-		assert.True(t, ready)
-		assert.NoError(t, err)
-	})
-}
-
 // TestReady verifies that the probe reports "ready" despite "WaitRsInit" stage reporting as not reached
 // (this is some bug in Automation Agent which we can work with)
 func TestReady(t *testing.T) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
