### PR TITLE
CLOUDP-209728  - add support for MDB7

### DIFF
--- a/.action_templates/jobs/tests.yaml
+++ b/.action_templates/jobs/tests.yaml
@@ -10,6 +10,8 @@ tests:
         - test-name: replica_set_enterprise_upgrade_4_5
           distro: ubi
         - test-name: replica_set_enterprise_upgrade_5_6
+          distro: ubi.
+        - test-name: replica_set_enterprise_upgrade_6_7
           distro: ubi
         - test-name: replica_set_recovery
           distro: ubi

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -96,6 +96,8 @@ jobs:
           distro: ubi
         - test-name: replica_set_enterprise_upgrade_5_6
           distro: ubi
+        - test-name: replica_set_enterprise_upgrade_6_7
+          distro: ubi
         - test-name: replica_set_recovery
           distro: ubi
         - test-name: replica_set_mongod_readiness

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,6 +102,8 @@ jobs:
           distro: ubi
         - test-name: replica_set_enterprise_upgrade_5_6
           distro: ubi
+        - test-name: replica_set_enterprise_upgrade_6_7
+          distro: ubi
         - test-name: replica_set_recovery
           distro: ubi
         - test-name: replica_set_mongod_readiness

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/blang/semver"
-	"github.com/mongodb/mongodb-kubernetes-operator/pkg/util/envvar"
 	"os"
 	"strconv"
 	"strings"
@@ -54,8 +52,6 @@ const (
 
 	lastSuccessfulConfiguration = "mongodb.com/v1.lastSuccessfulConfiguration"
 	lastAppliedMongoDBVersion   = "mongodb.com/v1.lastAppliedMongoDBVersion"
-
-	ignoreMdb7ErrorEnvVar = "IGNORE_MDB_7_ERROR"
 )
 
 func init() {
@@ -626,16 +622,6 @@ func (r *ReplicaSetReconciler) buildService(mdb mdbv1.MongoDBCommunity, portMana
 // it checks that the attempted Spec is valid in relation to the Spec that resulted from that last successful configuration.
 // The validation also returns the lastSuccessFulConfiguration Spec as mdbv1.MongoDBCommunitySpec.
 func (r ReplicaSetReconciler) validateSpec(mdb mdbv1.MongoDBCommunity) (error, *mdbv1.MongoDBCommunitySpec) {
-	if !envvar.ReadBool(ignoreMdb7ErrorEnvVar) {
-		semverVersion, err := semver.Make(mdb.Spec.Version)
-		if err != nil {
-			r.log.Warnf("could not parse version %v", mdb.Spec.Version)
-		} else {
-			if semverVersion.Major >= 7 {
-				return fmt.Errorf("mongodb >= 7.0.0 is not supported"), nil
-			}
-		}
-	}
 	lastSuccessfulConfigurationSaved, ok := mdb.Annotations[lastSuccessfulConfiguration]
 	if !ok {
 		// First version of Spec

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -171,20 +171,6 @@ func TestKubernetesResources_AreCreated(t *testing.T) {
 	assert.NotEmpty(t, s.Data[automationconfig.ConfigKey])
 }
 
-func TestKubernetesResources_MongoDB7IsRejected(t *testing.T) {
-	mdb := newTestReplicaSet()
-	mdb.Spec.Version = "7.0.0"
-
-	mgr := client.NewManager(&mdb)
-	r := NewReconciler(mgr)
-
-	res, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mdb.Namespace, Name: mdb.Name}})
-
-	assert.NoError(t, err)
-	assert.Equal(t, true, res.Requeue)
-	assert.Equal(t, time.Duration(0), res.RequeueAfter)
-}
-
 func TestStatefulSet_IsCorrectlyConfigured(t *testing.T) {
 	t.Setenv(construct.MongodbRepoUrl, "docker.io/mongodb")
 	t.Setenv(construct.MongodbImageEnv, "mongodb-community-server")

--- a/release.json
+++ b/release.json
@@ -4,7 +4,7 @@
   "version-upgrade-hook": "1.0.8",
   "readiness-probe": "1.0.17",
   "mongodb-agent": {
-    "version": "12.0.27.7746-1",
-    "tools_version": "100.8.0"
+    "version": "107.0.0.8465-1",
+    "tools_version": "100.9.0"
   }
 }

--- a/test/e2e/e2eutil.go
+++ b/test/e2e/e2eutil.go
@@ -70,7 +70,7 @@ func NewTestMongoDB(ctx *Context, name string, namespace string) (mdbv1.MongoDBC
 		Spec: mdbv1.MongoDBCommunitySpec{
 			Members:  3,
 			Type:     "ReplicaSet",
-			Version:  "6.0.5",
+			Version:  "7.0.2",
 			Arbiters: 0,
 			Security: mdbv1.Security{
 				Authentication: mdbv1.Authentication{

--- a/test/e2e/replica_set_enterprise_upgrade_6_7/replica_set_enterprise_upgrade_5_6_test.go
+++ b/test/e2e/replica_set_enterprise_upgrade_6_7/replica_set_enterprise_upgrade_5_6_test.go
@@ -1,0 +1,26 @@
+package replica_set
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/replica_set_enterprise_upgrade"
+)
+
+var (
+	versionsForUpgrades = []string{"6.0.5", "7.0.2"}
+)
+
+func TestMain(m *testing.M) {
+	code, err := e2eutil.RunTest(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func TestReplicaSet(t *testing.T) {
+	replica_set_enterprise_upgrade.DeployEnterpriseAndUpgradeTest(t, versionsForUpgrades)
+}

--- a/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -27,6 +27,8 @@ func TestReplicaSetOperatorUpgrade(t *testing.T) {
 	defer ctx.Teardown()
 
 	mdb, user := e2eutil.NewTestMongoDB(ctx, resourceName, testConfig.Namespace)
+	// Prior operator versions did not support MDB7
+	mdb.Spec.Version = "6.0.5"
 	scramUser := mdb.GetAuthUsers()[0]
 	mdb.Spec.Security.TLS = e2eutil.NewTestTLSConfig(false)
 	mdb.Spec.Arbiters = 1


### PR DESCRIPTION
### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


## Changes
- bumping agent  and tools version to support MDB7
- adding support for MDB7
- adding a migration test from 6 to 7 (https://github.com/mongodb/mongodb-kubernetes-operator/actions/runs/6773775091/job/18409562400?pr=1422) 
- bumping default test mdb version from 6 to 7, except for operator upgrade test. There we need to use mdb below 7 because we never supported mdb7 from those operator versions