### PR TITLE
CLOUDP-189434 Using Wait Steps instead of risky Steps

### DIFF
--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -136,7 +136,12 @@ func findCurrentStep(processStatuses map[string]health.MmsDirectorStatus) *healt
 	return lastStartedStep
 }
 
-// isWaitStep return true is the Agent is currently waiting for something.
+// isWaitStep returns true is the Agent is currently waiting for something to happen.
+//
+// Most of the time, the Agent waits for an initialization by other member of the cluster. In such case,
+// holding the rollout does not improve the overall system state. Even if the probe returns true too quickly
+// the worst thing that can happen is a short service interruption, which is still better than full service outage.
+//
 // The 15 seconds explanation:
 //   - The status file is written every 10s but the Agent processes steps independently of it
 //   - In order to avoid reacting on a newly added wait Step (as they can naturally go away), we're giving the Agent

--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/readiness/config"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/readiness/headless"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/readiness/health"
-	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/contains"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -25,12 +24,9 @@ const (
 	mongodNotReadyIntervalMinutes = time.Minute * 1
 )
 
-var riskySteps []string
 var logger *zap.SugaredLogger
 
 func init() {
-	riskySteps = []string{"WaitAllRsMembersUp", "WaitRsInit", "WaitCanUpdate"}
-
 	// By default, we log to the output (convenient for tests)
 	cfg := zap.NewDevelopmentConfig()
 	log, err := cfg.Build()
@@ -45,8 +41,7 @@ func init() {
 // The logic depends on if the pod is a standard MongoDB or an AppDB one.
 // - If MongoDB: then just the 'statuses[0].IsInGoalState` field is used to learn if the Agent has reached the goal
 // - if AppDB: the 'mmsStatus[0].lastGoalVersionAchieved' field is compared with the one from mounted automation config
-// Additionally if the previous check hasn't returned 'true' the "deadlock" case is checked to make sure the Agent is
-// not waiting for the other members.
+// Additionally if the previous check hasn't returned 'true' an additional check for wait steps is being performed
 func isPodReady(conf config.Config) (bool, error) {
 	healthStatus, err := parseHealthStatus(conf.HealthStatusReader)
 	if err != nil {
@@ -55,8 +50,8 @@ func isPodReady(conf config.Config) (bool, error) {
 	}
 
 	// The 'statuses' file can be empty only for OM Agents
-	if len(healthStatus.Healthiness) == 0 && !isHeadlessMode() {
-		logger.Info("'statuses' is empty. We assume there is no automation config for the agent yet.")
+	if len(healthStatus.Statuses) == 0 && !isHeadlessMode() {
+		logger.Debug("'statuses' is empty. We assume there is no automation config for the agent yet. Returning ready.")
 		return true, nil
 	}
 
@@ -73,33 +68,35 @@ func isPodReady(conf config.Config) (bool, error) {
 	}
 
 	if inGoalState && inReadyState {
-		logger.Info("Agent has reached goal state")
+		logger.Info("The Agent has reached goal state. Returning ready.")
 		return true, nil
 	}
 
 	// Fallback logic: the agent is not in goal state and got stuck in some steps
-	if !inGoalState && hasDeadlockedSteps(healthStatus) {
+	if !inGoalState && isOnWaitingStep(healthStatus) {
+		logger.Info("The Agent is on wait Step. Returning ready.")
 		return true, nil
 	}
 
+	logger.Info("Reached the end of the check. Returning not ready.")
 	return false, nil
 }
 
-// hasDeadlockedSteps returns true if the agent is stuck on waiting for the other agents
-func hasDeadlockedSteps(health health.Status) bool {
-	currentStep := findCurrentStep(health.ProcessPlans)
+// isOnWaitingStep returns true if the agent is stuck on waiting for the other Agents or something else to happen.
+func isOnWaitingStep(health health.Status) bool {
+	currentStep := findCurrentStep(health.MmsStatus)
 	if currentStep != nil {
-		return isDeadlocked(currentStep)
+		return isWaitStep(currentStep)
 	}
 	return false
 }
 
-// findCurrentStep returns the step which seems to be run by the Agent now. The step is always in the last plan
-// (see https://github.com/10gen/ops-manager-kubernetes/pull/401#discussion_r333071555) so we iterate over all the steps
-// there and find the last step which has "Started" non nil
-// (indeed this is not the perfect logic as sometimes the agent doesn't update the 'Started' as well - see
-// 'health-status-ok.json', but seems it works for finding deadlocks still
-// noinspection GoNilness
+// findCurrentStep returns the step which the Agent is working now.
+// The algorithm (described in https://github.com/10gen/ops-manager-kubernetes/pull/401#discussion_r333071555):
+//   - Obtain the latest plan (the last one in the plans array)
+//   - Find the last step, which has Started not nil and Completed nil. The Steps are processed as a tree in a BFS fashion.
+//     The last element is very likely to be the Step the Agent is performing at the moment. There are some chances that
+//     this is a waiting step, use isWaitStep to verify this.
 func findCurrentStep(processStatuses map[string]health.MmsDirectorStatus) *health.StepStatus {
 	var currentPlan *health.PlanStatus
 	if len(processStatuses) == 0 {
@@ -111,13 +108,14 @@ func findCurrentStep(processStatuses map[string]health.MmsDirectorStatus) *healt
 		logger.Errorf("Only one process status is expected but got %d!", len(processStatuses))
 		return nil
 	}
+
 	// There is always only one process managed by the Agent - so there will be only one loop
-	for k, v := range processStatuses {
-		if len(v.Plans) == 0 {
-			logger.Errorf("The process %s doesn't contain any plans!", k)
+	for processName, processStatus := range processStatuses {
+		if len(processStatus.Plans) == 0 {
+			logger.Errorf("The process %s doesn't contain any plans!", processName)
 			return nil
 		}
-		currentPlan = v.Plans[len(v.Plans)-1]
+		currentPlan = processStatus.Plans[len(processStatus.Plans)-1]
 	}
 
 	if currentPlan.Completed != nil {
@@ -129,7 +127,7 @@ func findCurrentStep(processStatuses map[string]health.MmsDirectorStatus) *healt
 	var lastStartedStep *health.StepStatus
 	for _, m := range currentPlan.Moves {
 		for _, s := range m.Steps {
-			if s.Started != nil {
+			if s.Started != nil && s.Completed == nil {
 				lastStartedStep = s
 			}
 		}
@@ -138,12 +136,18 @@ func findCurrentStep(processStatuses map[string]health.MmsDirectorStatus) *healt
 	return lastStartedStep
 }
 
-func isDeadlocked(status *health.StepStatus) bool {
+// isWaitStep return true is the Agent is currently waiting for something.
+// The 15 seconds explanation:
+//   - The status file is written every 10s but the Agent processes steps independently of it
+//   - In order to avoid reacting on a newly added wait Step (as they can naturally go away), we're giving the Agent
+//     at least 15 sends to spend on that Step.
+//   - This hopefully prevents the Probe from flipping False to True too quickly.
+func isWaitStep(status *health.StepStatus) bool {
 	// Some logic behind 15 seconds: the health status file is dumped each 10 seconds, so we are sure that if the agent
 	// has been in the step for 10 seconds - this means it is waiting for the other hosts, and they are not available
 	fifteenSecondsAgo := time.Now().Add(time.Duration(-15) * time.Second)
-	if contains.String(riskySteps, status.Step) && status.Completed == nil && status.Started.Before(fifteenSecondsAgo) {
-		logger.Infof("Indicated a possible deadlock, status: %s, started at %s but hasn't finished "+
+	if status.IsWaitStep && status.Completed == nil && status.Started.Before(fifteenSecondsAgo) {
+		logger.Debugf("Indicated a wait Step, status: %s, started at %s but hasn't finished "+
 			"yet. Marking the probe as ready", status.Step, status.Started.Format(time.RFC3339))
 		return true
 	}
@@ -160,7 +164,7 @@ func isInGoalState(health health.Status, conf config.Config) (bool, error) {
 // performCheckOMMode does a general check if the Agent has reached the goal state - must be called when Agent is in
 // "OM mode"
 func performCheckOMMode(health health.Status) bool {
-	for _, v := range health.Healthiness {
+	for _, v := range health.Statuses {
 		logger.Debug(v)
 		if v.IsInGoalState {
 			return true
@@ -231,10 +235,10 @@ func main() {
 // isInReadyState checks the MongoDB Server state. It returns true if the mongod process is up and its state
 // is PRIMARY or SECONDARY.
 func isInReadyState(health health.Status) bool {
-	if len(health.Healthiness) == 0 {
+	if len(health.Statuses) == 0 {
 		return true
 	}
-	for _, processHealth := range health.Healthiness {
+	for _, processHealth := range health.Statuses {
 		// We know this loop should run only once, in Kubernetes there's
 		// only 1 server managed per host.
 		if !processHealth.ExpectedToBeUp {

--- a/cmd/readiness/testdata/health-status-deadlocked-waiting-for-correct-automation-credentials.json
+++ b/cmd/readiness/testdata/health-status-deadlocked-waiting-for-correct-automation-credentials.json
@@ -1,0 +1,116 @@
+{
+  "statuses": {
+    "svcprovider-cluster-config-0": {
+      "IsInGoalState": false,
+      "LastMongoUpTime": 1669378820,
+      "ExpectedToBeUp": true,
+      "ReplicationStatus": 2
+    }
+  },
+  "mmsStatus": {
+    "svcprovider-cluster-config-0": {
+      "name": "svcprovider-cluster-config-0",
+      "lastGoalVersionAchieved": -1,
+      "plans": [
+        {
+          "started": "2022-11-25T11:35:45.442597196Z",
+          "completed": null,
+          "moves": [
+            {
+              "move": "Download",
+              "moveDoc": "Download mongodb binaries",
+              "steps": [
+                {
+                  "step": "Download",
+                  "stepDoc": "Download mongodb binaries (may take a while)",
+                  "isWaitStep": false,
+                  "started": "2022-11-25T11:35:45.44261521Z",
+                  "completed": "2022-11-25T11:35:50.8280641Z",
+                  "result": "success"
+                }
+              ]
+            },
+            {
+              "move": "Start",
+              "moveDoc": "Start the process",
+              "steps": [
+                {
+                  "step": "StartFresh",
+                  "stepDoc": "Start a mongo instance  (start fresh)",
+                  "isWaitStep": false,
+                  "started": "2022-11-25T11:35:50.828139893Z",
+                  "completed": "2022-11-25T11:35:52.623601143Z",
+                  "result": "success"
+                }
+              ]
+            },
+            {
+              "move": "WaitAllRsMembersUp",
+              "moveDoc": "Wait until all members of this process' repl set are up",
+              "steps": [
+                {
+                  "step": "WaitAllRsMembersUp",
+                  "stepDoc": "Wait until all members of this process' repl set are up",
+                  "isWaitStep": true,
+                  "started": "2022-11-25T11:35:52.623699243Z",
+                  "completed": null,
+                  "result": "wait"
+                }
+              ]
+            },
+            {
+              "move": "RsInit",
+              "moveDoc": "Initialize a replica set including the current MongoDB process",
+              "steps": [
+                {
+                  "step": "RsInit",
+                  "stepDoc": "Initialize a replica set",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitFeatureCompatibilityVersionCorrect",
+              "moveDoc": "Wait for featureCompatibilityVersion to be right",
+              "steps": [
+                {
+                  "step": "WaitFeatureCompatibilityVersionCorrect",
+                  "stepDoc": "Wait for featureCompatibilityVersion to be right",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "started": "2022-11-25T11:35:53.820885768Z",
+          "completed": null,
+          "moves": [
+            {
+              "move": "WaitHasCorrectAutomationCredentials",
+              "moveDoc": "Wait for the automation user to be added (if needed)",
+              "steps": [
+                {
+                  "step": "WaitHasCorrectAutomationCredentials",
+                  "stepDoc": "Wait for the automation user to be added (if needed)",
+                  "isWaitStep": true,
+                  "started": "2022-11-25T11:35:53.820925028Z",
+                  "completed": null,
+                  "result": "wait"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "errorCode": 0,
+      "errorString": ""
+    }
+  }
+}

--- a/cmd/readiness/testdata/health-status-enterprise-upgrade-interrupted.json
+++ b/cmd/readiness/testdata/health-status-enterprise-upgrade-interrupted.json
@@ -1,0 +1,271 @@
+{
+  "statuses": {
+    "my-replica-set-0": {
+      "IsInGoalState": false,
+      "LastMongoUpTime": 1689233828,
+      "ExpectedToBeUp": true,
+      "ReplicationStatus": 2
+    }
+  },
+  "mmsStatus": {
+    "my-replica-set-0": {
+      "name": "my-replica-set-0",
+      "lastGoalVersionAchieved": 8,
+      "plans": [
+        {
+          "automationConfigVersion": 8,
+          "started": "2023-07-13T07:31:43.706340549Z",
+          "completed": null,
+          "moves": [
+            {
+              "move": "Download",
+              "moveDoc": "Download mongodb binaries",
+              "steps": [
+                {
+                  "step": "Download",
+                  "stepDoc": "Download mongodb binaries (may take a while)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:31:43.706368293Z",
+                  "completed": "2023-07-13T07:31:52.545770428Z",
+                  "result": "success"
+                }
+              ]
+            },
+            {
+              "move": "DownloadMongosh",
+              "moveDoc": "Download Mongosh",
+              "steps": [
+                {
+                  "step": "DownloadMongosh",
+                  "stepDoc": "Download mongosh (may take a while)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:31:52.545834821Z",
+                  "completed": null,
+                  "result": "error"
+                }
+              ]
+            },
+            {
+              "move": "Start",
+              "moveDoc": "Start the process",
+              "steps": [
+                {
+                  "step": "StartFresh",
+                  "stepDoc": "Start a mongo instance  (start fresh)",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitAllRsMembersUp",
+              "moveDoc": "Wait until all members of this process' repl set are up",
+              "steps": [
+                {
+                  "step": "WaitAllRsMembersUp",
+                  "stepDoc": "Wait until all members of this process' repl set are up",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "RsInit",
+              "moveDoc": "Initialize a replica set including the current MongoDB process",
+              "steps": [
+                {
+                  "step": "RsInit",
+                  "stepDoc": "Initialize a replica set",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitFeatureCompatibilityVersionCorrect",
+              "moveDoc": "Wait for featureCompatibilityVersion to be right",
+              "steps": [
+                {
+                  "step": "WaitFeatureCompatibilityVersionCorrect",
+                  "stepDoc": "Wait for featureCompatibilityVersion to be right",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "automationConfigVersion": 8,
+          "started": "2023-07-13T07:32:02.715922827Z",
+          "completed": "2023-07-13T07:32:20.938102204Z",
+          "moves": [
+            {
+              "move": "Start",
+              "moveDoc": "Start the process",
+              "steps": [
+                {
+                  "step": "StartFresh",
+                  "stepDoc": "Start a mongo instance  (start fresh)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:32:02.715947483Z",
+                  "completed": "2023-07-13T07:32:09.844613082Z",
+                  "result": "success"
+                }
+              ]
+            },
+            {
+              "move": "UpdateSymLink",
+              "moveDoc": "Update the mongosh binary symlink",
+              "steps": [
+                {
+                  "step": "UpdateSymLink",
+                  "stepDoc": "Update the mongosh binary symlink",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:32:09.844681639Z",
+                  "completed": "2023-07-13T07:32:14.893961595Z",
+                  "result": "success"
+                }
+              ]
+            },
+            {
+              "move": "WaitAllRsMembersUp",
+              "moveDoc": "Wait until all members of this process' repl set are up",
+              "steps": [
+                {
+                  "step": "WaitAllRsMembersUp",
+                  "stepDoc": "Wait until all members of this process' repl set are up",
+                  "isWaitStep": true,
+                  "started": "2023-07-13T07:32:14.894030206Z",
+                  "completed": null,
+                  "result": "wait"
+                }
+              ]
+            },
+            {
+              "move": "RsInit",
+              "moveDoc": "Initialize a replica set including the current MongoDB process",
+              "steps": [
+                {
+                  "step": "RsInit",
+                  "stepDoc": "Initialize a replica set",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitFeatureCompatibilityVersionCorrect",
+              "moveDoc": "Wait for featureCompatibilityVersion to be right",
+              "steps": [
+                {
+                  "step": "WaitFeatureCompatibilityVersionCorrect",
+                  "stepDoc": "Wait for featureCompatibilityVersion to be right",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "automationConfigVersion": 9,
+          "started": "2023-07-13T07:35:56.706945979Z",
+          "completed": null,
+          "moves": [
+            {
+              "move": "Download",
+              "moveDoc": "Download mongodb binaries",
+              "steps": [
+                {
+                  "step": "Download",
+                  "stepDoc": "Download mongodb binaries (may take a while)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:35:56.706976268Z",
+                  "completed": "2023-07-13T07:36:01.116832943Z",
+                  "result": "success"
+                }
+              ]
+            },
+            {
+              "move": "ChangeVersion",
+              "moveDoc": "Change MongoDB Version",
+              "steps": [
+                {
+                  "step": "CheckWrongVersion",
+                  "stepDoc": "Check that MongoDB version is wrong",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:36:01.11709619Z",
+                  "completed": "2023-07-13T07:36:01.11734988Z",
+                  "result": "success"
+                },
+                {
+                  "step": "CheckRsCorrect",
+                  "stepDoc": "Check that replica set configuration is correct",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:36:01.117352255Z",
+                  "completed": "2023-07-13T07:36:01.117626127Z",
+                  "result": "success"
+                },
+                {
+                  "step": "WaitCanUpdate",
+                  "stepDoc": "Wait until the update can be made",
+                  "isWaitStep": true,
+                  "started": "2023-07-13T07:36:01.117628516Z",
+                  "completed": "2023-07-13T07:36:01.117818709Z",
+                  "result": "success"
+                },
+                {
+                  "step": "DisableBalancerIfFirst",
+                  "stepDoc": "Disable the balancer (may take a while)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:36:01.117821034Z",
+                  "completed": "2023-07-13T07:36:01.18783613Z",
+                  "result": "success"
+                },
+                {
+                  "step": "Stop",
+                  "stepDoc": "Shutdown the process",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:36:01.187839391Z",
+                  "completed": null,
+                  "result": ""
+                },
+                {
+                  "step": "RemoveDbFilesIfArbiterDowngrade",
+                  "stepDoc": "Delete db files if this is an arbiter downgrade.",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                },
+                {
+                  "step": "StartWithUpgrade",
+                  "stepDoc": "Start a mongo instance  (upgrade)",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "errorCode": 0,
+      "errorString": ""
+    }
+  }
+}

--- a/cmd/readiness/testdata/health-status-error-tls.json
+++ b/cmd/readiness/testdata/health-status-error-tls.json
@@ -1,0 +1,146 @@
+{
+  "statuses": {
+    "test-tls-base-rs-require-ssl-1": {
+      "IsInGoalState": false,
+      "LastMongoUpTime": 0,
+      "ExpectedToBeUp": true,
+      "ReplicationStatus": -1
+    }
+  },
+  "mmsStatus": {
+    "test-tls-base-rs-require-ssl-1": {
+      "name": "test-tls-base-rs-require-ssl-1",
+      "lastGoalVersionAchieved": -1,
+      "plans": [
+        {
+          "automationConfigVersion": 5,
+          "started": "2023-07-13T07:01:44.951990751Z",
+          "completed": null,
+          "moves": [
+            {
+              "move": "DownloadMongosh",
+              "moveDoc": "Download Mongosh",
+              "steps": [
+                {
+                  "step": "DownloadMongosh",
+                  "stepDoc": "Download mongosh (may take a while)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:01:44.952016495Z",
+                  "completed": null,
+                  "result": "error"
+                }
+              ]
+            },
+            {
+              "move": "Start",
+              "moveDoc": "Start the process",
+              "steps": [
+                {
+                  "step": "StartFresh",
+                  "stepDoc": "Start a mongo instance  (start fresh)",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitRsInit",
+              "moveDoc": "Wait for the replica set to be initialized by another member",
+              "steps": [
+                {
+                  "step": "WaitRsInit",
+                  "stepDoc": "Wait for the replica set to be initialized by another member",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitFeatureCompatibilityVersionCorrect",
+              "moveDoc": "Wait for featureCompatibilityVersion to be right",
+              "steps": [
+                {
+                  "step": "WaitFeatureCompatibilityVersionCorrect",
+                  "stepDoc": "Wait for featureCompatibilityVersion to be right",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "automationConfigVersion": 5,
+          "started": "2023-07-13T07:01:49.72582887Z",
+          "completed": null,
+          "moves": [
+            {
+              "move": "Start",
+              "moveDoc": "Start the process",
+              "steps": [
+                {
+                  "step": "StartFresh",
+                  "stepDoc": "Start a mongo instance  (start fresh)",
+                  "isWaitStep": false,
+                  "started": "2023-07-13T07:01:49.725856903Z",
+                  "completed": null,
+                  "result": "error"
+                }
+              ]
+            },
+            {
+              "move": "UpdateSymLink",
+              "moveDoc": "Update the mongosh binary symlink",
+              "steps": [
+                {
+                  "step": "UpdateSymLink",
+                  "stepDoc": "Update the mongosh binary symlink",
+                  "isWaitStep": false,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitRsInit",
+              "moveDoc": "Wait for the replica set to be initialized by another member",
+              "steps": [
+                {
+                  "step": "WaitRsInit",
+                  "stepDoc": "Wait for the replica set to be initialized by another member",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            },
+            {
+              "move": "WaitFeatureCompatibilityVersionCorrect",
+              "moveDoc": "Wait for featureCompatibilityVersion to be right",
+              "steps": [
+                {
+                  "step": "WaitFeatureCompatibilityVersionCorrect",
+                  "stepDoc": "Wait for featureCompatibilityVersion to be right",
+                  "isWaitStep": true,
+                  "started": null,
+                  "completed": null,
+                  "result": ""
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "errorCode": 0,
+      "errorString": "\u003ctest-tls-base-rs-require-ssl-1\u003e [07:03:13.893] Plan execution failed on step StartFresh as part of move Start : \u003ctest-tls-base-rs-require-ssl-1\u003e [07:03:13.893] Failed to apply action. Result = \u003cnil\u003e : \u003ctest-tls-base-rs-require-ssl-1\u003e [07:03:13.893] Error starting mongod : \u003ctest-tls-base-rs-require-ssl-1\u003e [07:03:13.893] Error running start command. cmd=[Args=[/var/lib/mongodb-mms-automation/mongodb-linux-x86_64-6.0.5-ent/bin/mongod -f /data/automation-mongod.conf]], stip=[args={\"net\":{\"bindIp\":\"0.0.0.0\",\"port\":27017,\"tls\":{\"CAFile\":\"/mongodb-automation/tls/ca/ca-pem\",\"FIPSMode\":true,\"allowConnectionsWithoutCertificates\":true,\"certificateKeyFile\":\"/mongodb-automation/tls/ZQHTF7GVI23UNJD4IHNM23NCX7Z6PUCB3PPAWCJ7TO3NB2WIHRDA\",\"mode\":\"requireTLS\"}},\"replication\":{\"replSetName\":\"test-tls-base-rs-require-ssl\"},\"storage\":{\"dbPath\":\"/data\"},\"systemLog\":{\"destination\":\"file\",\"path\":\"/var/log/mongodb-mms-automation/mongodb.log\"}}[],confPath=/data/automation-mongod.conf,version=6.0.5-ent-c9a99c120371d4d4c52cbb15dac34a36ce8d3b1d(enterprise),isKmipRotateMasterKey=false,useOldConfFile=false]\n\t,\nConfig Used:\n# THIS FILE IS MAINTAINED BY https://cloud-qa.mongodb.com . DO NOT MODIFY AS IT WILL BE OVERWRITTEN.\n# To make changes to your MongoDB deployment, please visit https://cloud-qa.mongodb.com . Your Group ID is 64a3eb7b7b02b627c635ea2b .\nnet:\n  bindIp: 0.0.0.0\n  port: 27017\n  tls:\n    CAFile: /mongodb-automation/tls/ca/ca-pem\n    FIPSMode: true\n    allowConnectionsWithoutCertificates: true\n    certificateKeyFile: /mongodb-automation/tls/ZQHTF7GVI23UNJD4IHNM23NCX7Z6PUCB3PPAWCJ7TO3NB2WIHRDA\n    mode: requireTLS\nprocessManagement:\n  fork: \"true\"\nreplication:\n  replSetName: test-tls-base-rs-require-ssl\nstorage:\n  dbPath: /data\nsystemLog:\n  destination: file\n  path: /var/log/mongodb-mms-automation/mongodb.log\n\t- Output (stdout/stderr): \nabout to fork child process, waiting until server is ready for connections.\nforked process: 823\nERROR: child process failed, exited with 1\nTo see additional information in this output, start without the \"--fork\" option.\n\n\t- Mongo Logs: \n{\"t\":{\"$date\":\"2023-07-13T07:03:13.883+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":23172,   \"ctx\":\"-\",\"msg\":\"FIPS 140-2 mode activated\"}\n{\"t\":{\"$date\":\"2023-07-13T07:03:13.884+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":4915701, \"ctx\":\"main\",\"msg\":\"Initialized wire specification\",\"attr\":{\"spec\":{\"incomingExternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"incomingInternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"outgoing\":{\"minWireVersion\":6,\"maxWireVersion\":17},\"isInternalClient\":true}}}\n{\"t\":{\"$date\":\"2023-07-13T07:03:13.888+00:00\"},\"s\":\"E\",  \"c\":\"NETWORK\",  \"id\":23248,   \"ctx\":\"main\",\"msg\":\"Cannot read certificate file\",\"attr\":{\"keyFile\":\"/mongodb-automation/tls/ZQHTF7GVI23UNJD4IHNM23NCX7Z6PUCB3PPAWCJ7TO3NB2WIHRDA\",\"error\":\"error:02001002:system library:fopen:No such file or directory\"}}\n{\"t\":{\"$date\":\"2023-07-13T07:03:13.888+00:00\"},\"s\":\"F\",  \"c\":\"CONTROL\",  \"id\":20574,   \"ctx\":\"main\",\"msg\":\"Error during global initialization\",\"attr\":{\"error\":{\"code\":140,\"codeName\":\"InvalidSSLConfiguration\",\"errmsg\":\"Can not set up PEM key file.\"}}}\n : exit status 1"
+    }
+  }
+}

--- a/pkg/readiness/headless/headless.go
+++ b/pkg/readiness/headless/headless.go
@@ -63,7 +63,7 @@ func PerformCheckHeadlessMode(health health.Status, conf config.Config) (bool, e
 
 // readCurrentAgentInfo returns the version the Agent has reached and the rs member name
 func readCurrentAgentInfo(health health.Status, targetVersion int64) int64 {
-	for _, v := range health.ProcessPlans {
+	for _, v := range health.MmsStatus {
 		zap.S().Debugf("Automation Config version: %d, Agent last version: %d", targetVersion, v.LastGoalStateClusterConfigVersion)
 		return v.LastGoalStateClusterConfigVersion
 	}
@@ -71,7 +71,7 @@ func readCurrentAgentInfo(health health.Status, targetVersion int64) int64 {
 	// from the Automation Config - the Agent just doesn't write the 'mmsStatus' at all so there is no indication of
 	// the version it has achieved (though health file contains 'IsInGoalState=true')
 	// Let's return the desired version in case if the Agent is in goal state and no plans exist in the health file
-	for _, v := range health.Healthiness {
+	for _, v := range health.Statuses {
 		if v.IsInGoalState {
 			return targetVersion
 		}

--- a/pkg/readiness/headless/headless_test.go
+++ b/pkg/readiness/headless/headless_test.go
@@ -19,7 +19,7 @@ func TestPerformCheckHeadlessMode(t *testing.T) {
 
 	c.ClientSet = fake.NewSimpleClientset(testdata.TestPod(c.Namespace, c.Hostname), testdata.TestSecret(c.Namespace, c.AutomationConfigSecretName, 11))
 	status := health.Status{
-		ProcessPlans: map[string]health.MmsDirectorStatus{c.Hostname: {
+		MmsStatus: map[string]health.MmsDirectorStatus{c.Hostname: {
 			LastGoalStateClusterConfigVersion: 10,
 		}},
 	}

--- a/pkg/readiness/health/health.go
+++ b/pkg/readiness/health/health.go
@@ -22,18 +22,18 @@ const (
 )
 
 type Status struct {
-	Healthiness  map[string]processHealth     `json:"statuses"`
-	ProcessPlans map[string]MmsDirectorStatus `json:"mmsStatus"`
+	Statuses  map[string]processStatus     `json:"statuses"`
+	MmsStatus map[string]MmsDirectorStatus `json:"mmsStatus"`
 }
 
-type processHealth struct {
+type processStatus struct {
 	IsInGoalState   bool               `json:"IsInGoalState"`
 	LastMongoUpTime int64              `json:"LastMongoUpTime"`
 	ExpectedToBeUp  bool               `json:"ExpectedToBeUp"`
 	ReplicaStatus   *replicationStatus `json:"ReplicationStatus"`
 }
 
-func (h processHealth) String() string {
+func (h processStatus) String() string {
 	return fmt.Sprintf("ExpectedToBeUp: %t, IsInGoalState: %t, LastMongoUpTime: %v", h.ExpectedToBeUp,
 		h.IsInGoalState, time.Unix(h.LastMongoUpTime, 0))
 }
@@ -55,17 +55,19 @@ type MoveStatus struct {
 	Steps []*StepStatus `json:"steps"`
 }
 type StepStatus struct {
-	Step      string     `json:"step"`
-	Started   *time.Time `json:"started"`
-	Completed *time.Time `json:"completed"`
-	Result    string     `json:"result"`
+	Step       string     `json:"step"`
+	StepDoc    string     `json:"stepDoc"`
+	IsWaitStep bool       `json:"isWaitStep"`
+	Started    *time.Time `json:"started"`
+	Completed  *time.Time `json:"completed"`
+	Result     string     `json:"result"`
 }
 
 // IsReadyState will return true, meaning a *ready state* in the sense that this Process can
 // accept read operations.
 // It returns true if the managed process is mongos or standalone (replicationStatusUndefined)
 // or if the agent doesn't publish the replica status (older agents)
-func (h processHealth) IsReadyState() bool {
+func (h processStatus) IsReadyState() bool {
 	if h.ReplicaStatus == nil {
 		return true
 	}

--- a/pkg/readiness/health/health_test.go
+++ b/pkg/readiness/health/health_test.go
@@ -12,7 +12,7 @@ func TestIsReadyStateNotPrimaryNorSecondary(t *testing.T) {
 	status := []replicationStatus{replicationStatusUndefined, replicationStatusPrimary, replicationStatusSecondary, replicationStatusArbiter}
 
 	for i := range status {
-		h := processHealth{ReplicaStatus: &status[i]}
+		h := processStatus{ReplicaStatus: &status[i]}
 		assert.True(t, h.IsReadyState())
 	}
 }
@@ -26,7 +26,7 @@ func TestIsNotReady(t *testing.T) {
 	}
 
 	for i := range status {
-		h := processHealth{ReplicaStatus: &status[i]}
+		h := processStatus{ReplicaStatus: &status[i]}
 		assert.False(t, h.IsReadyState())
 	}
 }


### PR DESCRIPTION
## Summary

This Pull Request changes the core deadlock detection algorithm and replaces it with detecting Wait Steps (the steps with `isWaitStep: true`. This loosens up the way the Probe behaves and makes it less restrictive. 

The end user impact is completely opposite now. In the worst case scenario, we will report the database to be ready (instead of not ready and blocking the rollout as we've seen before). The end user experience is much better as it may experience a short outage instead of full database blackout. 

This Pull Request also introduces name refactoring and aligns it with the field names in JSON file. This way, it's less confusing when discussing this with a wider Team.

## Technical details

A lot of this design is related to this conversation: https://github.com/mongodb/mongodb-kubernetes-operator/pull/1332

## Testing results in both Community and EA

* All tests against Community seem to be fine. I can successfully delete any number of Pods (being careful not to lose quorum, which causes a short outage - until a new quorum is established - see RAFT algorithm)
* All tests against EA seem to be fine. When introducing AutomationConfig changes and deleting Pods during the Rolling Update, it's easy to lose quorum. But even then, the system recovers in a few seconds. 

All tests against the Enterprise are successful [link](https://github.com/10gen/ops-manager-kubernetes/pull/2985).