### PR TITLE
CLOUDP-252271 Use gosec linter

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -7,7 +7,7 @@ jobs:
   Black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Black Check
         uses: jpetrucciani/black-check@7f5b2ad20fa5484f1884f07c1937e032ed8cd939
@@ -21,3 +21,13 @@ jobs:
         uses: jpetrucciani/mypy-check@179fdad632bf3ccf4cabb7ee4307ef25e51d2f96
         with:
           path: scripts/*/*.py
+
+  Golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,25 +51,3 @@ jobs:
 
       - name: Move the dependencies
         run: mv .venv /home/runner/work/_temp/_github_workflow
-
-      # This part is not needed until we can add GO linting
-      # - name : Install Operator SDK
-      #   run: |
-      #         curl -s https://api.github.com/repos/operator-framework/operator-sdk/releases/latest | grep browser_download_url | grep x86_64-linux-gnu | cut -d '"' -f 4 | wget -i -
-      #         sudo mv operator-sdk-*-x86_64-linux-gnu /usr/local/bin/operator-sdk
-      #         sudo chmod 777 /usr/local/bin/operator-sdk
-      # - name: Generate DeepCopy
-      #   Run: operator-sdk generate k8s
-
-      - name: Lint Code Base
-        uses: docker://github/super-linter:v4
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          # Now we set the PYTHONPATH to the path of the dependencies *inside* the container
-          PYTHONPATH: "/github/workspace/:\
-            /github/workflow/.venv/lib/python3.6/site-packages"
-          VALIDATE_YAML: true
-          VALIDATE_PYTHON: true
-          VALIDATE_BASH: true
-          FILTER_REGEX_EXCLUDE: "/helm-charts/charts/community-operator/templates/*"
-          # VALIDATE_GO: true  This is currently broken: https://github.com/github/super-linter/issues/143

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,17 +23,14 @@ linters:
     - staticcheck
     - unused
     - gosimple
-    - structcheck
-    - varcheck
     - ineffassign
-    - deadcode
     - typecheck
     - rowserrcheck
     - gosec
     - unconvert
 
 run:
-  modules-download-mode: 
+  modules-download-mode: mod
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 5m
   # default concurrency is a available CPU number

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Reviewers, please ensure that the CLA has been signed by referring to [the contr
 
 This project uses the following linters upon every Pull Request:
 
+* `gosec` is a tool that find security problems in the code
 * `Black` is a tool that verifies if Python code is properly formatted
 * `MyPy` is a Static Type Checker for Python
 * `Kube-linter` is a tool that verified if all Kubernetes YAML manifests are formatted correctly

--- a/cmd/readiness/readiness_test.go
+++ b/cmd/readiness/readiness_test.go
@@ -106,7 +106,7 @@ func TestDeadlockDetection(t *testing.T) {
 			isReadyExpected: false,
 		},
 	}
-	for testName, _ := range tests {
+	for testName := range tests {
 		testConfig := tests[testName]
 		t.Run(testName, func(t *testing.T) {
 			ready, err := isPodReady(ctx, testConfig.conf)
@@ -225,7 +225,7 @@ func TestObtainingCurrentStep(t *testing.T) {
 			expectedStep: "test",
 		},
 	}
-	for testName, _ := range tests {
+	for testName := range tests {
 		testConfig := tests[testName]
 		t.Run(testName, func(t *testing.T) {
 			step := findCurrentStep(testConfig.processStatuses)

--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -68,8 +68,8 @@ export NSS_WRAPPER_PASSWD=/tmp/passwd
 export LD_PRELOAD=libnss_wrapper.so
 export NSS_WRAPPER_GROUP=/etc/group
 fi
-
 `
+	//nolint:gosec //The credentials path is hardcoded in the container.
 	MongodbUserCommandWithAPIKeyExport = `current_uid=$(id -u)
 AGENT_API_KEY="$(cat /mongodb-automation/agent-api-key/agentApiKey)"
 declare -r current_uid

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -262,7 +262,7 @@ func HasExpectedMetadata(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expec
 		assert.NoError(t, err)
 		assert.NotEmpty(t, statefulSetList.Items)
 		for _, s := range statefulSetList.Items {
-			containsMetadata(t, &s.ObjectMeta, expectedLabels, expectedAnnotations, "statefulset "+s.Name)
+			containsMetadata(t, s.ObjectMeta, expectedLabels, expectedAnnotations, "statefulset "+s.Name)
 		}
 
 		volumeList := corev1.PersistentVolumeList{}
@@ -272,7 +272,7 @@ func HasExpectedMetadata(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expec
 		for _, s := range volumeList.Items {
 			volName := s.Name
 			if strings.HasPrefix(volName, "data-volume-") || strings.HasPrefix(volName, "logs-volume-") {
-				containsMetadata(t, &s.ObjectMeta, expectedLabels, expectedAnnotations, "volume "+volName)
+				containsMetadata(t, s.ObjectMeta, expectedLabels, expectedAnnotations, "volume "+volName)
 			}
 		}
 
@@ -304,12 +304,12 @@ func HasExpectedMetadata(ctx context.Context, mdb *mdbv1.MongoDBCommunity, expec
 				continue
 			}
 
-			containsMetadata(t, &s.ObjectMeta, expectedLabels, expectedAnnotations, "pod "+s.Name)
+			containsMetadata(t, s.ObjectMeta, expectedLabels, expectedAnnotations, "pod "+s.Name)
 		}
 	}
 }
 
-func containsMetadata(t *testing.T, metadata *metav1.ObjectMeta, expectedLabels map[string]string, expectedAnnotations map[string]string, msg string) {
+func containsMetadata(t *testing.T, metadata metav1.ObjectMeta, expectedLabels map[string]string, expectedAnnotations map[string]string, msg string) {
 	labels := metadata.Labels
 	for k, v := range expectedLabels {
 		assert.Contains(t, labels, k, msg+" has label "+k)

--- a/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
+++ b/test/e2e/replica_set_arbiter/replica_set_arbiter_test.go
@@ -69,9 +69,9 @@ func TestReplicaSetArbiter(t *testing.T) {
 			resourceName:     "mdb4",
 		},
 	}
-	for testName, _ := range tests {
+	for testName := range tests {
 		t.Run(testName, func(t *testing.T) {
-			testConfig, _ := tests[testName]
+			testConfig := tests[testName]
 			mdb, user := e2eutil.NewTestMongoDB(testCtx, testConfig.resourceName, "")
 			mdb.Spec.Arbiters = testConfig.numberOfArbiters
 			mdb.Spec.Members = testConfig.numberOfMembers

--- a/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
+++ b/test/e2e/replica_set_operator_upgrade/replica_set_operator_upgrade_test.go
@@ -73,7 +73,7 @@ func TestReplicaSetOperatorUpgrade(t *testing.T) {
 // TestReplicaSetOperatorUpgradeFrom0_7_2 is intended to be run locally not in CI.
 // It simulates deploying cluster using community operator 0.7.2 and then upgrading it using newer version.
 func TestReplicaSetOperatorUpgradeFrom0_7_2(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.Background() //nolint
 	t.Skip("Supporting this test in CI requires installing also CRDs from release v0.7.2")
 	resourceName := "mdb-upg"
 	testConfig := setup.LoadTestConfigFromEnv()

--- a/test/e2e/util/wait/wait.go
+++ b/test/e2e/util/wait/wait.go
@@ -161,11 +161,6 @@ func waitForStatefulSetCondition(ctx context.Context, t *testing.T, mdb *mdbv1.M
 	return waitForStatefulSetConditionWithSpecificSts(ctx, t, mdb, MembersStatefulSet, waitOpts, condition)
 }
 
-func waitForStatefulSetConditionArbiters(ctx context.Context, t *testing.T, mdb *mdbv1.MongoDBCommunity, waitOpts Options, condition func(set appsv1.StatefulSet) bool) error {
-	// uses members statefulset
-	return waitForStatefulSetConditionWithSpecificSts(ctx, t, mdb, ArbitersStatefulSet, waitOpts, condition)
-}
-
 func ForPodReadiness(ctx context.Context, t *testing.T, isReady bool, containerName string, timeout time.Duration, pod corev1.Pod) error {
 	return wait.PollUntilContextTimeout(ctx, time.Second*3, timeout, false, func(ctx context.Context) (done bool, err error) {
 		err = e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &pod)


### PR DESCRIPTION
This Pull Request introduces gosec through golangci-lint project. As a side-effect, it removes super-linter integration.

The motivation behind integrating it this way is using a single `//nolint` comment to disable (or mark as false-positive) all linters and not using linter-specific markers (such as `nosec`). 