### PR TITLE
chore(config): remove kustomize deprecations

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,6 +1,6 @@
 namePrefix: ""
 
-bases:
+resources:
   - ../crd
   - ../rbac
   - ../manager

--- a/config/local_run/kustomization.yaml
+++ b/config/local_run/kustomization.yaml
@@ -1,6 +1,6 @@
 # used to run the operator locally
 namePrefix: ""
 
-bases:
+resources:
   - ../crd
   - ../rbac


### PR DESCRIPTION
**What this PR does**

This PR removes a deprecation in two kustomizations, where the field kustomize v2's  `bases` field was still used.
From the version 3 `resources` replaces both usages of child kustomizations and bases kustomizations located outside of the user kustomization directory, becoming agnostic to the location of kustomizations, and their resources are accumulated the same way.

**Additional context**

Furthermore, kustomize v3 is already two major versions behind the current stable one (v5).
There are already users of the latter version, for example,  `kubectl` v1.27 comes with the embedded kustomize v5.0.1.

Unrelated to the previous point, it seems that no `operator-sdk generate kustomize manifests` automated run is present in the codebase, and the kustomizations are not automatically generated, right now.

**Open issues**

Closes #1355 

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
