### PR TITLE
Add default resource requirements for init-containers

### DIFF
--- a/config/samples/mongodb.com_v1_mongodbcommunity_specify_pod_resources.yaml
+++ b/config/samples/mongodb.com_v1_mongodbcommunity_specify_pod_resources.yaml
@@ -44,6 +44,15 @@ spec:
                 requests:
                   cpu: "0.2"
                   memory: 200M
+          initContainers:
+            - name: mongodb-agent-readinessprobe
+              resources:
+                limits:
+                  cpu: "2"
+                  memory: 200M
+                requests:
+                  cpu: "1"
+                  memory: 100M
 # the user credentials will be generated from this secret
 # once the credentials are generated, this secret is no longer required
 ---

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -284,6 +284,7 @@ func versionUpgradeHookInit(volumeMount []corev1.VolumeMount) container.Modifica
 		container.WithName(versionUpgradeHookName),
 		container.WithCommand([]string{"cp", "version-upgrade-hook", "/hooks/version-upgrade"}),
 		container.WithImage(os.Getenv(VersionUpgradeHookImageEnv)),
+		container.WithResourceRequirements(resourcerequirements.Defaults()),
 		container.WithImagePullPolicy(corev1.PullAlways),
 		container.WithVolumeMounts(volumeMount),
 		containerSecurityContext,
@@ -324,6 +325,7 @@ func readinessProbeInit(volumeMount []corev1.VolumeMount) container.Modification
 		container.WithImage(os.Getenv(ReadinessProbeImageEnv)),
 		container.WithImagePullPolicy(corev1.PullAlways),
 		container.WithVolumeMounts(volumeMount),
+		container.WithResourceRequirements(resourcerequirements.Defaults()),
 		containerSecurityContext,
 	)
 }


### PR DESCRIPTION
Related to https://github.com/mongodb/mongodb-kubernetes-operator/issues/1443 - I couldn't reproduce the issue. But while I was at it:
1. Added default resource requirements for init-containers.
2. Added a sample to override resource requirement for init-containers.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
