### PR TITLE
CLOUDP-253916 - readinessProbe: send to stdout as well, give option for compression and reduce default size

### DIFF
--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -210,7 +210,7 @@ func parseHealthStatus(reader io.Reader) (health.Status, error) {
 func initLogger(l *lumberjack.Logger) {
 	log := zap.New(zapcore.NewCore(
 		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
-		zapcore.AddSync(l),
+		zapcore.AddSync(os.Stdout),
 		zap.DebugLevel,
 	), zap.Development())
 	logger = log.Sugar()

--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -225,6 +225,8 @@ func initLogger(l *lumberjack.Logger) {
 	core := zapcore.NewTee(cores...)
 	log := zap.New(core, zap.Development())
 	logger = log.Sugar()
+
+	logger.Infof("logging configuration: %+v", l)
 }
 
 func main() {

--- a/pkg/readiness/config/config.go
+++ b/pkg/readiness/config/config.go
@@ -15,15 +15,17 @@ import (
 const (
 	DefaultAgentHealthStatusFilePath = "/var/log/mongodb-mms-automation/agent-health-status.json"
 	AgentHealthStatusFilePathEnv     = "AGENT_STATUS_FILEPATH"
+	WithAgentFileLogging             = "MDB_WITH_AGENT_FILE_LOGGING"
 
-	defaultLogPath              = "/var/log/mongodb-mms-automation/readiness.log"
-	podNamespaceEnv             = "POD_NAMESPACE"
-	automationConfigSecretEnv   = "AUTOMATION_CONFIG_MAP" //nolint
-	logPathEnv                  = "LOG_FILE_PATH"
-	hostNameEnv                 = "HOSTNAME"
-	readinessProbeLoggerBackups = "READINESS_PROBE_LOGGER_BACKUPS"
-	readinessProbeLoggerMaxSize = "READINESS_PROBE_LOGGER_MAX_SIZE"
-	readinessProbeLoggerMaxAge  = "READINESS_PROBE_LOGGER_MAX_AGE"
+	defaultLogPath               = "/var/log/mongodb-mms-automation/readiness.log"
+	podNamespaceEnv              = "POD_NAMESPACE"
+	automationConfigSecretEnv    = "AUTOMATION_CONFIG_MAP" //nolint
+	logPathEnv                   = "LOG_FILE_PATH"
+	hostNameEnv                  = "HOSTNAME"
+	readinessProbeLoggerBackups  = "READINESS_PROBE_LOGGER_BACKUPS"
+	readinessProbeLoggerMaxSize  = "READINESS_PROBE_LOGGER_MAX_SIZE"
+	readinessProbeLoggerMaxAge   = "READINESS_PROBE_LOGGER_MAX_AGE"
+	readinessProbeLoggerCompress = "READINESS_PROBE_LOGGER_COMPRESS"
 )
 
 type Config struct {
@@ -71,8 +73,9 @@ func GetLogger() *lumberjack.Logger {
 	logger := &lumberjack.Logger{
 		Filename:   readinessProbeLogFilePath(),
 		MaxBackups: readIntOrDefault(readinessProbeLoggerBackups, 5),
-		MaxSize:    readIntOrDefault(readinessProbeLoggerMaxSize, 10),
+		MaxSize:    readIntOrDefault(readinessProbeLoggerMaxSize, 5),
 		MaxAge:     readInt(readinessProbeLoggerMaxAge),
+		Compress:   ReadBoolWitDefault(readinessProbeLoggerCompress, "false"),
 	}
 	return logger
 }
@@ -104,4 +107,10 @@ func readIntOrDefault(envVarName string, defaultValue int) int {
 		return defaultValue
 	}
 	return intValue
+}
+
+// ReadBoolWitDefault returns the boolean value of an envvar of the given name.
+func ReadBoolWitDefault(envVarName string, defaultValue string) bool {
+	envVar := GetEnvOrDefault(envVarName, defaultValue)
+	return strings.TrimSpace(strings.ToLower(envVar)) == "true"
 }

--- a/pkg/readiness/config/config.go
+++ b/pkg/readiness/config/config.go
@@ -16,7 +16,7 @@ const (
 	DefaultAgentHealthStatusFilePath = "/var/log/mongodb-mms-automation/agent-health-status.json"
 	AgentHealthStatusFilePathEnv     = "AGENT_STATUS_FILEPATH"
 
-	defaultLogPath              = "/var/log/mongodb-mms-automation/readiness.log"
+	defaultLogPath              = "/proc/1/fd/1"
 	podNamespaceEnv             = "POD_NAMESPACE"
 	automationConfigSecretEnv   = "AUTOMATION_CONFIG_MAP" //nolint
 	logPathEnv                  = "LOG_FILE_PATH"

--- a/pkg/readiness/config/config.go
+++ b/pkg/readiness/config/config.go
@@ -16,7 +16,7 @@ const (
 	DefaultAgentHealthStatusFilePath = "/var/log/mongodb-mms-automation/agent-health-status.json"
 	AgentHealthStatusFilePathEnv     = "AGENT_STATUS_FILEPATH"
 
-	defaultLogPath              = "/proc/1/fd/1"
+	defaultLogPath              = "/var/log/mongodb-mms-automation/readiness.log"
 	podNamespaceEnv             = "POD_NAMESPACE"
 	automationConfigSecretEnv   = "AUTOMATION_CONFIG_MAP" //nolint
 	logPathEnv                  = "LOG_FILE_PATH"
@@ -71,7 +71,7 @@ func GetLogger() *lumberjack.Logger {
 	logger := &lumberjack.Logger{
 		Filename:   readinessProbeLogFilePath(),
 		MaxBackups: readIntOrDefault(readinessProbeLoggerBackups, 5),
-		MaxSize:    readInt(readinessProbeLoggerMaxSize),
+		MaxSize:    readIntOrDefault(readinessProbeLoggerMaxSize, 10),
 		MaxAge:     readInt(readinessProbeLoggerMaxAge),
 	}
 	return logger


### PR DESCRIPTION
### Summary:
example output with the console/stdout logger
```
  Warning  Unhealthy  2m28s  kubelet            Readiness probe failed: {"level":"error","ts":1718279186.4724512,"msg":"health status file not avaible yet: open /var/log/mongodb-mms-automation/agent-health-status.json: no such file or directory "}
  Warning  Unhealthy  83s    kubelet            Readiness probe failed: {"level":"debug","ts":1718279251.0533059,"msg":"ExpectedToBeUp: true, IsInGoalState: false, LastMongoUpTime: 1970-01-01 00:00:00 +0000 UTC"}
{"level":"info","ts":1718279251.053355,"msg":"Mongod is not ready"}
{"level":"info","ts":1718279251.0533628,"msg":"Reached the end of the check. Returning not ready."}
  Warning  Unhealthy  78s  kubelet  Readiness probe failed: {"level":"debug","ts":1718279256.0862045,"msg":"ExpectedToBeUp: true, IsInGoalState: false, LastMongoUpTime: 1970-01-01 00:00:00 +0000 UTC"}
{"level":"info","ts":1718279256.0862503,"msg":"Mongod is not ready"}
{"level":"info","ts":1718279256.086258,"msg":"Reached the end of the check. Returning not ready."}
  Warning  Unhealthy  33s  kubelet  Readiness probe failed: {"level":"debug","ts":1718279301.0727608,"msg":"ExpectedToBeUp: true, IsInGoalState: false, LastMongoUpTime: 2024-06-13 11:48:16 +0000 UTC"}
{"level":"debug","ts":1718279301.0728135,"msg":"The Agent hasn't reported working on the new config yet, the last plan finished at 2024-06-13T11:48:15Z"}
{"level":"info","ts":1718279301.0728211,"msg":"Reached the end of the check. Returning not ready."}
  Warning  Unhealthy  28s  kubelet  Readiness probe failed: {"level":"debug","ts":1718279306.0484068,"msg":"ExpectedToBeUp: true, IsInGoalState: false, LastMongoUpTime: 2024-06-13 11:48:16 +0000 UTC"}
{"level":"debug","ts":1718279306.0484557,"msg":"The Agent hasn't reported working on the new config yet, the last plan finished at 2024-06-13T11:48:15Z"}
{"level":"info","ts":1718279306.0484633,"msg":"Reached the end of the check. Returning not ready."}

```
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
