### PR TITLE
Removed omitempty from member config priority

### DIFF
--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -276,7 +276,7 @@ type ReplicaSetMember struct {
 	// is different in AC from the CR(CR don't support float) - hence all the members are declared
 	// separately
 	Votes    *int              `json:"votes,omitempty"`
-	Priority float32           `json:"priority,omitempty"`
+	Priority float32           `json:"priority"`
 	Tags     map[string]string `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
It is not possible to change priority of any given member to zero because it's a default value and it's not marshalled. 