### PR TITLE
fix red herring in the readinessProbe

### DIFF
--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -221,12 +221,15 @@ func main() {
 		panic(err)
 	}
 
+	initLogger(config.GetLogger())
+
 	healthStatusFilePath := config.GetEnvOrDefault(config.AgentHealthStatusFilePathEnv, config.DefaultAgentHealthStatusFilePath)
 	file, err := os.Open(healthStatusFilePath)
 	// The agent might be slow in creating the health status file.
 	// In that case, we don't want to panic to show the message
 	// in the kubernetes description. That would be a red herring, since that will solve itself with enough time.
 	if err != nil {
+		logger.Errorf("health status file not avaible yet: %s ", err)
 		os.Exit(1)
 	}
 
@@ -234,8 +237,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	initLogger(cfg.Logger)
 
 	ready, err := isPodReady(cfg)
 	if err != nil {

--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -221,7 +221,16 @@ func main() {
 		panic(err)
 	}
 
-	cfg, err := config.BuildFromEnvVariables(clientSet, isHeadlessMode())
+	healthStatusFilePath := config.GetEnvOrDefault(config.AgentHealthStatusFilePathEnv, config.DefaultAgentHealthStatusFilePath)
+	file, err := os.Open(healthStatusFilePath)
+	// The agent might be slow in creating the health status file.
+	// In that case, we don't want to panic to show the message
+	// in the kubernetes description. That would be a red herring, since that will solve itself with enough time.
+	if err != nil {
+		os.Exit(1)
+	}
+
+	cfg, err := config.BuildFromEnvVariables(clientSet, isHeadlessMode(), file)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/readiness/config/config.go
+++ b/pkg/readiness/config/config.go
@@ -33,7 +33,6 @@ type Config struct {
 	AutomationConfigSecretName string
 	HealthStatusReader         io.Reader
 	LogFilePath                string
-	Logger                     *lumberjack.Logger
 }
 
 func BuildFromEnvVariables(clientSet kubernetes.Interface, isHeadless bool, file *os.File) (Config, error) {
@@ -56,13 +55,6 @@ func BuildFromEnvVariables(clientSet kubernetes.Interface, isHeadless bool, file
 		}
 	}
 
-	logger := &lumberjack.Logger{
-		Filename:   readinessProbeLogFilePath(),
-		MaxBackups: readIntOrDefault(readinessProbeLoggerBackups, 5),
-		MaxSize:    readInt(readinessProbeLoggerMaxSize),
-		MaxAge:     readInt(readinessProbeLoggerMaxAge),
-	}
-
 	// Note, that we shouldn't close the file here - it will be closed very soon by the 'ioutil.ReadAll'
 	// in main.go
 	return Config{
@@ -72,8 +64,17 @@ func BuildFromEnvVariables(clientSet kubernetes.Interface, isHeadless bool, file
 		Hostname:                   hostname,
 		HealthStatusReader:         file,
 		LogFilePath:                logFilePath,
-		Logger:                     logger,
 	}, nil
+}
+
+func GetLogger() *lumberjack.Logger {
+	logger := &lumberjack.Logger{
+		Filename:   readinessProbeLogFilePath(),
+		MaxBackups: readIntOrDefault(readinessProbeLoggerBackups, 5),
+		MaxSize:    readInt(readinessProbeLoggerMaxSize),
+		MaxAge:     readInt(readinessProbeLoggerMaxAge),
+	}
+	return logger
 }
 
 func readinessProbeLogFilePath() string {

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
   "golang-builder-image": "golang:1.21",
   "operator": "0.9.0",
   "version-upgrade-hook": "1.0.8",
-  "readiness-probe": "1.0.17",
+  "readiness-probe": "1.0.18",
   "agent": "107.0.1.8507-1",
   "agent-tools-version": "100.9.4"
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

### Summary
- fixes the red herring that the agent-health-status file is missing
- continue of fix: https://github.com/mongodb/mongodb-kubernetes-operator/pull/1224, we missed a few places. This PR instead suggests to test for the file as early as possible in the code
- it can be missing, since the agent requires some time until it populates that file
- while it is still populating the probe should just return unready and it will eventually work 