### PR TITLE
Expanding TLS settings

### DIFF
--- a/config/samples/mongodb.com_v1_mongodbcommunity_tls_cr.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_tls_cr.yaml
@@ -12,10 +12,19 @@ spec:
       modes: ["SCRAM"]
     tls:
       enabled: true
+      optional: true
       certificateKeySecretRef:
         name: tls-secret-name
       caConfigMapRef:
         name: tls-ca-configmap-name
+  statefulSet:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: mongodb-agent
+            useSslForAllConnections: true
+            sslRequireValidServerCertificates: false
   users:
     - name: my-user
       db: admin


### PR DESCRIPTION
### All Submissions:

* [-] Have you opened an Issue before filing this PR? 
* [+] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [+] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [-] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

Default example does not work if TLS on mongodb is enforced (optional: false) because mongodb-agent keeps trying to establish unencrypted connection and due to that the health-check never succeeds, so it is better to add some more settings to mongodb-agent section to make it work both with optional and mandatory TLS and to accept self signed certificates if any is used (which is common approach for cluster internal mongodb installations).

Let me know if it is better to add some inline comments near those options to make it more clear for the users. 