### PR TITLE
CLOUDP-217175: Do not install weak dependencies for nss_wrapper

### DIFF
--- a/scripts/dev/templates/agent/Dockerfile.ubi
+++ b/scripts/dev/templates/agent/Dockerfile.ubi
@@ -3,8 +3,9 @@
 {% set base_image = "registry.access.redhat.com/ubi8/ubi-minimal" %}
 
 {% block packages -%}
-RUN microdnf install -y  --disableplugin=subscription-manager curl \
-    hostname nss_wrapper tar gzip procps\
+RUN microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper
+RUN microdnf install -y --disableplugin=subscription-manager curl \
+    hostname tar gzip procps\
     && microdnf upgrade -y  \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### All Submissions:

Weak dependencies for `nss_wrapper` can be safely ignored in the agent image.

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
