### PR TITLE
CLOUDP-155037 - ensure we are waiting for some time until all the agents have finished updating the ports

### DIFF
--- a/pkg/agent/replica_set_port_manager.go
+++ b/pkg/agent/replica_set_port_manager.go
@@ -128,7 +128,7 @@ func (r *ReplicaSetPortManager) calculateExpectedPorts() (processPortMap map[str
 	for _, podState := range r.currentPodStates {
 		if !podState.ReachedGoalState {
 			r.log.Debugf("Port change required but not all pods reached goal state, abandoning port change")
-			return processPortMap, portChangeRequired, oldPort
+			return processPortMap, true, oldPort
 		}
 	}
 
@@ -143,5 +143,5 @@ func (r *ReplicaSetPortManager) calculateExpectedPorts() (processPortMap map[str
 		}
 	}
 
-	return processPortMap, portChangeRequired, oldPort
+	return processPortMap, true, oldPort
 }


### PR DESCRIPTION
### Summary:
- making sure we wait and retry for some time until we fail the port change test. More description is in the method which has changed. 
### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
