### PR TITLE
CLOUDP-82639: ARM support

### DIFF
--- a/.action_templates/e2e-fork-template.yaml
+++ b/.action_templates/e2e-fork-template.yaml
@@ -9,6 +9,7 @@ jobs:
     - template: checkout-fork
     - template: setup-and-install-python
     - template: quay-login
+    - template: set-up-qemu
     - template: build-and-push-development-images
   - template: tests
     steps:

--- a/.action_templates/e2e-pr-template.yaml
+++ b/.action_templates/e2e-pr-template.yaml
@@ -9,6 +9,7 @@ jobs:
     - template: checkout
     - template: setup-and-install-python
     - template: quay-login
+    - template: set-up-qemu
     - template: build-and-push-development-images
   - template: tests
     steps:

--- a/.action_templates/e2e-single-template.yaml
+++ b/.action_templates/e2e-single-template.yaml
@@ -6,6 +6,7 @@ jobs:
     - template: checkout
     - template: setup-and-install-python
     - template: quay-login
+    - template: set-up-qemu
     - template: build-and-push-development-images
   - template: single-test
     steps:

--- a/.action_templates/steps/build-and-push-development-images.yaml
+++ b/.action_templates/steps/build-and-push-development-images.yaml
@@ -1,6 +1,6 @@
 - name: Build and Push Images
   run: |
-    python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false
+    python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
   env:
     MONGODB_COMMUNITY_CONFIG: "${{ github.workspace }}/scripts/ci/config.json"
     version_id: "${{ github.run_id }}"

--- a/.action_templates/steps/set-up-qemu.yaml
+++ b/.action_templates/steps/set-up-qemu.yaml
@@ -1,0 +1,2 @@
+- name: Set up QEMU
+  uses: docker/setup-qemu-action@v2

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -70,6 +70,9 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+    # template: .action_templates/steps/set-up-qemu.yaml
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -76,7 +76,7 @@ jobs:
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
-        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false
+        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
       env:
         MONGODB_COMMUNITY_CONFIG: ${{ github.workspace }}/scripts/ci/config.json
         version_id: ${{ github.run_id }}

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -72,6 +72,9 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+    # template: .action_templates/steps/set-up-qemu.yaml
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -78,7 +78,7 @@ jobs:
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
-        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false
+        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
       env:
         MONGODB_COMMUNITY_CONFIG: ${{ github.workspace }}/scripts/ci/config.json
         version_id: ${{ github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,7 @@ jobs:
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
-        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false
+        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
       env:
         MONGODB_COMMUNITY_CONFIG: ${{ github.workspace }}/scripts/ci/config.json
         version_id: ${{ github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,9 @@ jobs:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+    # template: .action_templates/steps/set-up-qemu.yaml
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ NAMESPACE := $(shell jq -r .namespace < $(MONGODB_COMMUNITY_CONFIG))
 UPGRADE_HOOK_IMG := $(shell jq -r .version_upgrade_hook_image < $(MONGODB_COMMUNITY_CONFIG))
 READINESS_PROBE_IMG := $(shell jq -r .readiness_probe_image < $(MONGODB_COMMUNITY_CONFIG))
 REGISTRY := $(shell jq -r .repo_url < $(MONGODB_COMMUNITY_CONFIG))
-AGENT_IMAGE_NAME := $(shell jq -r .agent_image_ubuntu < $(MONGODB_COMMUNITY_CONFIG))
+AGENT_IMAGE_NAME := $(shell jq -r .agent_image_ubi < $(MONGODB_COMMUNITY_CONFIG))
 
 HELM_CHART ?= ./helm-charts/charts/community-operator
 
@@ -150,7 +150,7 @@ e2e-image: ## Build and push e2e test image
 	python pipeline.py --image-name e2e
 
 agent-image: ## Build and push agent image
-	python pipeline.py --image-name agent-ubuntu
+	# python pipeline.py --image-name agent-ubuntu
 	python pipeline.py --image-name agent-ubi
 
 readiness-probe-image: ## Build and push readiness probe image

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ e2e-image: ## Build and push e2e test image
 	python pipeline.py --image-name e2e
 
 agent-image: ## Build and push agent image
-	# python pipeline.py --image-name agent-ubuntu
+	python pipeline.py --image-name agent-ubuntu
 	python pipeline.py --image-name agent-ubi
 
 readiness-probe-image: ## Build and push readiness probe image

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
         - name: MONGODB_IMAGE
           value: mongodb-community-server
         - name: MONGODB_REPO_URL
-          value: docker.io/mongodb
+          value: quay.io/mongodb
         image: quay.io/mongodb/mongodb-kubernetes-operator:0.8.2
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator

--- a/deploy/openshift/operator_openshift.yaml
+++ b/deploy/openshift/operator_openshift.yaml
@@ -55,7 +55,7 @@ spec:
         - name: MONGODB_IMAGE
           value: mongo
         - name: MONGODB_REPO_URL
-          value: docker.io
+          value: quay.io
         image: quay.io/mongodb/mongodb-kubernetes-operator:0.8.2
         imagePullPolicy: Always
         name: mongodb-kubernetes-operator

--- a/docs/install-upgrade.md
+++ b/docs/install-upgrade.md
@@ -179,9 +179,9 @@ for MongoDB Docker images:
    - MongoDB tests, maintains, and supports them.
 
    | Environment Variable | Description | Default                      |
-   |----|------------------------------|----|
+   |----|------------------------------|------------------------------|
    | `MONGODB_IMAGE` | From the `MONGODB_REPO_URL`, absolute path to the MongoDB Docker image that you want to deploy. | `"mongodb-community-server"` |
-   | `MONGODB_REPO_URL` | URL of the container registry that contains the MongoDB Docker image that you want to deploy. | `"docker.io/mongodb"`        |
+   | `MONGODB_REPO_URL` | URL of the container registry that contains the MongoDB Docker image that you want to deploy. | `"quay.io/mongodb"`          |
 
    ```yaml
        spec:

--- a/inventories/e2e-inventory.yaml
+++ b/inventories/e2e-inventory.yaml
@@ -19,12 +19,12 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
 
       - name: e2e-build
         task_type: docker_build
 
-        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
 
         labels:
           quay.expires-after: 48h
@@ -52,12 +52,12 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-amd64
+          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
 
       - name: e2e-build
         task_type: docker_build
 
-        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-amd64
+        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
 
         labels:
           quay.expires-after: 48h

--- a/inventories/e2e-inventory.yaml
+++ b/inventories/e2e-inventory.yaml
@@ -2,7 +2,40 @@ vars:
   registry: <registry>
 
 images:
-  - name: e2e
+  - name: e2e-arm64
+    vars:
+      context: .
+      template_context: scripts/dev/templates
+    inputs:
+      - e2e_image
+    platform: linux/arm64
+    stages:
+      - name: e2e-template
+        task_type: dockerfile_template
+        distro: e2e
+
+        inputs:
+          - builder
+          - base_image
+
+        output:
+          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+
+      - name: e2e-build
+        task_type: docker_build
+
+        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
+            tag: $(inputs.params.version_id)-arm64
+          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
+            tag: latest-arm64
+
+  - name: e2e-amd64
     vars:
       context: .
       template_context: scripts/dev/templates
@@ -19,19 +52,19 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
+          - dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-amd64
 
       - name: e2e-build
         task_type: docker_build
 
-        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)
+        dockerfile: scripts/dev/templates/Dockerfile.ubi-$(inputs.params.version_id)-amd64
 
         labels:
           quay.expires-after: 48h
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
-            tag: $(inputs.params.version_id)
+            tag: $(inputs.params.version_id)-amd64
           - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
-            tag: latest
+            tag: latest-amd64
 

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -2,7 +2,7 @@ vars:
   registry: <registry>
 
 images:
-  - name: operator-ubi
+  - name: operator-ubi-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/operator
@@ -30,7 +30,7 @@ images:
 
         output:
         - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
-          tag: $(inputs.params.version_id)-context
+          tag: $(inputs.params.version_id)-context-amd64
 
       - name: operator-template-dev
         task_type: dockerfile_template
@@ -40,27 +40,27 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-amd64
 
       - name: operator-build-dev
         task_type: docker_build
         tags: ["ubi"]
-        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-amd64
 
         inputs:
           - version_id
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image_dev):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image_dev):$(inputs.params.version_id)-context-amd64
 
         labels:
           quay.expires-after: 48h
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
-            tag: $(inputs.params.version_id)
+            tag: $(inputs.params.version_id)-amd64
           - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
-            tag: latest
+            tag: latest-amd64
 
 #
 # Release build stages
@@ -83,7 +83,7 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
-            tag: $(inputs.params.release_version)-context
+            tag: $(inputs.params.release_version)-context-amd64
 
       - name: operator-template-release
         task_type: dockerfile_template
@@ -94,8 +94,8 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-amd64
+#          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: operator-build-release
         task_type: docker_build
@@ -104,14 +104,128 @@ images:
         inputs:
           - release_version
 
-        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-amd64
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context-amd64
 
         labels:
           quay.expires-after: Never
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
-            tag: $(inputs.params.release_version)
+            tag: $(inputs.params.release_version)-amd64
+
+  - name: operator-ubi-arm64
+    vars:
+      context: .
+      template_context: scripts/dev/templates/operator
+
+    inputs:
+      - operator_image
+      - operator_image_dev
+
+    platform: linux/arm64
+
+    stages:
+      #
+      # Dev build stages
+      #
+      - name: operator-builder-dev
+        task_type: docker_build
+        tags: [ "ubi" ]
+        dockerfile: scripts/dev/templates/operator/Dockerfile.builder
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+            tag: $(inputs.params.version_id)-context-arm64
+
+      - name: operator-template-dev
+        task_type: dockerfile_template
+        tags: [ "ubi" ]
+        template_file_extension: operator
+        inputs:
+          - base_image
+
+        output:
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-arm64
+
+      - name: operator-build-dev
+        task_type: docker_build
+        tags: [ "ubi" ]
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-arm64
+
+        inputs:
+          - version_id
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image_dev):$(inputs.params.version_id)-context-arm64
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+            tag: $(inputs.params.version_id)-arm64
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+            tag: latest-arm64
+
+      #
+      # Release build stages
+      #
+      - name: operator-builder-release
+        task_type: docker_build
+        tags: [ "ubi", "release" ]
+
+        inputs:
+          - builder_image
+          - release_version
+
+        dockerfile: scripts/dev/templates/operator/Dockerfile.builder
+
+        labels:
+          quay.expires-after: Never
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+            tag: $(inputs.params.release_version)-context-arm64
+
+      - name: operator-template-release
+        task_type: dockerfile_template
+        tags: [ "ubi", "release" ]
+        template_file_extension: operator
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-arm64
+#          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: operator-build-release
+        task_type: docker_build
+        tags: [ "ubi", "release" ]
+
+        inputs:
+          - release_version
+
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-arm64
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context-arm64
+
+        labels:
+          quay.expires-after: Never
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+            tag: $(inputs.params.release_version)-arm64

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -95,7 +95,7 @@ images:
 
         output:
           - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-amd64
-#          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: operator-build-release
         task_type: docker_build
@@ -209,7 +209,7 @@ images:
 
         output:
           - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-arm64
-#          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: operator-build-release
         task_type: docker_build

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -40,12 +40,12 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-amd64
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)
 
       - name: operator-build-dev
         task_type: docker_build
         tags: ["ubi"]
-        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-amd64
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)
 
         inputs:
           - version_id
@@ -94,7 +94,7 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-amd64
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: operator-build-release
@@ -104,7 +104,7 @@ images:
         inputs:
           - release_version
 
-        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-amd64
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context-amd64
@@ -154,12 +154,12 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-arm64
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)
 
       - name: operator-build-dev
         task_type: docker_build
         tags: [ "ubi" ]
-        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)-arm64
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.version_id)
 
         inputs:
           - version_id
@@ -208,7 +208,7 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-arm64
+          - dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: operator-build-release
@@ -218,7 +218,7 @@ images:
         inputs:
           - release_version
 
-        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)-arm64
+        dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context-arm64

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -207,7 +207,7 @@ images:
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.agent_version)
 
-  - name: readiness-probe-init
+  - name: readiness-probe-init-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/readiness
@@ -230,7 +230,7 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
-            tag: $(inputs.params.version_id)-context
+            tag: $(inputs.params.version_id)-context-amd64
 
       - name: readiness-template-ubi
         task_type: dockerfile_template
@@ -241,15 +241,15 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-amd64
 
       - name: readiness-init-build
         task_type: docker_build
         tags: [ "readiness-probe", "ubi" ]
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-amd64
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context-amd64
 
 
         labels:
@@ -257,9 +257,9 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
-            tag: $(inputs.params.version_id)
+            tag: $(inputs.params.version_id)-amd64
           - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
-            tag: latest
+            tag: latest-amd64
 
       - name: readiness-init-context-release
         task_type: docker_build
@@ -278,7 +278,7 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
-            tag: $(inputs.params.release_version)-context
+            tag: $(inputs.params.release_version)-context-amd64
 
       - name: readiness-template-release
         task_type: dockerfile_template
@@ -289,16 +289,16 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-amd64
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: readiness-init-build-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-amd64
         tags: [ "readiness-probe", "release" , "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.release_version)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.release_version)-context-amd64
 
         labels:
           quay.expires-after: Never
@@ -309,9 +309,113 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
-            tag: $(inputs.params.release_version)
+            tag: $(inputs.params.release_version)-amd64
 
-  - name: version-post-start-hook-init
+  - name: readiness-probe-init-arm64
+    vars:
+      context: .
+      template_context: scripts/dev/templates/readiness
+
+    inputs:
+      - readiness_probe_image
+      - readiness_probe_image_dev
+
+    platform: linux/arm64
+    stages:
+      - name: readiness-init-context-build
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
+        tags: [ "readiness-probe", "ubi" ]
+        labels:
+          quay.expires-after: 48h
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
+            tag: $(inputs.params.version_id)-context-arm64
+
+      - name: readiness-template-ubi
+        task_type: dockerfile_template
+        tags: [ "ubi" ]
+        template_file_extension: readiness
+
+        inputs:
+          - base_image
+
+        output:
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-arm64
+
+      - name: readiness-init-build
+        task_type: docker_build
+        tags: [ "readiness-probe", "ubi" ]
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-arm64
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context-arm64
+
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
+            tag: $(inputs.params.version_id)-arm64
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
+            tag: latest-arm64
+
+      - name: readiness-init-context-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
+        tags: [ "readiness-probe", "release" , "ubi" ]
+
+        labels:
+          quay.expires-after: Never
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        inputs:
+          - release_version
+          - builder_image
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+            tag: $(inputs.params.release_version)-context-arm64
+
+      - name: readiness-template-release
+        task_type: dockerfile_template
+        tags: [ "readiness-probe", "release", "ubi" ]
+        template_file_extension: readiness
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-arm64
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: readiness-init-build-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-arm64
+        tags: [ "readiness-probe", "release" , "ubi" ]
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.release_version)-context-arm64
+
+        labels:
+          quay.expires-after: Never
+
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+            tag: $(inputs.params.release_version)-arm64
+
+  - name: version-post-start-hook-init-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/versionhook
@@ -335,7 +439,7 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
-            tag: $(inputs.params.version_id)-context
+            tag: $(inputs.params.version_id)-context-amd64
 
       - name: version-post-start-hook-template-ubi
         task_type: dockerfile_template
@@ -346,24 +450,24 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-amd64
 
       - name: version-post-start-hook-init-build
         task_type: docker_build
-        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-amd64
         tags: [ "post-start-hook", "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev):$(inputs.params.version_id)-context-amd64
 
         labels:
           quay.expires-after: 48h
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
-            tag: $(inputs.params.version_id)
+            tag: $(inputs.params.version_id)-amd64
           - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
-            tag: latest
+            tag: latest-amd64
 
       - name: version-post-start-hook-init-context-release
         task_type: docker_build
@@ -382,7 +486,7 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
-            tag: $(inputs.params.release_version)-context
+            tag: $(inputs.params.release_version)-context-amd64
 
       - name: versionhook-template-release
         task_type: dockerfile_template
@@ -393,16 +497,16 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-amd64
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: version-post-start-hook-init-build-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-amd64
         tags: [ "release", "post-start-hook",  "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.release_version)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.release_version)-context-amd64
 
         labels:
           quay.expires-after: Never
@@ -413,4 +517,108 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
-            tag: $(inputs.params.release_version)
+            tag: $(inputs.params.release_version)-amd64
+
+  - name: version-post-start-hook-init-arm64
+    vars:
+      context: .
+      template_context: scripts/dev/templates/versionhook
+
+    inputs:
+      - version_post_start_hook_image
+      - version_post_start_hook_image_dev
+
+    platform: linux/arm64
+    stages:
+      - name: version-post-start-hook-init-context-build
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.builder
+        tags: [ "post-start-hook", "ubi" ]
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+            tag: $(inputs.params.version_id)-context-arm64
+
+      - name: version-post-start-hook-template-ubi
+        task_type: dockerfile_template
+        tags: [ "ubi" ]
+        template_file_extension: versionhook
+
+        inputs:
+          - base_image
+
+        output:
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-arm64
+
+      - name: version-post-start-hook-init-build
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-arm64
+        tags: [ "post-start-hook", "ubi" ]
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev):$(inputs.params.version_id)-context-arm64
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+            tag: $(inputs.params.version_id)-arm64
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+            tag: latest-arm64
+
+      - name: version-post-start-hook-init-context-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.builder
+        tags: [ "release", "post-start-hook",  "ubi", ]
+
+        labels:
+          quay.expires-after: Never
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        inputs:
+          - release_version
+          - builder_image
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+            tag: $(inputs.params.release_version)-context-arm64
+
+      - name: versionhook-template-release
+        task_type: dockerfile_template
+        tags: [ "post-start-hook", "release", "ubi" ]
+        template_file_extension: versionhook
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-arm64
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: version-post-start-hook-init-build-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-arm64
+        tags: [ "release", "post-start-hook",  "ubi" ]
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.release_version)-context-arm64
+
+        labels:
+          quay.expires-after: Never
+
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+            tag: $(inputs.params.release_version)-arm64

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -142,13 +142,13 @@ images:
         tags: [ "ubi" ]
 
         output:
-          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-amd64
+          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
       - name: agent-ubi-build
         task_type: docker_build
         tags: [ "ubi" ]
 
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-amd64
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context-amd64
@@ -194,7 +194,7 @@ images:
       - name: agent-ubi-release
         task_type: docker_build
         tags: [ "ubi", "release" ]
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-amd64
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context-amd64
@@ -243,13 +243,13 @@ images:
         tags: [ "ubi" ]
 
         output:
-          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
       - name: agent-ubi-build
         task_type: docker_build
         tags: [ "ubi" ]
 
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context-arm64
@@ -295,7 +295,7 @@ images:
       - name: agent-ubi-release
         task_type: docker_build
         tags: [ "ubi", "release" ]
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context-arm64
@@ -342,12 +342,12 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-amd64
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
 
       - name: readiness-init-build
         task_type: docker_build
         tags: [ "readiness-probe", "ubi" ]
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-amd64
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context-amd64
@@ -390,12 +390,12 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-amd64
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: readiness-init-build-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-amd64
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
         tags: [ "readiness-probe", "release" , "ubi" ]
 
         buildargs:
@@ -446,12 +446,12 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-arm64
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
 
       - name: readiness-init-build
         task_type: docker_build
         tags: [ "readiness-probe", "ubi" ]
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)-arm64
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
 
         buildargs:
           imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context-arm64
@@ -494,12 +494,12 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-arm64
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: readiness-init-build-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)-arm64
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
         tags: [ "readiness-probe", "release" , "ubi" ]
 
         buildargs:
@@ -551,11 +551,11 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-amd64
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
 
       - name: version-post-start-hook-init-build
         task_type: docker_build
-        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-amd64
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
         tags: [ "post-start-hook", "ubi" ]
 
         buildargs:
@@ -598,12 +598,12 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-amd64
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: version-post-start-hook-init-build-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-amd64
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
         tags: [ "release", "post-start-hook",  "ubi" ]
 
         buildargs:
@@ -655,11 +655,11 @@ images:
           - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-arm64
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
 
       - name: version-post-start-hook-init-build
         task_type: docker_build
-        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)-arm64
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
         tags: [ "post-start-hook", "ubi" ]
 
         buildargs:
@@ -702,12 +702,12 @@ images:
           - release_version
 
         output:
-          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-arm64
+          - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
 
       - name: version-post-start-hook-init-build-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)-arm64
+        dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
         tags: [ "release", "post-start-hook",  "ubi" ]
 
         buildargs:

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -106,7 +106,7 @@ images:
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
             tag: $(inputs.params.agent_version)
 
-  - name: agent-ubi
+  - name: agent-ubi-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/agent
@@ -134,7 +134,7 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: $(inputs.params.version_id)-context
+            tag: $(inputs.params.version_id)-context-amd64
 
       - name: agent-template-ubi
         task_type: dockerfile_template
@@ -142,16 +142,16 @@ images:
         tags: [ "ubi" ]
 
         output:
-          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
+          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-amd64
 
       - name: agent-ubi-build
         task_type: docker_build
         tags: [ "ubi" ]
 
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-amd64
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context-amd64
           agent_version: $(inputs.params.agent_version)
 
         labels:
@@ -159,9 +159,9 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: $(inputs.params.version_id)
+            tag: $(inputs.params.version_id)-amd64
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: latest
+            tag: latest-amd64
 
       - name: agent-template-ubi-s3
         task_type: dockerfile_template
@@ -189,15 +189,15 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)-context
+            tag: $(inputs.params.agent_version)-context-amd64
 
       - name: agent-ubi-release
         task_type: docker_build
         tags: [ "ubi", "release" ]
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-amd64
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context-amd64
           agent_version: $(inputs.params.agent_version)
 
         labels:
@@ -205,7 +205,108 @@ images:
 
         output:
           - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)
+            tag: $(inputs.params.agent_version)-amd64
+
+  - name: agent-ubi-arm64
+    vars:
+      context: .
+      template_context: scripts/dev/templates/agent
+
+    inputs:
+      - agent_version
+      - tools_version
+      - agent_image
+      - agent_image_dev
+
+    platform: linux/arm64
+    stages:
+      - name: agent-ubi-context
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
+        tags: [ "ubi" ]
+        buildargs:
+          agent_version: $(inputs.params.agent_version)
+          tools_version: $(inputs.params.tools_version)
+          agent_distro: amzn2_aarch64
+          tools_distro: rhel82-aarch64
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
+            tag: $(inputs.params.version_id)-context-arm64
+
+      - name: agent-template-ubi
+        task_type: dockerfile_template
+        distro: ubi
+        tags: [ "ubi" ]
+
+        output:
+          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+
+      - name: agent-ubi-build
+        task_type: docker_build
+        tags: [ "ubi" ]
+
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context-arm64
+          agent_version: $(inputs.params.agent_version)
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
+            tag: $(inputs.params.version_id)-arm64
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
+            tag: latest-arm64
+
+      - name: agent-template-ubi-s3
+        task_type: dockerfile_template
+        tags: [ "ubi", "release" ]
+        distro: ubi
+
+        inputs:
+          - release_version
+
+        output:
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-agent/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: agent-context-ubi-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
+        tags: [ "ubi", "release" ]
+        buildargs:
+          agent_version: $(inputs.params.agent_version)
+          tools_version: $(inputs.params.tools_version)
+          agent_distro: amzn2_aarch64
+          tools_distro: rhel82-aarch64
+
+        labels:
+          quay.expires-after: Never
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+            tag: $(inputs.params.agent_version)-context-arm64
+
+      - name: agent-ubi-release
+        task_type: docker_build
+        tags: [ "ubi", "release" ]
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)-arm64
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context-arm64
+          agent_version: $(inputs.params.agent_version)
+
+        labels:
+          quay.expires-after: Never
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
+            tag: $(inputs.params.agent_version)-arm64
 
   - name: readiness-probe-init-amd64
     vars:

--- a/pipeline.py
+++ b/pipeline.py
@@ -107,6 +107,11 @@ def build_readiness_probe_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.readiness_probe_image_dev)
 
+    if config.gh_run_id != "":
+        create_and_push_manifest(
+            config, config.readiness_probe_image_dev, config.gh_run_id
+        )
+
     if "release" in config.include_tags:
         create_and_push_manifest(
             config, config.readiness_probe_image, release["readiness-probe"]
@@ -150,6 +155,11 @@ def build_version_post_start_hook_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.version_upgrade_hook_image_dev)
 
+    if config.gh_run_id != "":
+        create_and_push_manifest(
+            config, config.version_upgrade_hook_image_dev, config.gh_run_id
+        )
+
     if "release" in config.include_tags:
         create_and_push_manifest(
             config, config.version_upgrade_hook_image, release["version-upgrade-hook"]
@@ -192,6 +202,9 @@ def build_operator_ubi_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.operator_image_dev)
 
+    if config.gh_run_id != "":
+        create_and_push_manifest(config, config.operator_image_dev, config.gh_run_id)
+
     if "release" in config.include_tags:
         create_and_push_manifest(
             config, config.operator_image, release["mongodb-kubernetes-operator"]
@@ -222,6 +235,9 @@ def build_e2e_image(config: DevConfig) -> None:
     )
 
     create_and_push_manifest(config, config.e2e_image)
+
+    if config.gh_run_id != "":
+        create_and_push_manifest(config, config.e2e_image, config.gh_run_id)
 
 
 def create_and_push_manifest(
@@ -284,6 +300,7 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--image-name", type=str)
     parser.add_argument("--release", type=lambda x: x.lower() == "true")
+    parser.add_argument("--tag", type=str)
     return parser.parse_args()
 
 
@@ -302,6 +319,8 @@ def main() -> int:
     # by default we do not want to run any release tasks. We must explicitly
     # use the --release flag to run them.
     config.ensure_skip_tag("release")
+
+    config.gh_run_id = args.tag
 
     # specify --release to release the image
     if args.release:

--- a/pipeline.py
+++ b/pipeline.py
@@ -252,6 +252,17 @@ def build_e2e_image(config: DevConfig) -> None:
         create_and_push_manifest(config, config.e2e_image, config.gh_run_id)
 
 
+"""
+generates docker manifests by running the following commands:
+1. Clear existing manifests
+docker manifest rm config.repo_url/image:tag
+2. Create the manifest
+docker manifest create config.repo_url/image:tag --amend config.repo_url/image:tag-amd64 --amend config.repo_url/image:tag-arm64
+3. Push the manifest
+docker manifest push config.repo_url/image:tag
+"""
+
+
 def create_and_push_manifest(
     config: DevConfig, image: str, tag: str = "latest"
 ) -> None:
@@ -285,11 +296,6 @@ def create_and_push_manifest(
 
     if cp.returncode != 0:
         raise Exception(cp.stderr)
-
-
-# docker manifest rm $(REPO_URL)/$(OPERATOR_IMAGE):latest | true
-# docker manifest create $(REPO_URL)/$(OPERATOR_IMAGE):latest --amend $(REPO_URL)/$(OPERATOR_IMAGE):latest-amd64 --amend $(REPO_URL)/$(OPERATOR_IMAGE):latest-arm64
-# docker manifest push $(REPO_URL)/$(OPERATOR_IMAGE):latest
 
 
 def sonar_build_image(

--- a/pipeline.py
+++ b/pipeline.py
@@ -253,7 +253,7 @@ def build_e2e_image(config: DevConfig) -> None:
 
 
 """
-generates docker manifests by running the following commands:
+Generates docker manifests by running the following commands:
 1. Clear existing manifests
 docker manifest rm config.repo_url/image:tag
 2. Create the manifest

--- a/pipeline.py
+++ b/pipeline.py
@@ -43,17 +43,29 @@ def _build_agent_args(config: DevConfig) -> Dict[str, str]:
 
 
 def build_agent_image_ubi(config: DevConfig) -> None:
-    image_name = "agent-ubi"
     args = _build_agent_args(config)
     args["agent_image"] = config.agent_image_ubi
     args["agent_image_dev"] = config.agent_dev_image_ubi
     config.ensure_tag_is_run("ubi")
 
     sonar_build_image(
-        image_name,
+        "agent-ubi-amd64",
         config,
         args=args,
     )
+    sonar_build_image(
+        "agent-ubi-arm64",
+        config,
+        args=args,
+    )
+
+    create_and_push_manifest(config, config.agent_dev_image_ubi)
+
+    if config.gh_run_id is not None and config.gh_run_id != "":
+        create_and_push_manifest(config, config.agent_dev_image_ubi, config.gh_run_id)
+
+    if "release" in config.include_tags:
+        create_and_push_manifest(config, config.agent_image_ubi, args["agent_version"])
 
 
 def build_agent_image_ubuntu(config: DevConfig) -> None:
@@ -107,7 +119,7 @@ def build_readiness_probe_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.readiness_probe_image_dev)
 
-    if config.gh_run_id != "":
+    if config.gh_run_id is not None and config.gh_run_id != "":
         create_and_push_manifest(
             config, config.readiness_probe_image_dev, config.gh_run_id
         )
@@ -155,7 +167,7 @@ def build_version_post_start_hook_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.version_upgrade_hook_image_dev)
 
-    if config.gh_run_id != "":
+    if config.gh_run_id is not None and config.gh_run_id != "":
         create_and_push_manifest(
             config, config.version_upgrade_hook_image_dev, config.gh_run_id
         )
@@ -202,7 +214,7 @@ def build_operator_ubi_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.operator_image_dev)
 
-    if config.gh_run_id != "":
+    if config.gh_run_id is not None and config.gh_run_id != "":
         create_and_push_manifest(config, config.operator_image_dev, config.gh_run_id)
 
     if "release" in config.include_tags:
@@ -236,7 +248,7 @@ def build_e2e_image(config: DevConfig) -> None:
 
     create_and_push_manifest(config, config.e2e_image)
 
-    if config.gh_run_id != "":
+    if config.gh_run_id is not None and config.gh_run_id != "":
         create_and_push_manifest(config, config.e2e_image, config.gh_run_id)
 
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -66,6 +66,9 @@ def build_agent_image_ubi(config: DevConfig) -> None:
 
     if "release" in config.include_tags:
         create_and_push_manifest(config, config.agent_image_ubi, args["agent_version"])
+        create_and_push_manifest(
+            config, config.agent_image_ubi, args["agent_version"] + "-context"
+        )
 
 
 def build_agent_image_ubuntu(config: DevConfig) -> None:
@@ -128,6 +131,11 @@ def build_readiness_probe_image(config: DevConfig) -> None:
         create_and_push_manifest(
             config, config.readiness_probe_image, release["readiness-probe"]
         )
+        create_and_push_manifest(
+            config,
+            config.readiness_probe_image,
+            release["readiness-probe"] + "-context",
+        )
 
 
 def build_version_post_start_hook_image(config: DevConfig) -> None:
@@ -176,6 +184,11 @@ def build_version_post_start_hook_image(config: DevConfig) -> None:
         create_and_push_manifest(
             config, config.version_upgrade_hook_image, release["version-upgrade-hook"]
         )
+        create_and_push_manifest(
+            config,
+            config.version_upgrade_hook_image,
+            release["version-upgrade-hook"] + "-context",
+        )
 
 
 def build_operator_ubi_image(config: DevConfig) -> None:
@@ -220,6 +233,11 @@ def build_operator_ubi_image(config: DevConfig) -> None:
     if "release" in config.include_tags:
         create_and_push_manifest(
             config, config.operator_image, release["mongodb-kubernetes-operator"]
+        )
+        create_and_push_manifest(
+            config,
+            config.operator_image,
+            release["mongodb-kubernetes-operator"] + "-context",
         )
 
 

--- a/pkg/automationconfig/automation_config_builder.go
+++ b/pkg/automationconfig/automation_config_builder.go
@@ -436,6 +436,18 @@ func buildDummyMongoDbVersionConfig(version string) MongoDbVersionConfig {
 				Flavor:       "ubuntu",
 				Modules:      []string{},
 			},
+			{
+				Platform:     "linux",
+				Architecture: "aarch64",
+				Flavor:       "ubuntu",
+				Modules:      []string{},
+			},
+			{
+				Platform:     "linux",
+				Architecture: "aarch64",
+				Flavor:       "rhel",
+				Modules:      []string{},
+			},
 		},
 	}
 

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -1,7 +1,7 @@
 {
   "namespace": "default",
   "repo_url": "quay.io/mongodb",
-  "mongodb_image_repo_url": "docker.io/mongodb",
+  "mongodb_image_repo_url": "quay.io/mongodb",
   "mongodb_image_name": "mongodb-community-server",
   "operator_image": "mongodb-kubernetes-operator",
   "operator_image_dev": "community-operator-dev",

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -35,6 +35,7 @@ class DevConfig:
         self._distro = distro
         self.include_tags: List[str] = []
         self.skip_tags: List[str] = []
+        self.gh_run_id = ""
 
     def ensure_tag_is_run(self, tag: str) -> None:
         if tag not in self.include_tags:

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -161,7 +161,7 @@ class DevConfig:
 
 
 def load_config(
-    config_file_path: Optional[str] = None, distro: Distro = Distro.UBUNTU
+    config_file_path: Optional[str] = None, distro: Distro = Distro.UBI
 ) -> DevConfig:
     if config_file_path is None:
         config_file_path = get_config_path()

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -114,7 +114,7 @@ class DevConfig:
 
     @property
     def mongodb_image_repo_url(self) -> str:
-        return self._config.get("mongodb_image_repo_url", "docker.io/mongodb")
+        return self._config.get("mongodb_image_repo_url", "quay.io/mongodb")
 
     @property
     def agent_dev_image_ubi(self) -> str:

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -247,7 +247,7 @@ def parse_args() -> argparse.Namespace:
         "--distro",
         help="The distro of images that should be used",
         type=str,
-        default="ubuntu",
+        default="ubi",
     )
     parser.add_argument("--config_file", help="Path to the config file")
     return parser.parse_args()

--- a/scripts/dev/templates/Dockerfile.e2e
+++ b/scripts/dev/templates/Dockerfile.e2e
@@ -4,9 +4,10 @@
 COPY testdata/tls/ testdata/tls/
 {% endblock -%}
 
-
+ARG TARGETOS
+ARG TARGETARCH
 {% block install_helm -%}
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" \
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/${TARGETOS}/${TARGETARCH}/kubectl" \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \

--- a/scripts/dev/templates/Dockerfile.template
+++ b/scripts/dev/templates/Dockerfile.template
@@ -1,8 +1,8 @@
 {% if builder %}
-FROM {{builder_image}} AS builder
+FROM --platform=$TARGETPLATFORM {{builder_image}} AS builder
 
 {% else %}
-FROM {{base_image}}
+FROM --platform=$TARGETPLATFORM {{base_image}}
 {% endif %}
 
 {% block packages -%}

--- a/scripts/dev/templates/operator/Dockerfile.builder
+++ b/scripts/dev/templates/operator/Dockerfile.builder
@@ -1,12 +1,14 @@
 ARG builder_image
-FROM ${builder_image} AS builder
+FROM --platform=$BUILDPLATFORM ${builder_image} AS builder
 
 RUN mkdir /workspace
 WORKDIR /workspace
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/manager/main.go
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/manager/main.go
 
 FROM busybox
 

--- a/scripts/dev/templates/readiness/Dockerfile.builder
+++ b/scripts/dev/templates/readiness/Dockerfile.builder
@@ -1,12 +1,14 @@
 ARG builder_image
-FROM ${builder_image} as builder
+FROM --platform=$BUILDPLATFORM ${builder_image} as builder
 
 RUN mkdir /workspace
 WORKDIR /workspace
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o readinessprobe cmd/readiness/main.go
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o readinessprobe cmd/readiness/main.go
 
 FROM busybox
 

--- a/scripts/dev/templates/versionhook/Dockerfile.builder
+++ b/scripts/dev/templates/versionhook/Dockerfile.builder
@@ -1,12 +1,14 @@
 ARG builder_image
-FROM ${builder_image} as builder
+FROM --platform=$BUILDPLATFORM ${builder_image} as builder
 
 RUN mkdir /workspace
 WORKDIR /workspace
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o version-upgrade-hook cmd/versionhook/main.go
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o version-upgrade-hook cmd/versionhook/main.go
 
 FROM busybox
 

--- a/test/e2e/setup/test_config.go
+++ b/test/e2e/setup/test_config.go
@@ -39,7 +39,7 @@ func LoadTestConfigFromEnv() TestConfig {
 		CertManagerVersion:      envvar.GetEnvOrDefault(testCertManagerVersionEnvName, "v1.5.3"),
 		OperatorImage:           envvar.GetEnvOrDefault(operatorImageEnvName, "quay.io/mongodb/community-operator-dev:latest"),
 		MongoDBImage:            envvar.GetEnvOrDefault(construct.MongodbImageEnv, "mongodb-community-server"),
-		MongoDBRepoUrl:          envvar.GetEnvOrDefault(construct.MongodbRepoUrl, "docker.io/mongodb"),
+		MongoDBRepoUrl:          envvar.GetEnvOrDefault(construct.MongodbRepoUrl, "quay.io/mongodb"),
 		VersionUpgradeHookImage: envvar.GetEnvOrDefault(construct.VersionUpgradeHookImageEnv, "quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2"),
 		AgentImage:              envvar.GetEnvOrDefault(construct.AgentImageEnv, "quay.io/mongodb/mongodb-agent:10.29.0.6830-1"), // TODO: better way to decide default agent image.
 		ClusterWide:             envvar.ReadBool(clusterWideEnvName),


### PR DESCRIPTION
Closes #299 

### Summary

The image building process will use the same dockerfile for both of architectures. The dockerfiles have been updated to accommodate for any target platform. Like before, we use sonar to build docker images, but now, sonar is used twice to build an image for both amd64 and arm64 architecture. Thus resulting in images with the suffix '-amd64' and '-arm64'. 
After building the images, the method `create_and_push_manifest` will use the created images with the architecture suffix and combine them in a manifest which is then pushed to the quay.io registry. This manifest is the final multi-arch image. In the end, the users will be able to pull the same image tag and get the appropriate image for their architecture, thus, it will work ootb for both architectures.

Here is an interesting blog about this: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/ 

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
