### PR TITLE
CLOUDP-204110 Add jq to the Agent

### DIFF
--- a/scripts/dev/templates/agent/Dockerfile.ubi
+++ b/scripts/dev/templates/agent/Dockerfile.ubi
@@ -5,7 +5,7 @@
 {% block packages -%}
 RUN microdnf install -y --disableplugin=subscription-manager --setopt=install_weak_deps=0 nss_wrapper
 RUN microdnf install -y --disableplugin=subscription-manager curl \
-    hostname tar gzip procps\
+    hostname tar gzip procps jq\
     && microdnf upgrade -y  \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

This Pull Request introduces `jq` to the Agent image which is going to be needed for processing logs in the Static Containers architecture. In this mode, the Agent is going to launch `agent-launcher.sh` which in turn uses `jq`.

As a subsequent step, we will be releasing `13.9.1.8594` (Cloud QA) and `107.0.0.8502-1` (OM7) versions, which contain the `operatorMode` switch in the Automation.