### PR TITLE
CLOUDP-211733 - Pipeline and build process refactoring

### DIFF
--- a/.action_templates/jobs/setup.yaml
+++ b/.action_templates/jobs/setup.yaml
@@ -7,5 +7,5 @@ setup:
         - pipeline-argument: mongodb-kubernetes-operator
         - pipeline-argument: version-upgrade-hook
         - pipeline-argument: readiness-probe
-        - pipeline-argument: mongodb-agent
+        - pipeline-argument: agent
         - pipeline-argument: e2e

--- a/.action_templates/jobs/setup.yaml
+++ b/.action_templates/jobs/setup.yaml
@@ -4,8 +4,8 @@ setup:
     fail-fast: false
     matrix:
       include:
-        - pipeline-argument: operator-ubi
-        - pipeline-argument: version-post-start-hook-init
-        - pipeline-argument: readiness-probe-init
-        - pipeline-argument: agent-ubi
+        - pipeline-argument: mongodb-kubernetes-operator
+        - pipeline-argument: version-upgrade-hook
+        - pipeline-argument: readiness-probe
+        - pipeline-argument: mongodb-agent
         - pipeline-argument: e2e

--- a/.action_templates/steps/build-and-push-development-images.yaml
+++ b/.action_templates/steps/build-and-push-development-images.yaml
@@ -1,6 +1,6 @@
 - name: Build and Push Images
   run: |
-    python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
+    python pipeline.py --image-name ${{ matrix.pipeline-argument }}  --tag ${{ github.run_id }}
   env:
     MONGODB_COMMUNITY_CONFIG: "${{ github.workspace }}/scripts/ci/config.json"
     version_id: "${{ github.run_id }}"

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -76,7 +76,7 @@ jobs:
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
-        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
+        python pipeline.py --image-name ${{ matrix.pipeline-argument }}  --tag ${{ github.run_id }}
       env:
         MONGODB_COMMUNITY_CONFIG: ${{ github.workspace }}/scripts/ci/config.json
         version_id: ${{ github.run_id }}

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
         - pipeline-argument: operator
         - pipeline-argument: version-upgrade-hook
         - pipeline-argument: readiness-probe
-        - pipeline-argument: mongodb-agent
+        - pipeline-argument: agent
         - pipeline-argument: e2e
     steps:
     # template: .action_templates/steps/checkout.yaml

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -40,10 +40,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - pipeline-argument: operator-ubi
-        - pipeline-argument: version-post-start-hook-init
-        - pipeline-argument: readiness-probe-init
-        - pipeline-argument: agent-ubi
+        - pipeline-argument: operator
+        - pipeline-argument: version-upgrade-hook
+        - pipeline-argument: readiness-probe
+        - pipeline-argument: mongodb-agent
         - pipeline-argument: e2e
     steps:
     # template: .action_templates/steps/checkout.yaml

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -36,7 +36,7 @@ jobs:
         - pipeline-argument: operator
         - pipeline-argument: version-upgrade-hook
         - pipeline-argument: readiness-probe
-        - pipeline-argument: mongodb-agent
+        - pipeline-argument: agent
         - pipeline-argument: e2e
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || contains(github.event.pull_request.labels.*.name,
       'safe-to-test')

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -78,7 +78,7 @@ jobs:
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
-        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
+        python pipeline.py --image-name ${{ matrix.pipeline-argument }}  --tag ${{ github.run_id }}
       env:
         MONGODB_COMMUNITY_CONFIG: ${{ github.workspace }}/scripts/ci/config.json
         version_id: ${{ github.run_id }}

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -33,10 +33,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - pipeline-argument: operator-ubi
-        - pipeline-argument: version-post-start-hook-init
-        - pipeline-argument: readiness-probe-init
-        - pipeline-argument: agent-ubi
+        - pipeline-argument: operator
+        - pipeline-argument: version-upgrade-hook
+        - pipeline-argument: readiness-probe
+        - pipeline-argument: mongodb-agent
         - pipeline-argument: e2e
     if: contains(github.event.pull_request.labels.*.name, 'dependencies') || contains(github.event.pull_request.labels.*.name,
       'safe-to-test')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,10 +40,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - pipeline-argument: operator-ubi
-        - pipeline-argument: version-post-start-hook-init
-        - pipeline-argument: readiness-probe-init
-        - pipeline-argument: agent-ubi
+        - pipeline-argument: operator
+        - pipeline-argument: version-upgrade-hook
+        - pipeline-argument: readiness-probe
+        - pipeline-argument: mongodb-agent
         - pipeline-argument: e2e
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master'
       || (github.event.pull_request.head.repo.full_name == github.repository && github.actor

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
         - pipeline-argument: operator
         - pipeline-argument: version-upgrade-hook
         - pipeline-argument: readiness-probe
-        - pipeline-argument: mongodb-agent
+        - pipeline-argument: agent
         - pipeline-argument: e2e
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master'
       || (github.event.pull_request.head.repo.full_name == github.repository && github.actor

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,7 @@ jobs:
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
-        python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release false --tag ${{ github.run_id }}
+        python pipeline.py --image-name ${{ matrix.pipeline-argument }}  --tag ${{ github.run_id }}
       env:
         MONGODB_COMMUNITY_CONFIG: ${{ github.workspace }}/scripts/ci/config.json
         version_id: ${{ github.run_id }}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Publish Image To Quay
         if: steps.release_status.outputs.OUTPUT == 'unreleased'
-        run: python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release true
+        run: python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release
         env:
           MONGODB_COMMUNITY_CONFIG: "${{ github.workspace }}/scripts/ci/config.json"
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -12,16 +12,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - pipeline-argument: operator-ubi
-            release-key: mongodb-kubernetes-operator
-          - pipeline-argument: version-post-start-hook-init
+          - pipeline-argument: operator
+            release-key: operator
+          - pipeline-argument: version-upgrade-hook
             release-key: version-upgrade-hook
-          - pipeline-argument: readiness-probe-init
+          - pipeline-argument: readiness-probe
             release-key: readiness-probe
-          - pipeline-argument: agent-ubi
+          - pipeline-argument: mongodb-agent
             release-key: mongodb-agent
-          - pipeline-argument: agent-ubuntu
-            release-key: mongodb-agent
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -18,8 +18,8 @@ jobs:
             release-key: version-upgrade-hook
           - pipeline-argument: readiness-probe
             release-key: readiness-probe
-          - pipeline-argument: mongodb-agent
-            release-key: mongodb-agent
+          - pipeline-argument: agent
+            release-key: agent
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-images:
     runs-on: ubuntu-latest
-    #if: startsWith(github.event.pull_request.title, 'Release MongoDB Kubernetes Operator') && github.event.review.state == 'approved'
+    if: startsWith(github.event.pull_request.title, 'Release MongoDB Kubernetes Operator') && github.event.review.state == 'approved'
     strategy:
       matrix:
         include:
@@ -62,22 +62,22 @@ jobs:
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
 
-  #create-draft-release:
-  #  runs-on: ubuntu-latest
-  #  needs: [release-images]
-  #  steps:
-  #  - name: Checkout Code
-  #    uses: actions/checkout@v2
-  #  - name: Determine Release Tag
-  #    id: release_tag
-  #    run: |
-  #      OUTPUT=$(jq -r '."mongodb-kubernetes-operator"' < $GITHUB_WORKSPACE/release.json)
-  #      echo "::set-output name=OUTPUT::$OUTPUT"
-  #  - name: Create Github Release
-  #    uses: ncipollo/release-action@v1
-  #    with:
-  #      tag: "v${{ steps.release_tag.outputs.OUTPUT }}"
-  #      name: MongoDB Kubernetes Operator
-  #      bodyFile: "${{ github.workspace }}/docs/RELEASE_NOTES.md"
-  #      draft: true
-  #      token: ${{ secrets.GITHUB_TOKEN }}
+  create-draft-release:
+    runs-on: ubuntu-latest
+    needs: [release-images]
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: Determine Release Tag
+      id: release_tag
+      run: |
+        OUTPUT=$(jq -r '."mongodb-kubernetes-operator"' < $GITHUB_WORKSPACE/release.json)
+        echo "::set-output name=OUTPUT::$OUTPUT"
+    - name: Create Github Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: "v${{ steps.release_tag.outputs.OUTPUT }}"
+        name: MongoDB Kubernetes Operator
+        bodyFile: "${{ github.workspace }}/docs/RELEASE_NOTES.md"
+        draft: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-images:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.title, 'Release MongoDB Kubernetes Operator') && github.event.review.state == 'approved'
+    #if: startsWith(github.event.pull_request.title, 'Release MongoDB Kubernetes Operator') && github.event.review.state == 'approved'
     strategy:
       matrix:
         include:
@@ -62,22 +62,22 @@ jobs:
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
 
-  create-draft-release:
-    runs-on: ubuntu-latest
-    needs: [release-images]
-    steps:
-    - name: Checkout Code
-      uses: actions/checkout@v2
-    - name: Determine Release Tag
-      id: release_tag
-      run: |
-        OUTPUT=$(jq -r '."mongodb-kubernetes-operator"' < $GITHUB_WORKSPACE/release.json)
-        echo "::set-output name=OUTPUT::$OUTPUT"
-    - name: Create Github Release
-      uses: ncipollo/release-action@v1
-      with:
-        tag: "v${{ steps.release_tag.outputs.OUTPUT }}"
-        name: MongoDB Kubernetes Operator
-        bodyFile: "${{ github.workspace }}/docs/RELEASE_NOTES.md"
-        draft: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+  #create-draft-release:
+  #  runs-on: ubuntu-latest
+  #  needs: [release-images]
+  #  steps:
+  #  - name: Checkout Code
+  #    uses: actions/checkout@v2
+  #  - name: Determine Release Tag
+  #    id: release_tag
+  #    run: |
+  #      OUTPUT=$(jq -r '."mongodb-kubernetes-operator"' < $GITHUB_WORKSPACE/release.json)
+  #      echo "::set-output name=OUTPUT::$OUTPUT"
+  #  - name: Create Github Release
+  #    uses: ncipollo/release-action@v1
+  #    with:
+  #      tag: "v${{ steps.release_tag.outputs.OUTPUT }}"
+  #      name: MongoDB Kubernetes Operator
+  #      bodyFile: "${{ github.workspace }}/docs/RELEASE_NOTES.md"
+  #      draft: true
+  #      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Publish Image To Quay
-        #if: steps.release_status.outputs.OUTPUT == 'unreleased'
+        if: steps.release_status.outputs.OUTPUT == 'unreleased'
         run: python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release
         env:
           MONGODB_COMMUNITY_CONFIG: "${{ github.workspace }}/scripts/ci/config.json"

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Publish Image To Quay
-        if: steps.release_status.outputs.OUTPUT == 'unreleased'
+        #if: steps.release_status.outputs.OUTPUT == 'unreleased'
         run: python pipeline.py --image-name ${{ matrix.pipeline-argument }} --release
         env:
           MONGODB_COMMUNITY_CONFIG: "${{ github.workspace }}/scripts/ci/config.json"

--- a/.github/workflows/release-single-image.yml
+++ b/.github/workflows/release-single-image.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish Image To Quay
         if: steps.release_status.outputs.OUTPUT == 'unreleased'
-        run: python pipeline.py --image-name ${{ github.event.inputs.pipeline-argument }} --release true
+        run: python pipeline.py --image-name ${{ github.event.inputs.pipeline-argument }} --release
         env:
           MONGODB_COMMUNITY_CONFIG: "${{ github.workspace }}/scripts/ci/config.json"
           AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ e2e-image: ## Build and push e2e test image
 
 agent-image: ## Build and push agent image
 	python pipeline.py --image-name agent-ubuntu
-	python pipeline.py --image-name mongodb-agent
+	python pipeline.py --image-name agent
 
 readiness-probe-image: ## Build and push readiness probe image
 	python pipeline.py --image-name readiness-probe

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ e2e-image: ## Build and push e2e test image
 	python pipeline.py --image-name e2e
 
 agent-image: ## Build and push agent image
-	python pipeline.py --image-name agent-ubuntu
 	python pipeline.py --image-name agent
 
 readiness-probe-image: ## Build and push readiness probe image

--- a/Makefile
+++ b/Makefile
@@ -144,20 +144,20 @@ generate-env-file: ## generates a local-test.env for local testing
 ##@ Image
 
 operator-image: ## Build and push the operator image
-	python pipeline.py --image-name operator-ubi
+	python pipeline.py --image-name operator
 
 e2e-image: ## Build and push e2e test image
 	python pipeline.py --image-name e2e
 
 agent-image: ## Build and push agent image
 	python pipeline.py --image-name agent-ubuntu
-	python pipeline.py --image-name agent-ubi
+	python pipeline.py --image-name mongodb-agent
 
 readiness-probe-image: ## Build and push readiness probe image
-	python pipeline.py --image-name readiness-probe-init
+	python pipeline.py --image-name readiness-probe
 
 version-upgrade-post-start-hook-image: ## Build and push version upgrade post start hook image
-	python pipeline.py --image-name version-post-start-hook-init
+	python pipeline.py --image-name version-upgrade-hook
 
 all-images: operator-image e2e-image agent-image readiness-probe-image version-upgrade-post-start-hook-image ## create all required images
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -59,8 +59,7 @@ to be able to run properly. Create a json file with the following content:
   "operator_image": "mongodb-kubernetes-operator",
   "e2e_image": "community-operator-e2e",
   "version_upgrade_hook_image": "community-operator-version-upgrade-post-start-hook",
-  "agent_image_ubuntu": "mongodb-agent-dev",
-  "agent_image_ubi": "mongodb-agent-ubi-dev",
+  "agent_image": "mongodb-agent-ubi-dev",
   "readiness_probe_image": "mongodb-kubernetes-readiness",
   "s3_bucket": ""
 }
@@ -73,10 +72,8 @@ to be able to run properly. Create a json file with the following content:
 3. `operator_image` will be used as the name of the operator deployment, and the name of the operator image when build.
 4. `e2e_image` the name of e2e test image that will be built.
 5. `version_upgrade_hook_image` the name of the version upgrade post start hook image.
-6. `image_type` this can be either `ubi` or `ubuntu` and determines the distro of the images built. (currently only the agent image has multiple distros)
-7. `agent_image_ubuntu` the name of the ubuntu agent image.
-8. `agent_image_ubi` the name of the ubi agent image.
-9. `s3_bucket` the S3 bucket that Dockerfiles will be pushed to as part of the release process. Note: this is only required when running the release tasks locally.
+6. `agent_image` the name of the agent image.
+7. `s3_bucket` the S3 bucket that Dockerfiles will be pushed to as part of the release process. Note: this is only required when running the release tasks locally.
 
 
 You can set the `MONGODB_COMMUNITY_CONFIG` environment variable to be the absolute path of this file.

--- a/inventories/e2e-inventory.yaml
+++ b/inventories/e2e-inventory.yaml
@@ -7,7 +7,7 @@ images:
       context: .
       template_context: scripts/dev/templates
     inputs:
-      - e2e_image
+      - image
     platform: linux/arm64
     stages:
       - name: e2e-template
@@ -30,9 +30,9 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.version_id)-arm64
-          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: latest-arm64
 
   - name: e2e-amd64
@@ -40,7 +40,7 @@ images:
       context: .
       template_context: scripts/dev/templates
     inputs:
-      - e2e_image
+      - image
     platform: linux/amd64
     stages:
       - name: e2e-template
@@ -63,8 +63,8 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.version_id)-amd64
-          - registry: $(inputs.params.registry)/$(inputs.params.e2e_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: latest-amd64
 

--- a/inventories/operator-inventory.yaml
+++ b/inventories/operator-inventory.yaml
@@ -2,14 +2,14 @@ vars:
   registry: <registry>
 
 images:
-  - name: operator-ubi-amd64
+  - name: operator-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/operator
 
     inputs:
-      - operator_image
-      - operator_image_dev
+      - image
+      - image_dev
 
     platform: linux/amd64
 
@@ -29,7 +29,7 @@ images:
           quay.expires-after: 48h
 
         output:
-        - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+        - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
           tag: $(inputs.params.version_id)-context-amd64
 
       - name: operator-template-dev
@@ -51,15 +51,15 @@ images:
           - version_id
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image_dev):$(inputs.params.version_id)-context-amd64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-amd64
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-amd64
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: latest-amd64
 
 #
@@ -82,7 +82,7 @@ images:
           builder_image: $(inputs.params.builder_image)
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-context-amd64
 
       - name: operator-template-release
@@ -107,23 +107,23 @@ images:
         dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context-amd64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-amd64
 
         labels:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-amd64
 
-  - name: operator-ubi-arm64
+  - name: operator-arm64
     vars:
       context: .
       template_context: scripts/dev/templates/operator
 
     inputs:
-      - operator_image
-      - operator_image_dev
+      - image
+      - image_dev
 
     platform: linux/arm64
 
@@ -143,7 +143,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-context-arm64
 
       - name: operator-template-dev
@@ -165,15 +165,15 @@ images:
           - version_id
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image_dev):$(inputs.params.version_id)-context-arm64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-arm64
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-arm64
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: latest-arm64
 
       #
@@ -196,7 +196,7 @@ images:
           builder_image: $(inputs.params.builder_image)
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-context-arm64
 
       - name: operator-template-release
@@ -221,11 +221,11 @@ images:
         dockerfile: scripts/dev/templates/operator/Dockerfile.operator-$(inputs.params.release_version)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.operator_image):$(inputs.params.release_version)-context-arm64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-arm64
 
         labels:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.operator_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-arm64

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -2,129 +2,26 @@ vars:
   registry: <registry>
 
 images:
-  - name: agent-ubuntu
+
+  - name: agent-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/agent
 
     inputs:
-      - agent_version
+      - release_version
       - tools_version
-      - agent_image
-      - agent_image_dev
+      - image
+      - image_dev
 
     platform: linux/amd64
     stages:
-      - name: agent-ubuntu-context
-        task_type: docker_build
-        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
-        tags: [ "ubuntu" ]
-        buildargs:
-          agent_version: $(inputs.params.agent_version)
-          tools_version: $(inputs.params.tools_version)
-          agent_distro: linux_x86_64
-          tools_distro: ubuntu1604-x86_64
-
-        labels:
-          quay.expires-after: 48h
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: $(inputs.params.version_id)-context
-
-      - name: agent-template-ubuntu
-        task_type: dockerfile_template
-        tags: [ "ubuntu" ]
-        distro: ubuntu
-
-        output:
-          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubuntu-$(inputs.params.version_id)
-
-      - name: agent-ubuntu-build
-        task_type: docker_build
-        tags: [ "ubuntu" ]
-
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubuntu-$(inputs.params.version_id)
-
-        buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context
-          agent_version: $(inputs.params.agent_version)
-
-        labels:
-          quay.expires-after: 48h
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: $(inputs.params.version_id)
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: latest
-
-      - name: agent-template-ubuntu-s3
-        task_type: dockerfile_template
-        tags: [ "ubuntu", "release" ]
-        distro: ubuntu
-
-        inputs:
-          - release_version
-          - s3_bucket
-
-        output:
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-agent/$(inputs.params.release_version)/ubuntu/Dockerfile
-
-      - name: agent-context-ubuntu-release
-        task_type: docker_build
-        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
-        tags: [ "ubuntu", "release" ]
-        buildargs:
-          agent_version: $(inputs.params.agent_version)
-          tools_version: $(inputs.params.tools_version)
-          agent_distro: linux_x86_64
-          tools_distro: ubuntu1604-x86_64
-
-        labels:
-          quay.expires-after: Never
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)-context
-
-      - name: agent-ubuntu-release
-        task_type: docker_build
-        tags: [ "ubuntu", "release" ]
-        distro: ubuntu
-
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubuntu-$(inputs.params.version_id)
-
-        buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context
-          agent_version: $(inputs.params.agent_version)
-
-        labels:
-          quay.expires-after: Never
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)
-
-  - name: agent-ubi-amd64
-    vars:
-      context: .
-      template_context: scripts/dev/templates/agent
-
-    inputs:
-      - agent_version
-      - tools_version
-      - agent_image
-      - agent_image_dev
-
-    platform: linux/amd64
-    stages:
-      - name: agent-ubi-context
+      - name: mongodb-agent-context
         task_type: docker_build
         dockerfile: scripts/dev/templates/agent/Dockerfile.builder
         tags: [ "ubi" ]
         buildargs:
-          agent_version: $(inputs.params.agent_version)
+          agent_version: $(inputs.params.release_version)
           tools_version: $(inputs.params.tools_version)
           agent_distro: rhel7_x86_64
           tools_distro: rhel70-x86_64
@@ -133,7 +30,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-context-amd64
 
       - name: agent-template-ubi
@@ -144,23 +41,23 @@ images:
         output:
           - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
-      - name: agent-ubi-build
+      - name: mongodb-agent-build
         task_type: docker_build
         tags: [ "ubi" ]
 
         dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context-amd64
-          agent_version: $(inputs.params.agent_version)
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-amd64
+          agent_version: $(inputs.params.release_version)
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-amd64
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: latest-amd64
 
       - name: agent-template-ubi-s3
@@ -179,7 +76,7 @@ images:
         dockerfile: scripts/dev/templates/agent/Dockerfile.builder
         tags: [ "ubi", "release" ]
         buildargs:
-          agent_version: $(inputs.params.agent_version)
+          agent_version: $(inputs.params.release_version)
           tools_version: $(inputs.params.tools_version)
           agent_distro: rhel7_x86_64
           tools_distro: rhel70-x86_64
@@ -188,346 +85,346 @@ images:
           quay.expires-after: Never
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)-context-amd64
-
-      - name: agent-ubi-release
-        task_type: docker_build
-        tags: [ "ubi", "release" ]
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
-
-        buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context-amd64
-          agent_version: $(inputs.params.agent_version)
-
-        labels:
-          quay.expires-after: Never
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)-amd64
-
-  - name: agent-ubi-arm64
-    vars:
-      context: .
-      template_context: scripts/dev/templates/agent
-
-    inputs:
-      - agent_version
-      - tools_version
-      - agent_image
-      - agent_image_dev
-
-    platform: linux/arm64
-    stages:
-      - name: agent-ubi-context
-        task_type: docker_build
-        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
-        tags: [ "ubi" ]
-        buildargs:
-          agent_version: $(inputs.params.agent_version)
-          tools_version: $(inputs.params.tools_version)
-          agent_distro: amzn2_aarch64
-          tools_distro: rhel82-aarch64
-
-        labels:
-          quay.expires-after: 48h
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: $(inputs.params.version_id)-context-arm64
-
-      - name: agent-template-ubi
-        task_type: dockerfile_template
-        distro: ubi
-        tags: [ "ubi" ]
-
-        output:
-          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
-
-      - name: agent-ubi-build
-        task_type: docker_build
-        tags: [ "ubi" ]
-
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
-
-        buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image_dev):$(inputs.params.version_id)-context-arm64
-          agent_version: $(inputs.params.agent_version)
-
-        labels:
-          quay.expires-after: 48h
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: $(inputs.params.version_id)-arm64
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image_dev)
-            tag: latest-arm64
-
-      - name: agent-template-ubi-s3
-        task_type: dockerfile_template
-        tags: [ "ubi", "release" ]
-        distro: ubi
-
-        inputs:
-          - release_version
-
-        output:
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-agent/$(inputs.params.release_version)/ubi/Dockerfile
-
-      - name: agent-context-ubi-release
-        task_type: docker_build
-        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
-        tags: [ "ubi", "release" ]
-        buildargs:
-          agent_version: $(inputs.params.agent_version)
-          tools_version: $(inputs.params.tools_version)
-          agent_distro: amzn2_aarch64
-          tools_distro: rhel82-aarch64
-
-        labels:
-          quay.expires-after: Never
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)-context-arm64
-
-      - name: agent-ubi-release
-        task_type: docker_build
-        tags: [ "ubi", "release" ]
-        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
-
-        buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.agent_image):$(inputs.params.agent_version)-context-arm64
-          agent_version: $(inputs.params.agent_version)
-
-        labels:
-          quay.expires-after: Never
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.agent_image)
-            tag: $(inputs.params.agent_version)-arm64
-
-  - name: readiness-probe-init-amd64
-    vars:
-      context: .
-      template_context: scripts/dev/templates/readiness
-
-    inputs:
-      - readiness_probe_image
-      - readiness_probe_image_dev
-
-    platform: linux/amd64
-    stages:
-      - name: readiness-init-context-build
-        task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
-        tags: [ "readiness-probe", "ubi" ]
-        labels:
-          quay.expires-after: 48h
-
-        buildargs:
-          builder_image: $(inputs.params.builder_image)
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
-            tag: $(inputs.params.version_id)-context-amd64
-
-      - name: readiness-template-ubi
-        task_type: dockerfile_template
-        tags: [ "ubi" ]
-        template_file_extension: readiness
-
-        inputs:
-          - base_image
-
-        output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
-
-      - name: readiness-init-build
-        task_type: docker_build
-        tags: [ "readiness-probe", "ubi" ]
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
-
-        buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context-amd64
-
-
-        labels:
-          quay.expires-after: 48h
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
-            tag: $(inputs.params.version_id)-amd64
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
-            tag: latest-amd64
-
-      - name: readiness-init-context-release
-        task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
-        tags: [ "readiness-probe", "release" , "ubi" ]
-
-        labels:
-          quay.expires-after: Never
-
-        buildargs:
-          builder_image: $(inputs.params.builder_image)
-
-        inputs:
-          - release_version
-          - builder_image
-
-        output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-context-amd64
 
-      - name: readiness-template-release
-        task_type: dockerfile_template
-        tags: [ "readiness-probe", "release", "ubi" ]
-        template_file_extension: readiness
-        inputs:
-          - base_image
-          - release_version
-
-        output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
-
-      - name: readiness-init-build-release
+      - name: mongodb-agent-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
-        tags: [ "readiness-probe", "release" , "ubi" ]
+        tags: [ "ubi", "release" ]
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.release_version)-context-amd64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-amd64
+          agent_version: $(inputs.params.release_version)
 
         labels:
           quay.expires-after: Never
 
-        inputs:
-          - base_image
-          - release_version
-
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-amd64
 
-  - name: readiness-probe-init-arm64
+  - name: agent-arm64
     vars:
       context: .
-      template_context: scripts/dev/templates/readiness
+      template_context: scripts/dev/templates/agent
 
     inputs:
-      - readiness_probe_image
-      - readiness_probe_image_dev
+      - release_version
+      - tools_version
+      - image
+      - image_dev
 
     platform: linux/arm64
     stages:
-      - name: readiness-init-context-build
+      - name: mongodb-agent-context
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
-        tags: [ "readiness-probe", "ubi" ]
+        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
+        tags: [ "ubi" ]
+        buildargs:
+          agent_version: $(inputs.params.release_version)
+          tools_version: $(inputs.params.tools_version)
+          agent_distro: amzn2_aarch64
+          tools_distro: rhel82-aarch64
+
         labels:
           quay.expires-after: 48h
 
-        buildargs:
-          builder_image: $(inputs.params.builder_image)
-
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-context-arm64
 
-      - name: readiness-template-ubi
+      - name: agent-template-ubi
         task_type: dockerfile_template
+        distro: ubi
         tags: [ "ubi" ]
-        template_file_extension: readiness
-
-        inputs:
-          - base_image
 
         output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+          - dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
-      - name: readiness-init-build
+      - name: mongodb-agent-build
         task_type: docker_build
-        tags: [ "readiness-probe", "ubi" ]
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+        tags: [ "ubi" ]
+
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev):$(inputs.params.version_id)-context-arm64
-
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-arm64
+          agent_version: $(inputs.params.release_version)
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-arm64
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: latest-arm64
 
-      - name: readiness-init-context-release
+      - name: agent-template-ubi-s3
+        task_type: dockerfile_template
+        tags: [ "ubi", "release" ]
+        distro: ubi
+
+        inputs:
+          - release_version
+
+        output:
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-agent/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: agent-context-ubi-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
-        tags: [ "readiness-probe", "release" , "ubi" ]
+        dockerfile: scripts/dev/templates/agent/Dockerfile.builder
+        tags: [ "ubi", "release" ]
+        buildargs:
+          agent_version: $(inputs.params.release_version)
+          tools_version: $(inputs.params.tools_version)
+          agent_distro: amzn2_aarch64
+          tools_distro: rhel82-aarch64
 
         labels:
           quay.expires-after: Never
 
-        buildargs:
-          builder_image: $(inputs.params.builder_image)
-
-        inputs:
-          - release_version
-          - builder_image
-
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-context-arm64
 
-      - name: readiness-template-release
-        task_type: dockerfile_template
-        tags: [ "readiness-probe", "release", "ubi" ]
-        template_file_extension: readiness
-        inputs:
-          - base_image
-          - release_version
-
-        output:
-          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
-          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
-
-      - name: readiness-init-build-release
+      - name: mongodb-agent-release
         task_type: docker_build
-        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
-        tags: [ "readiness-probe", "release" , "ubi" ]
+        tags: [ "ubi", "release" ]
+        dockerfile: scripts/dev/templates/agent/Dockerfile.ubi-$(inputs.params.version_id)
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.readiness_probe_image):$(inputs.params.release_version)-context-arm64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-arm64
+          agent_version: $(inputs.params.release_version)
 
         labels:
           quay.expires-after: Never
 
-        inputs:
-          - base_image
-          - release_version
-
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.readiness_probe_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-arm64
 
-  - name: version-post-start-hook-init-amd64
+  - name: readiness-probe-amd64
+    vars:
+      context: .
+      template_context: scripts/dev/templates/readiness
+
+    inputs:
+      - image
+      - image_dev
+
+    platform: linux/amd64
+    stages:
+      - name: readiness-init-context-build
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
+        tags: [ "readiness-probe", "ubi" ]
+        labels:
+          quay.expires-after: 48h
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
+            tag: $(inputs.params.version_id)-context-amd64
+
+      - name: readiness-template-ubi
+        task_type: dockerfile_template
+        tags: [ "ubi" ]
+        template_file_extension: readiness
+
+        inputs:
+          - base_image
+
+        output:
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+
+      - name: readiness-init-build
+        task_type: docker_build
+        tags: [ "readiness-probe", "ubi" ]
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-amd64
+
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
+            tag: $(inputs.params.version_id)-amd64
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
+            tag: latest-amd64
+
+      - name: readiness-init-context-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
+        tags: [ "readiness-probe", "release" , "ubi" ]
+
+        labels:
+          quay.expires-after: Never
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        inputs:
+          - release_version
+          - builder_image
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
+            tag: $(inputs.params.release_version)-context-amd64
+
+      - name: readiness-template-release
+        task_type: dockerfile_template
+        tags: [ "readiness-probe", "release", "ubi" ]
+        template_file_extension: readiness
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: readiness-init-build-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
+        tags: [ "readiness-probe", "release" , "ubi" ]
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-amd64
+
+        labels:
+          quay.expires-after: Never
+
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
+            tag: $(inputs.params.release_version)-amd64
+
+  - name: readiness-probe-arm64
+    vars:
+      context: .
+      template_context: scripts/dev/templates/readiness
+
+    inputs:
+      - image
+      - image_dev
+
+    platform: linux/arm64
+    stages:
+      - name: readiness-init-context-build
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
+        tags: [ "readiness-probe", "ubi" ]
+        labels:
+          quay.expires-after: 48h
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
+            tag: $(inputs.params.version_id)-context-arm64
+
+      - name: readiness-template-ubi
+        task_type: dockerfile_template
+        tags: [ "ubi" ]
+        template_file_extension: readiness
+
+        inputs:
+          - base_image
+
+        output:
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+
+      - name: readiness-init-build
+        task_type: docker_build
+        tags: [ "readiness-probe", "ubi" ]
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.version_id)
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-arm64
+
+
+        labels:
+          quay.expires-after: 48h
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
+            tag: $(inputs.params.version_id)-arm64
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
+            tag: latest-arm64
+
+      - name: readiness-init-context-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.builder
+        tags: [ "readiness-probe", "release" , "ubi" ]
+
+        labels:
+          quay.expires-after: Never
+
+        buildargs:
+          builder_image: $(inputs.params.builder_image)
+
+        inputs:
+          - release_version
+          - builder_image
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
+            tag: $(inputs.params.release_version)-context-arm64
+
+      - name: readiness-template-release
+        task_type: dockerfile_template
+        tags: [ "readiness-probe", "release", "ubi" ]
+        template_file_extension: readiness
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
+          - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-readinessprobe/$(inputs.params.release_version)/ubi/Dockerfile
+
+      - name: readiness-init-build-release
+        task_type: docker_build
+        dockerfile: scripts/dev/templates/readiness/Dockerfile.readiness-$(inputs.params.release_version)
+        tags: [ "readiness-probe", "release" , "ubi" ]
+
+        buildargs:
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-arm64
+
+        labels:
+          quay.expires-after: Never
+
+        inputs:
+          - base_image
+          - release_version
+
+        output:
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
+            tag: $(inputs.params.release_version)-arm64
+
+  - name: version-upgrade-hook-amd64
     vars:
       context: .
       template_context: scripts/dev/templates/versionhook
 
     inputs:
-      - version_post_start_hook_image
-      - version_post_start_hook_image_dev
+      - image
+      - image_dev
 
     platform: linux/amd64
     stages:
-      - name: version-post-start-hook-init-context-build
+      - name: version-upgrade-hook-context-build
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.builder
         tags: [ "post-start-hook", "ubi" ]
@@ -539,7 +436,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-context-amd64
 
       - name: version-post-start-hook-template-ubi
@@ -553,24 +450,24 @@ images:
         output:
           - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
 
-      - name: version-post-start-hook-init-build
+      - name: version-upgrade-hook-build
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
         tags: [ "post-start-hook", "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev):$(inputs.params.version_id)-context-amd64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-amd64
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-amd64
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: latest-amd64
 
-      - name: version-post-start-hook-init-context-release
+      - name: version-upgrade-hook-context-release
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.builder
         tags: [ "release", "post-start-hook",  "ubi", ]
@@ -586,7 +483,7 @@ images:
           - builder_image
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-context-amd64
 
       - name: versionhook-template-release
@@ -601,13 +498,13 @@ images:
           - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
 
-      - name: version-post-start-hook-init-build-release
+      - name: version-upgrade-hook-build-release
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
         tags: [ "release", "post-start-hook",  "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.release_version)-context-amd64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-amd64
 
         labels:
           quay.expires-after: Never
@@ -617,21 +514,21 @@ images:
           - release_version
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-amd64
 
-  - name: version-post-start-hook-init-arm64
+  - name: version-upgrade-hook-arm64
     vars:
       context: .
       template_context: scripts/dev/templates/versionhook
 
     inputs:
-      - version_post_start_hook_image
-      - version_post_start_hook_image_dev
+      - image
+      - image_dev
 
     platform: linux/arm64
     stages:
-      - name: version-post-start-hook-init-context-build
+      - name: version-upgrade-hook-context-build
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.builder
         tags: [ "post-start-hook", "ubi" ]
@@ -643,7 +540,7 @@ images:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-context-arm64
 
       - name: version-post-start-hook-template-ubi
@@ -657,24 +554,24 @@ images:
         output:
           - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
 
-      - name: version-post-start-hook-init-build
+      - name: version-upgrade-hook-build
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.version_id)
         tags: [ "post-start-hook", "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev):$(inputs.params.version_id)-context-arm64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image_dev):$(inputs.params.version_id)-context-arm64
 
         labels:
           quay.expires-after: 48h
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: $(inputs.params.version_id)-arm64
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image_dev)
+          - registry: $(inputs.params.registry)/$(inputs.params.image_dev)
             tag: latest-arm64
 
-      - name: version-post-start-hook-init-context-release
+      - name: version-upgrade-hook-context-release
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.builder
         tags: [ "release", "post-start-hook",  "ubi", ]
@@ -690,7 +587,7 @@ images:
           - builder_image
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-context-arm64
 
       - name: versionhook-template-release
@@ -705,13 +602,13 @@ images:
           - dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
           - dockerfile: $(inputs.params.s3_bucket)/mongodb-kubernetes-operator-version-upgrade-post-start-hook/$(inputs.params.release_version)/ubi/Dockerfile
 
-      - name: version-post-start-hook-init-build-release
+      - name: version-upgrade-hook-build-release
         task_type: docker_build
         dockerfile: scripts/dev/templates/versionhook/Dockerfile.versionhook-$(inputs.params.release_version)
         tags: [ "release", "post-start-hook",  "ubi" ]
 
         buildargs:
-          imagebase: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image):$(inputs.params.release_version)-context-arm64
+          imagebase: $(inputs.params.registry)/$(inputs.params.image):$(inputs.params.release_version)-context-arm64
 
         labels:
           quay.expires-after: Never
@@ -721,5 +618,5 @@ images:
           - release_version
 
         output:
-          - registry: $(inputs.params.registry)/$(inputs.params.version_post_start_hook_image)
+          - registry: $(inputs.params.registry)/$(inputs.params.image)
             tag: $(inputs.params.release_version)-arm64

--- a/pipeline.py
+++ b/pipeline.py
@@ -120,7 +120,7 @@ def push_manifest(
     final_manifest = "{0}/{1}:{2}".format(config.repo_url, image_name, image_tag)
     remove_args = ["docker", "manifest", "rm", final_manifest]
     print("Removing existing manifest")
-    run_cli_command(remove_args, raise_exception=False)
+    run_cli_command(remove_args, fail_on_error=False)
 
     create_args = [
         "docker",
@@ -140,8 +140,8 @@ def push_manifest(
     run_cli_command(push_args)
 
 
-# Raises exceptions by default but this can be deactivated
-def run_cli_command(args: List[str], raise_exception: bool = True):
+# Raises exceptions by default
+def run_cli_command(args: List[str], fail_on_error: bool = True):
     command = " ".join(args)
     print(f"Running: {command}")
     try:
@@ -153,8 +153,8 @@ def run_cli_command(args: List[str], raise_exception: bool = True):
             check=False,
         )
     except Exception as e:
-        print(f"Error executing command: {e}")
-        if raise_exception:
+        print(f" Command raised the following exception: {e}")
+        if fail_on_error:
             raise Exception
         else:
             print("Continuing...")
@@ -166,7 +166,7 @@ def run_cli_command(args: List[str], raise_exception: bool = True):
         print(f"Error running command")
         print(f"stdout:\n{stdout}")
         print(f"stderr:\n{error_msg}")
-        if raise_exception:
+        if fail_on_error:
             raise Exception
         else:
             print("Continuing...")

--- a/pipeline.py
+++ b/pipeline.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from typing import Dict, List, Set
 
-from scripts.dev.dev_config import load_config
+from scripts.dev.dev_config import load_config, DevConfig
 from sonar.sonar import process_image
 
 # These image names must correspond to prefixes in release.json, developer configuration and inventories
@@ -22,7 +22,7 @@ def load_release() -> Dict:
         return json.load(f)
 
 
-def build_image_args(config, image_name: str) -> Dict[str, str]:
+def build_image_args(config: DevConfig, image_name: str) -> Dict[str, str]:
     release = load_release()
 
     # Naming in pipeline : readiness-probe, naming in dev config : readiness_probe_image
@@ -61,7 +61,7 @@ def build_image_args(config, image_name: str) -> Dict[str, str]:
     return arguments
 
 
-def build_and_push_image(image_name: str, config, args: Dict[str, str], architectures: Set[str], should_push: bool):
+def build_and_push_image(image_name: str, config: DevConfig, args: Dict[str, str], architectures: Set[str], should_push: bool):
     for arch in architectures:
         image_tag = f"{image_name}-{arch}"
         process_image(
@@ -86,7 +86,7 @@ docker manifest push config.repo_url/image:tag
 """
 
 
-def push_manifest(config, image_tag: str):
+def push_manifest(config: DevConfig, image_tag: str):
     print(f"Pushing manifest for {image_tag}")
     final_manifest = "{0}/{1}".format(config.repo_url, image_tag)
     args = ["docker", "manifest", "rm", final_manifest]
@@ -145,7 +145,7 @@ def main() -> int:
     )
     args = parser.parse_args()
     image_name = args.image_name
-    config = load_config()
+    config: DevConfig = load_config()
 
     if args.arch:
         arch_set = set(args.arch)

--- a/pipeline.py
+++ b/pipeline.py
@@ -216,7 +216,9 @@ def main() -> int:
 
     # Warn user if trying to release E2E tests
     if args.release and image_name == "e2e":
-        print("Warning : releasing E2E test will fail because E2E image has no release version")
+        print(
+            "Warning : releasing E2E test will fail because E2E image has no release version"
+        )
 
     # Skipping release tasks by default
     if not args.release:

--- a/pipeline.py
+++ b/pipeline.py
@@ -83,6 +83,9 @@ def build_and_push_image(
         push_manifest(config, architectures, args["image_dev"])
         if config.gh_run_id is not None and config.gh_run_id != "":
             push_manifest(config, architectures, args["image_dev"], config.gh_run_id)
+    else:
+        # If no image dev (only e2e is concerned) we push the manifest anyway
+        push_manifest(config, architectures, args["image"])
 
     if release:
         push_manifest(config, architectures, args["image"], args["release_version"])

--- a/pipeline.py
+++ b/pipeline.py
@@ -195,9 +195,21 @@ Many parameters are defined in the dev configuration, default path is : ~/.commu
 
 def main() -> int:
     args = _parse_args()
+
     image_name = args.image_name
+    if image_name not in VALID_IMAGE_NAMES:
+        print(
+            f"Invalid image name: {image_name}. Valid options are: {VALID_IMAGE_NAMES}"
+        )
+        return 1
+
+    # Handle dev config
     config: DevConfig = load_config()
     config.gh_run_id = args.tag
+    # Must explicitly set the --release flag to run these tasks
+    config.ensure_skip_tag("release")
+    if args.release:
+        config.ensure_tag_is_run("release")
 
     if args.arch:
         arch_set = set(args.arch)
@@ -205,12 +217,6 @@ def main() -> int:
         # Default is multi-arch
         arch_set = ["amd64", "arm64"]
     print("Building for architectures:", ", ".join(map(str, arch_set)))
-
-    if image_name not in VALID_IMAGE_NAMES:
-        print(
-            f"Invalid image name: {image_name}. Valid options are: {VALID_IMAGE_NAMES}"
-        )
-        return 1
 
     image_args = build_image_args(config, image_name)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -214,6 +214,10 @@ def main() -> int:
     config: DevConfig = load_config()
     config.gh_run_id = args.tag
 
+    # Warn user if trying to release E2E tests
+    if args.release and image_name == "e2e":
+        print("Warning : releasing E2E test will fail because E2E image has no release version")
+
     # Skipping release tasks by default
     if not args.release:
         config.ensure_skip_tag("release")

--- a/pipeline.py
+++ b/pipeline.py
@@ -52,6 +52,7 @@ def build_image_args(config: DevConfig, image_name: str) -> Dict[str, str]:
         arguments["inventory"] = "inventories/operator-inventory.yaml"
 
     if image_name == "e2e":
+        arguments.pop("builder", None)
         arguments["base_image"] = release["golang-builder-image"]
         arguments["inventory"] = "inventories/e2e-inventory.yaml"
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -42,7 +42,6 @@ def build_image_args(config: DevConfig, image_name: str) -> Dict[str, str]:
         "builder_image": release["golang-builder-image"],
         "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
         "inventory": "inventory.yaml",
-        # These two options below can probably be removed
         "skip_tags": config.skip_tags,  # Include skip_tags
         "include_tags": config.include_tags,  # Include include_tags
     }
@@ -214,12 +213,10 @@ def main() -> int:
     # Handle dev config
     config: DevConfig = load_config()
     config.gh_run_id = args.tag
-    # TODO fix usage of 'ensure skip' and 'ensure is run', is it useful ? Do we need to explicitly use "ubi" tag everywhere as in the old pipeline ?
 
-    # Must explicitly set the --release flag to run these tasks
-    #config.ensure_skip_tag("release")
-    #if args.release:
-    #    config.ensure_tag_is_run("release")
+    # Skipping release tasks by default
+    if not args.release:
+        config.ensure_skip_tag("release")
 
     if args.arch:
         arch_set = set(args.arch)

--- a/pipeline.py
+++ b/pipeline.py
@@ -79,9 +79,10 @@ def build_and_push_image(
             include_tags=args["include_tags"],
         )
 
-    push_manifest(config, architectures, args["image_dev"])
-    if config.gh_run_id is not None and config.gh_run_id != "":
-        push_manifest(config, architectures, args["image_dev"], config.gh_run_id)
+    if args["image_dev"]:
+        push_manifest(config, architectures, args["image_dev"])
+        if config.gh_run_id is not None and config.gh_run_id != "":
+            push_manifest(config, architectures, args["image_dev"], config.gh_run_id)
 
     if release:
         push_manifest(config, architectures, args["image"], args["release_version"])

--- a/pipeline.py
+++ b/pipeline.py
@@ -80,12 +80,17 @@ def build_and_push_image(
         )
 
     if args["image_dev"]:
-        push_manifest(config, architectures, args["image_dev"])
-        if config.gh_run_id is not None and config.gh_run_id != "":
-            push_manifest(config, architectures, args["image_dev"], config.gh_run_id)
+        image_to_push = args["image_dev"]
+    elif image_name == "e2e":
+        # If no image dev (only e2e is concerned) we push the normal image
+        image_to_push = args["image"]
     else:
-        # If no image dev (only e2e is concerned) we push the manifest anyway
-        push_manifest(config, architectures, args["image"])
+        raise Exception("Dev image must be specified")
+
+    push_manifest(config, architectures, image_to_push)
+    
+    if config.gh_run_id:
+        push_manifest(config, architectures, image_to_push, config.gh_run_id)
 
     if release:
         push_manifest(config, architectures, args["image"], args["release_version"])

--- a/pipeline.py
+++ b/pipeline.py
@@ -44,7 +44,7 @@ def build_image_args(config: DevConfig, image_name: str) -> Dict[str, str]:
         "inventory": "inventory.yaml",
         # These two options below can probably be removed
         "skip_tags": config.skip_tags,  # Include skip_tags
-        "include_tags": config.include_tags  # Include include_tags
+        "include_tags": config.include_tags,  # Include include_tags
     }
 
     # Handle special cases
@@ -61,8 +61,13 @@ def build_image_args(config: DevConfig, image_name: str) -> Dict[str, str]:
     return arguments
 
 
-def build_and_push_image(image_name: str, config: DevConfig, args: Dict[str, str], architectures: Set[str],
-                         release: bool):
+def build_and_push_image(
+    image_name: str,
+    config: DevConfig,
+    args: Dict[str, str],
+    architectures: Set[str],
+    release: bool,
+):
     for arch in architectures:
         image_tag = f"{image_name}-{arch}"
         process_image(
@@ -70,13 +75,15 @@ def build_and_push_image(image_name: str, config: DevConfig, args: Dict[str, str
             build_args=args,
             inventory=args["inventory"],
             skip_tags=args["skip_tags"],
-            include_tags=args["include_tags"]
+            include_tags=args["include_tags"],
         )
     if release:
         # TODO : is the release with gh_run_id still needed ?
         push_manifest(config, architectures, args["image_dev"])
         push_manifest(config, architectures, args["image"], args["release_version"])
-        push_manifest(config, architectures, args["image"], args["release_version"] + "-context")
+        push_manifest(
+            config, architectures, args["image"], args["release_version"] + "-context"
+        )
 
 
 """
@@ -90,7 +97,12 @@ docker manifest push config.repo_url/image:tag
 """
 
 
-def push_manifest(config: DevConfig, architectures: Set[str], image_name: str, image_tag: str = "latest"):
+def push_manifest(
+    config: DevConfig,
+    architectures: Set[str],
+    image_name: str,
+    image_tag: str = "latest",
+):
     print(f"Pushing manifest for {image_tag}")
     final_manifest = "{0}/{1}:{2}".format(config.repo_url, image_name, image_tag)
     remove_args = ["docker", "manifest", "rm", final_manifest]
@@ -120,7 +132,13 @@ def run_cli_command(args: List[str], raise_exception: bool = True):
     command = " ".join(args)
     print(f"Running: {command}")
     try:
-        cp = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, check=False)
+        cp = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            check=False,
+        )
     except Exception as e:
         print(f"Error executing command: {e}")
         if raise_exception:
@@ -175,10 +193,12 @@ def main() -> int:
     else:
         # Default is multi-arch
         arch_set = ["amd64", "arm64"]
-    print("Building for architectures:", ', '.join(map(str, arch_set)))
+    print("Building for architectures:", ", ".join(map(str, arch_set)))
 
     if image_name not in VALID_IMAGE_NAMES:
-        print(f"Invalid image name: {image_name}. Valid options are: {VALID_IMAGE_NAMES}")
+        print(
+            f"Invalid image name: {image_name}. Valid options are: {VALID_IMAGE_NAMES}"
+        )
         return 1
 
     image_args = build_image_args(config, image_name)

--- a/pipeline.py
+++ b/pipeline.py
@@ -214,10 +214,12 @@ def main() -> int:
     # Handle dev config
     config: DevConfig = load_config()
     config.gh_run_id = args.tag
+    # TODO fix usage of 'ensure skip' and 'ensure is run', is it useful ? Do we need to explicitly use "ubi" tag everywhere as in the old pipeline ?
+
     # Must explicitly set the --release flag to run these tasks
-    config.ensure_skip_tag("release")
-    if args.release:
-        config.ensure_tag_is_run("release")
+    #config.ensure_skip_tag("release")
+    #if args.release:
+    #    config.ensure_tag_is_run("release")
 
     if args.arch:
         arch_set = set(args.arch)

--- a/pipeline.py
+++ b/pipeline.py
@@ -61,7 +61,8 @@ def build_image_args(config: DevConfig, image_name: str) -> Dict[str, str]:
     return arguments
 
 
-def build_and_push_image(image_name: str, config: DevConfig, args: Dict[str, str], architectures: Set[str], release: bool):
+def build_and_push_image(image_name: str, config: DevConfig, args: Dict[str, str], architectures: Set[str],
+                         release: bool):
     for arch in architectures:
         image_tag = f"{image_name}-{arch}"
         process_image(
@@ -101,7 +102,7 @@ def push_manifest(config: DevConfig, architectures: Set[str], image_name: str, i
         "manifest",
         "create",
         final_manifest,
-        ]
+    ]
 
     for arch in architectures:
         create_args.extend(["--amend", final_manifest + "-" + arch])

--- a/pipeline.py
+++ b/pipeline.py
@@ -88,7 +88,7 @@ def build_and_push_image(
         raise Exception("Dev image must be specified")
 
     push_manifest(config, architectures, image_to_push)
-    
+
     if config.gh_run_id:
         push_manifest(config, architectures, image_to_push, config.gh_run_id)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,273 +1,78 @@
 import argparse
 import json
-import sys
 import subprocess
-from typing import Dict, Optional
+import sys
+from typing import Dict, List, Set
 
+from scripts.dev.dev_config import load_config
 from sonar.sonar import process_image
 
-from scripts.dev.dev_config import load_config, DevConfig
-
-VALID_IMAGE_NAMES = frozenset(
-    [
-        "agent-ubi",
-        "agent-ubuntu",
-        "readiness-probe-init",
-        "version-post-start-hook-init",
-        "operator-ubi",
-        "e2e",
-    ]
-)
-
-DEFAULT_IMAGE_TYPE = "ubi"
-DEFAULT_NAMESPACE = "default"
+# These image names must correspond to prefixes in release.json, developer configuration and inventories
+VALID_IMAGE_NAMES = {
+    "agent",
+    "readiness-probe",
+    "version-upgrade-hook",
+    "operator",
+    "e2e",
+}
 
 
-def _load_release() -> Dict:
+def load_release() -> Dict:
     with open("release.json") as f:
-        release = json.loads(f.read())
-    return release
+        return json.load(f)
 
 
-def _build_agent_args(config: DevConfig) -> Dict[str, str]:
-    release = _load_release()
-    return {
-        "agent_version": release["mongodb-agent"]["version"],
-        "release_version": release["mongodb-agent"]["version"],
-        "tools_version": release["mongodb-agent"]["tools_version"],
-        "agent_image": config.agent_image,
-        "agent_image_dev": config.agent_dev_image,
+def build_image_args(config, image_name: str) -> Dict[str, str]:
+    release = load_release()
+
+    # Naming in pipeline : readiness-probe, naming in dev config : readiness_probe_image
+    image_name_prefix = image_name.replace("-", "_")
+
+    # Default config
+    arguments = {
+        "builder": "true",
+        # Defaults to "" if empty, e2e has no release version
+        "release_version": release.get(image_name, ""),
+        "tools_version": "",
+        "image": getattr(config, f"{image_name_prefix}_image"),
+        # Defaults to "" if empty, e2e has no dev image
+        "image_dev": getattr(config, f"{image_name_prefix}_image_dev", ""),
         "registry": config.repo_url,
         "s3_bucket": config.s3_bucket,
+        "builder_image": release["golang-builder-image"],
+        "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
+        "inventory": "inventory.yaml",
+        # These two options below can probably be removed
+        "skip_tags": config.skip_tags,  # Include skip_tags
+        "include_tags": config.include_tags  # Include include_tags
     }
 
+    # Handle special cases
+    if image_name == "operator":
+        arguments["inventory"] = "inventories/operator-inventory.yaml"
 
-def build_agent_image_ubi(config: DevConfig) -> None:
-    args = _build_agent_args(config)
-    args["agent_image"] = config.agent_image_ubi
-    args["agent_image_dev"] = config.agent_dev_image_ubi
-    config.ensure_tag_is_run("ubi")
+    if image_name == "e2e":
+        arguments["base_image"] = release["golang-builder-image"]
+        arguments["inventory"] = "inventories/e2e-inventory.yaml"
 
-    sonar_build_image(
-        "agent-ubi-amd64",
-        config,
-        args=args,
-    )
-    sonar_build_image(
-        "agent-ubi-arm64",
-        config,
-        args=args,
-    )
+    if image_name == "agent":
+        arguments["tools_version"] = release["agent-tools-version"]
 
-    create_and_push_manifest(config, config.agent_dev_image_ubi)
+    return arguments
 
-    if config.gh_run_id is not None and config.gh_run_id != "":
-        create_and_push_manifest(config, config.agent_dev_image_ubi, config.gh_run_id)
 
-    if "release" in config.include_tags:
-        create_and_push_manifest(config, config.agent_image_ubi, args["agent_version"])
-        create_and_push_manifest(
-            config, config.agent_image_ubi, args["agent_version"] + "-context"
+def build_and_push_image(image_name: str, config, args: Dict[str, str], architectures: Set[str], should_push: bool):
+    for arch in architectures:
+        image_tag = f"{image_name}-{arch}"
+        process_image(
+            image_tag,
+            build_args=args,
+            inventory=args["inventory"],
+            skip_tags=args["skip_tags"],
+            include_tags=args["include_tags"]
         )
-
-
-def build_agent_image_ubuntu(config: DevConfig) -> None:
-    image_name = "agent-ubuntu"
-    args = _build_agent_args(config)
-    args["agent_image"] = config.agent_image_ubuntu
-    args["agent_image_dev"] = config.agent_dev_image_ubuntu
-    config.ensure_tag_is_run("ubuntu")
-
-    sonar_build_image(
-        image_name,
-        config,
-        args=args,
-    )
-
-
-def build_readiness_probe_image(config: DevConfig) -> None:
-    release = _load_release()
-    config.ensure_tag_is_run("readiness-probe")
-    config.ensure_tag_is_run("ubi")
-
-    sonar_build_image(
-        "readiness-probe-init-amd64",
-        config,
-        args={
-            "builder": "true",
-            "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-            "registry": config.repo_url,
-            "release_version": release["readiness-probe"],
-            "readiness_probe_image": config.readiness_probe_image,
-            "readiness_probe_image_dev": config.readiness_probe_image_dev,
-            "builder_image": release["golang-builder-image"],
-            "s3_bucket": config.s3_bucket,
-        },
-    )
-
-    sonar_build_image(
-        "readiness-probe-init-arm64",
-        config,
-        args={
-            "builder": "true",
-            "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-            "registry": config.repo_url,
-            "release_version": release["readiness-probe"],
-            "readiness_probe_image": config.readiness_probe_image,
-            "readiness_probe_image_dev": config.readiness_probe_image_dev,
-            "builder_image": release["golang-builder-image"],
-            "s3_bucket": config.s3_bucket,
-        },
-    )
-
-    create_and_push_manifest(config, config.readiness_probe_image_dev)
-
-    if config.gh_run_id is not None and config.gh_run_id != "":
-        create_and_push_manifest(
-            config, config.readiness_probe_image_dev, config.gh_run_id
-        )
-
-    if "release" in config.include_tags:
-        create_and_push_manifest(
-            config, config.readiness_probe_image, release["readiness-probe"]
-        )
-        create_and_push_manifest(
-            config,
-            config.readiness_probe_image,
-            release["readiness-probe"] + "-context",
-        )
-
-
-def build_version_post_start_hook_image(config: DevConfig) -> None:
-    release = _load_release()
-    config.ensure_tag_is_run("post-start-hook")
-    config.ensure_tag_is_run("ubi")
-
-    sonar_build_image(
-        "version-post-start-hook-init-amd64",
-        config,
-        args={
-            "builder": "true",
-            "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-            "registry": config.repo_url,
-            "release_version": release["version-upgrade-hook"],
-            "version_post_start_hook_image": config.version_upgrade_hook_image,
-            "version_post_start_hook_image_dev": config.version_upgrade_hook_image_dev,
-            "builder_image": release["golang-builder-image"],
-            "s3_bucket": config.s3_bucket,
-        },
-    )
-
-    sonar_build_image(
-        "version-post-start-hook-init-arm64",
-        config,
-        args={
-            "builder": "true",
-            "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-            "registry": config.repo_url,
-            "release_version": release["version-upgrade-hook"],
-            "version_post_start_hook_image": config.version_upgrade_hook_image,
-            "version_post_start_hook_image_dev": config.version_upgrade_hook_image_dev,
-            "builder_image": release["golang-builder-image"],
-            "s3_bucket": config.s3_bucket,
-        },
-    )
-
-    create_and_push_manifest(config, config.version_upgrade_hook_image_dev)
-
-    if config.gh_run_id is not None and config.gh_run_id != "":
-        create_and_push_manifest(
-            config, config.version_upgrade_hook_image_dev, config.gh_run_id
-        )
-
-    if "release" in config.include_tags:
-        create_and_push_manifest(
-            config, config.version_upgrade_hook_image, release["version-upgrade-hook"]
-        )
-        create_and_push_manifest(
-            config,
-            config.version_upgrade_hook_image,
-            release["version-upgrade-hook"] + "-context",
-        )
-
-
-def build_operator_ubi_image(config: DevConfig) -> None:
-    release = _load_release()
-    config.ensure_tag_is_run("ubi")
-    sonar_build_image(
-        "operator-ubi-amd64",
-        config,
-        args={
-            "registry": config.repo_url,
-            "builder": "true",
-            "builder_image": release["golang-builder-image"],
-            "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-            "operator_image": config.operator_image,
-            "operator_image_dev": config.operator_image_dev,
-            "release_version": release["mongodb-kubernetes-operator"],
-            "s3_bucket": config.s3_bucket,
-        },
-        inventory="inventories/operator-inventory.yaml",
-    )
-    sonar_build_image(
-        "operator-ubi-arm64",
-        config,
-        args={
-            "registry": config.repo_url,
-            "builder": "true",
-            "builder_image": release["golang-builder-image"],
-            "base_image": "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-            "operator_image": config.operator_image,
-            "operator_image_dev": config.operator_image_dev,
-            "release_version": release["mongodb-kubernetes-operator"],
-            "s3_bucket": config.s3_bucket,
-        },
-        inventory="inventories/operator-inventory.yaml",
-    )
-
-    create_and_push_manifest(config, config.operator_image_dev)
-
-    if config.gh_run_id is not None and config.gh_run_id != "":
-        create_and_push_manifest(config, config.operator_image_dev, config.gh_run_id)
-
-    if "release" in config.include_tags:
-        create_and_push_manifest(
-            config, config.operator_image, release["mongodb-kubernetes-operator"]
-        )
-        create_and_push_manifest(
-            config,
-            config.operator_image,
-            release["mongodb-kubernetes-operator"] + "-context",
-        )
-
-
-def build_e2e_image(config: DevConfig) -> None:
-    release = _load_release()
-    sonar_build_image(
-        "e2e-arm64",
-        config,
-        args={
-            "registry": config.repo_url,
-            "base_image": release["golang-builder-image"],
-            "e2e_image": config.e2e_image,
-        },
-        inventory="inventories/e2e-inventory.yaml",
-    )
-    sonar_build_image(
-        "e2e-amd64",
-        config,
-        args={
-            "registry": config.repo_url,
-            "base_image": release["golang-builder-image"],
-            "e2e_image": config.e2e_image,
-        },
-        inventory="inventories/e2e-inventory.yaml",
-    )
-
-    create_and_push_manifest(config, config.e2e_image)
-
-    if config.gh_run_id is not None and config.gh_run_id != "":
-        create_and_push_manifest(config, config.e2e_image, config.gh_run_id)
+        if should_push:
+            push_manifest(config, image_tag)
 
 
 """
@@ -281,14 +86,12 @@ docker manifest push config.repo_url/image:tag
 """
 
 
-def create_and_push_manifest(
-    config: DevConfig, image: str, tag: str = "latest"
-) -> None:
-    final_manifest = "{0}/{1}:{2}".format(config.repo_url, image, tag)
+def push_manifest(config, image_tag: str):
+    print(f"Pushing manifest for {image_tag}")
+    final_manifest = "{0}/{1}".format(config.repo_url, image_tag)
     args = ["docker", "manifest", "rm", final_manifest]
-    args_str = " ".join(args)
-    print(f"removing existing manifest: {args_str}")
-    subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print("removing existing manifest")
+    run_cli_command(args, raise_exception=False)
 
     args = [
         "docker",
@@ -299,79 +102,66 @@ def create_and_push_manifest(
         final_manifest + "-amd64",
         "--amend",
         final_manifest + "-arm64",
-    ]
-    args_str = " ".join(args)
-    print(f"creating new manifest: {args_str}")
-    cp = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    if cp.returncode != 0:
-        raise Exception(cp.stderr)
+        ]
+    print("creating new manifest")
+    run_cli_command(args)
 
     args = ["docker", "manifest", "push", final_manifest]
-    args_str = " ".join(args)
-    print(f"pushing new manifest: {args_str}")
-    cp = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print("pushing new manifest")
+    run_cli_command(args)
 
-    if cp.returncode != 0:
+
+def run_cli_command(args: List[str], raise_exception: bool = True):
+    command = " ".join(args)
+    print(f"Running: {command} ...")
+    cp = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if cp.returncode != 0 and raise_exception:
         raise Exception(cp.stderr)
 
 
-def sonar_build_image(
-    image_name: str,
-    config: DevConfig,
-    args: Optional[Dict[str, str]] = None,
-    inventory: str = "inventory.yaml",
-) -> None:
-    """Calls sonar to build `image_name` with arguments defined in `args`."""
-    process_image(
-        image_name,
-        build_args=args,
-        inventory=inventory,
-        include_tags=config.include_tags,
-        skip_tags=config.skip_tags,
-    )
+"""
+Takes arguments:
+--image-name : The name of the image to build, must be one of VALID_IMAGE_NAMES
+--release : We push the image to the registry only if this flag is set
+--architecture : List of architectures to build for the image
 
+Run with --help for more information
+Example usage : `python pipeline.py --image-name agent --release`
 
-def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--image-name", type=str)
-    parser.add_argument("--release", type=lambda x: x.lower() == "true")
-    parser.add_argument("--tag", type=str)
-    return parser.parse_args()
+Builds and push the docker image to the registry
+Many parameters are defined in the dev configuration, default path is : ~/.community-operator-dev/config.json
+"""
 
 
 def main() -> int:
-    args = _parse_args()
-
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image-name", type=str)
+    parser.add_argument("--release", action="store_true", default=False)
+    parser.add_argument(
+        "--arch",
+        choices=["amd64", "arm64"],
+        nargs="+",
+        help="for daily builds only, specify the list of architectures to build for images",
+    )
+    args = parser.parse_args()
     image_name = args.image_name
-    if image_name not in VALID_IMAGE_NAMES:
-        print(
-            f"Image name [{image_name}] is not valid. Must be one of [{', '.join(VALID_IMAGE_NAMES)}]"
-        )
-        return 1
-
     config = load_config()
 
-    # by default we do not want to run any release tasks. We must explicitly
-    # use the --release flag to run them.
-    config.ensure_skip_tag("release")
+    if args.arch:
+        arch_set = set(args.arch)
+    else:
+        # Default is multi-arch
+        arch_set = ["amd64", "arm64"]
+    print("Building for architectures:", ', '.join(map(str, arch_set)))
 
-    config.gh_run_id = args.tag
+    if image_name not in VALID_IMAGE_NAMES:
+        print(f"Invalid image name: {image_name}. Valid options are: {VALID_IMAGE_NAMES}")
+        return 1
 
-    # specify --release to release the image
-    if args.release:
-        config.ensure_tag_is_run("release")
+    image_args = build_image_args(config, image_name)
+    should_push = args.release
 
-    image_build_function = {
-        "agent-ubi": build_agent_image_ubi,
-        "agent-ubuntu": build_agent_image_ubuntu,
-        "readiness-probe-init": build_readiness_probe_image,
-        "version-post-start-hook-init": build_version_post_start_hook_image,
-        "operator-ubi": build_operator_ubi_image,
-        "e2e": build_e2e_image,
-    }[image_name]
-
-    image_build_function(config)
+    build_and_push_image(image_name, config, image_args, arch_set, should_push)
     return 0
 
 

--- a/release.json
+++ b/release.json
@@ -3,6 +3,6 @@
   "operator": "0.9.0",
   "version-upgrade-hook": "1.0.8",
   "readiness-probe": "1.0.17",
-  "mongodb-agent": "107.0.0.8465-1",
+  "agent": "107.0.0.8465-1",
   "agent-tools-version": "100.9.0"
 }

--- a/release.json
+++ b/release.json
@@ -1,10 +1,8 @@
 {
   "golang-builder-image": "golang:1.21",
-  "mongodb-kubernetes-operator": "0.9.0",
+  "operator": "0.9.0",
   "version-upgrade-hook": "1.0.8",
   "readiness-probe": "1.0.17",
-  "mongodb-agent": {
-    "version": "107.0.0.8465-1",
-    "tools_version": "100.9.0"
-  }
+  "mongodb-agent": "107.0.0.8465-1",
+  "agent-tools-version": "100.9.0"
 }

--- a/scripts/ci/config.json
+++ b/scripts/ci/config.json
@@ -8,10 +8,8 @@
   "e2e_image": "community-operator-e2e",
   "version_upgrade_hook_image": "mongodb-kubernetes-operator-version-upgrade-post-start-hook",
   "version_upgrade_hook_image_dev": "mongodb-kubernetes-operator-version-upgrade-post-start-hook-dev",
-  "agent_image_ubuntu": "mongodb-agent",
-  "agent_image_ubuntu_dev": "mongodb-agent-dev",
-  "agent_image_ubi": "mongodb-agent-ubi",
-  "agent_image_ubi_dev": "mongodb-agent-ubi-dev",
+  "agent_image": "mongodb-agent-ubi",
+  "agent_image_dev": "mongodb-agent-ubi-dev",
   "readiness_probe_image": "mongodb-kubernetes-readinessprobe",
   "readiness_probe_image_dev": "mongodb-kubernetes-readinessprobe-dev",
   "s3_bucket": "s3://enterprise-operator-dockerfiles/dockerfiles"

--- a/scripts/ci/determine_required_releases.py
+++ b/scripts/ci/determine_required_releases.py
@@ -11,7 +11,7 @@ import requests
 
 # contains a map of the quay urls to fetch data about the corresponding images.
 QUAY_URL_MAP: Dict[str, List[str]] = {
-    "mongodb-agent": [
+    "agent": [
         "https://quay.io/api/v1/repository/mongodb/mongodb-agent-ubi",
         "https://quay.io/api/v1/repository/mongodb/mongodb-agent",
     ],
@@ -21,7 +21,7 @@ QUAY_URL_MAP: Dict[str, List[str]] = {
     "version-upgrade-hook": [
         "https://quay.io/api/v1/repository/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook"
     ],
-    "mongodb-kubernetes-operator": [
+    "operator": [
         "https://quay.io/api/v1/repository/mongodb/mongodb-kubernetes-operator"
     ],
 }
@@ -48,8 +48,6 @@ def _load_image_name_to_version_map() -> Dict[str, str]:
     with open("release.json") as f:
         release = json.loads(f.read())
 
-    # agent section is a sub object, we change the mapping so the key corresponds to the version directly.
-    release["mongodb-agent"] = release["mongodb-agent"]["version"]
     return release
 
 

--- a/scripts/ci/update_release.py
+++ b/scripts/ci/update_release.py
@@ -49,7 +49,7 @@ def update_operator_deployment(operator_deployment: Dict, release: Dict) -> None
         0
     ]
     operator_container["image"] = _replace_tag(
-        operator_container["image"], release["mongodb-kubernetes-operator"]
+        operator_container["image"], release["operator"]
     )
     operator_envs = operator_container["env"]
     for env in operator_envs:
@@ -59,24 +59,24 @@ def update_operator_deployment(operator_deployment: Dict, release: Dict) -> None
             env["value"] = _replace_tag(env["value"], release["readiness-probe"])
         if env["name"] == "AGENT_IMAGE":
             env["value"] = _replace_tag(
-                env["value"], release["mongodb-agent"]["version"]
+                env["value"], release["agent"]["version"]
             )
 
 
 def update_chart_values(values: Dict, release: Dict) -> None:
-    values["agent"]["version"] = release["mongodb-agent"]["version"]
+    values["agent"]["version"] = release["agent"]
     values["versionUpgradeHook"]["version"] = release["version-upgrade-hook"]
     values["readinessProbe"]["version"] = release["readiness-probe"]
-    values["operator"]["version"] = release["mongodb-kubernetes-operator"]
+    values["operator"]["version"] = release["operator"]
 
 
 def update_chart(chart: Dict, release: Dict) -> None:
-    chart["version"] = release["mongodb-kubernetes-operator"]
-    chart["appVersion"] = release["mongodb-kubernetes-operator"]
+    chart["version"] = release["operator"]
+    chart["appVersion"] = release["operator"]
 
     for dependency in chart.get("dependencies", []):
         if dependency["name"] == "community-operator-crds":
-            dependency["version"] = release["mongodb-kubernetes-operator"]
+            dependency["version"] = release["operator"]
 
 
 def main() -> int:

--- a/scripts/ci/update_release.py
+++ b/scripts/ci/update_release.py
@@ -58,9 +58,7 @@ def update_operator_deployment(operator_deployment: Dict, release: Dict) -> None
         if env["name"] == "READINESS_PROBE_IMAGE":
             env["value"] = _replace_tag(env["value"], release["readiness-probe"])
         if env["name"] == "AGENT_IMAGE":
-            env["value"] = _replace_tag(
-                env["value"], release["agent"]["version"]
-            )
+            env["value"] = _replace_tag(env["value"], release["agent"]["version"])
 
 
 def update_chart_values(values: Dict, release: Dict) -> None:

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -116,33 +116,12 @@ class DevConfig:
     def mongodb_image_repo_url(self) -> str:
         return self._config.get("mongodb_image_repo_url", "quay.io/mongodb")
 
-    @property
-    def agent_dev_image_ubi(self) -> str:
-        return self._get_dev_image("agent_image_ubi_dev", "agent_image_ubi")
-
-    @property
-    def agent_dev_image_ubuntu(self) -> str:
-        return self._get_dev_image("agent_image_ubuntu_dev", "agent_image_ubuntu")
-
-    @property
-    def agent_image_ubuntu(self) -> str:
-        return self._config["agent_image_ubuntu"]
-
-    @property
-    def agent_image_ubi(self) -> str:
-        return self._config["agent_image_ubi"]
+    def agent_image(self) -> str:
+        return self._config["agent_image"]
 
     @property
     def agent_dev_image(self) -> str:
-        if self._distro == Distro.UBI:
-            return self._get_dev_image("agent_image_ubi_dev", "agent_image_ubi")
-        return self._get_dev_image("agent_image_ubuntu_dev", "agent_image_ubuntu")
-
-    @property
-    def agent_image(self) -> str:
-        if self._distro == Distro.UBI:
-            return self.agent_dev_image_ubi
-        return self.agent_dev_image_ubuntu
+        return self._get_dev_image("agent_image_dev", "agent_image")
 
     @property
     def image_type(self) -> str:

--- a/scripts/dev/dev_config.py
+++ b/scripts/dev/dev_config.py
@@ -116,11 +116,12 @@ class DevConfig:
     def mongodb_image_repo_url(self) -> str:
         return self._config.get("mongodb_image_repo_url", "quay.io/mongodb")
 
+    @property
     def agent_image(self) -> str:
         return self._config["agent_image"]
 
     @property
-    def agent_dev_image(self) -> str:
+    def agent_image_dev(self) -> str:
         return self._get_dev_image("agent_image_dev", "agent_image")
 
     @property

--- a/scripts/dev/e2e.py
+++ b/scripts/dev/e2e.py
@@ -106,7 +106,7 @@ def create_test_pod(args: argparse.Namespace, dev_config: DevConfig) -> None:
                         },
                         {
                             "name": "AGENT_IMAGE",
-                            "value": f"{dev_config.repo_url}/{dev_config.agent_dev_image}:{args.tag}",
+                            "value": f"{dev_config.repo_url}/{dev_config.agent_image_dev}:{args.tag}",
                         },
                         {
                             "name": "TEST_NAMESPACE",


### PR DESCRIPTION
## Refactoring of `pipeline.py`

### Overview
- The `pipeline.py` file was refactored to reduce duplication and simplify the build process.
- Initially, there was a lot of duplication with different functions for building each image type (e.g., `build_agent_image_ubi`, `build_version_post_start_hook_image`). These shared 90% of their logic and configuration.
- The refactoring process introduced a unified function, `build_and_push_image`, to handle the building and pushing of images.

### Key Changes
1. **Unified Build Function**:
   - A single function `build_and_push_image` replaced the multiple image-building functions.
   - This function centralizes the image-building process, reducing redundancy.

2. **New Argument Building Function**:
   - Introduced `build_image_args` to define the build arguments passed to Sonar.
   - This function starts with a default argument dictionary, then edits the fields for handling special cases as necessary.

3. **Simplified Argument Handling**:
   - Replaced specific arguments passed to sonar like `e2e_image`, `operator_image`, etc., with a generic `image` argument.
   - Adjustments in Sonar inventory files to align with the new generic `image` parameter.
   - Removed the `agent-ubuntu` variant in `inventory.yaml`.

4. **Unified Variant Naming**:
   - Standardized `--image-name` flag values in `VALID_IMAGES_NAMES` to be consistent with values in `~/.community-operator-dev/config.json`.
   - For example, `operator` in pipeline corresponds to `operator_image` in dev config, and `version_upgrade_hook` corresponds to `version_upgrade_hook_image`. Dev images have the _image_dev prefix. No need for any explicit mapping anymore.
   - Harmonized naming in `release.json` too.
   - Eliminated `-ubi` prefixes for operator and agent images and removed the logic for building Ubuntu-based images.

5. **Adjustments in E2E Tests and Makefile**:
   - Updated to reflect new image names and ensure correct pipeline argument passing.

6. **Argument Parsing Changes**:
   - Modified the behavior of the `--release` flag: now, it's either added to signify a release or omitted otherwise (instead of `--release true` or `--release false`).
   - Introduced a new architecture flag to choose the build architecture, defaulting to multi-architecture if not specified.

7. **Documentation Updates**:
   - Updated documentation to reflect changes in the local development configuration.

8. **Additional Improvements**:
   - Implemented a new function for running CLI commands with improved error handling, remove a lot of redundancy.
   - Enhanced manifest pushing logic: the `--amend` argument is now added only for the correct architectures to prevent errors from non-existent image names.


