### PR TITLE
CLOUDP-204105 Copied DB Tools to their own directory

### DIFF
--- a/scripts/dev/templates/agent/Dockerfile.template
+++ b/scripts/dev/templates/agent/Dockerfile.template
@@ -39,5 +39,8 @@ RUN tar xfz /agent/mongodb-agent.tar.gz \
 
 RUN tar xfz /agent/mongodb-tools.tgz --directory /var/lib/mongodb-mms-automation/ && rm /agent/mongodb-tools.tgz
 
+# This is required for static containers
+RUN mkdir /tools && cp -r /var/lib/mongodb-mms-automation/mongodb-database-tools-*/* /tools
+
 USER 2000
 CMD ["/agent/mongodb-agent", "-cluster=/var/lib/automation/config/automation-config.json"]


### PR DESCRIPTION
This Pull Request creates a copy of the MongoDB DB Tools in the `/tools`. This is required as the `/var/lib/mongodb-mms-automation` is shadowed by a volume mount (and therefore it's being replaced by an empty directory making its image content not available). 

Later on, the `agent-launcher.sh` will create proper symbolic links for it. 