### PR TITLE
Returning ready if there are no plans in headless mode

### DIFF
--- a/pkg/readiness/headless/headless.go
+++ b/pkg/readiness/headless/headless.go
@@ -67,19 +67,11 @@ func readCurrentAgentInfo(health health.Status, targetVersion int64) int64 {
 		zap.S().Debugf("Automation Config version: %d, Agent last version: %d", targetVersion, v.LastGoalStateClusterConfigVersion)
 		return v.LastGoalStateClusterConfigVersion
 	}
-	// The edge case: if the scale down operation is happening and the member + process are removed
-	// from the Automation Config - the Agent just doesn't write the 'mmsStatus' at all so there is no indication of
-	// the version it has achieved (though health file contains 'IsInGoalState=true')
-	// Let's return the desired version in case if the Agent is in goal state and no plans exist in the health file
-	for _, v := range health.Statuses {
-		if v.IsInGoalState {
-			return targetVersion
-		}
-		return -1
-	}
 
-	// There's a small theoretical probability that the Pod got restarted right when the Agent shutdown the Mongodb
-	// on scale down - in this case the 'health' file is empty - so we return the target version to avoid locking
-	// the Operator waiting for the annotation
+	// If there are no plans, we always return target version.
+	// Previously we relied on IsInGoalState, but the agent started sometimes returning IsInGoalState=false when scaling down members.
+	// No plans will occur if the agent is just starting or if the current process is not in the process list in automation config.
+	// Either way this is not a blocker for the operator to perform necessary statefulset changes on it.
+
 	return targetVersion
 }


### PR DESCRIPTION
Sometimes the agent is not returning IsInGoalState when mongod is scaled down. 
This change prevents the operator from being stuck and allows to progress and remove the pod from the statefulset.

If there are no plans after removing the process from automation config and IsInGoalState=false, the target version was -1 and it wasn't possible to recover automatically from this situation.
