### PR TITLE
expose readinessProbe settings, add documentation

### DIFF
--- a/controllers/construct/mongodbstatefulset_test.go
+++ b/controllers/construct/mongodbstatefulset_test.go
@@ -1,0 +1,97 @@
+package construct
+
+import (
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/readiness/config"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestCollectEnvVars(t *testing.T) {
+	tests := []struct {
+		name        string
+		envSetup    map[string]string
+		expectedEnv []corev1.EnvVar
+	}{
+		{
+			name: "Basic env vars set",
+			envSetup: map[string]string{
+				config.ReadinessProbeLoggerBackups: "3",
+				config.ReadinessProbeLoggerMaxSize: "10M",
+				config.ReadinessProbeLoggerMaxAge:  "7",
+				config.WithAgentFileLogging:        "enabled",
+			},
+			expectedEnv: []corev1.EnvVar{
+				{
+					Name:  config.AgentHealthStatusFilePathEnv,
+					Value: "/healthstatus/agent-health-status.json",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerBackups,
+					Value: "3",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerMaxSize,
+					Value: "10M",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerMaxAge,
+					Value: "7",
+				},
+				{
+					Name:  config.WithAgentFileLogging,
+					Value: "enabled",
+				},
+			},
+		},
+		{
+			name: "Additional env var set",
+			envSetup: map[string]string{
+				config.ReadinessProbeLoggerBackups:  "3",
+				config.ReadinessProbeLoggerMaxSize:  "10M",
+				config.ReadinessProbeLoggerMaxAge:   "7",
+				config.ReadinessProbeLoggerCompress: "true",
+				config.WithAgentFileLogging:         "enabled",
+			},
+			expectedEnv: []corev1.EnvVar{
+				{
+					Name:  config.AgentHealthStatusFilePathEnv,
+					Value: "/healthstatus/agent-health-status.json",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerBackups,
+					Value: "3",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerMaxSize,
+					Value: "10M",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerMaxAge,
+					Value: "7",
+				},
+				{
+					Name:  config.ReadinessProbeLoggerCompress,
+					Value: "true",
+				},
+				{
+					Name:  config.WithAgentFileLogging,
+					Value: "enabled",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment variables
+			for key, value := range tt.envSetup {
+				t.Setenv(key, value)
+			}
+
+			actualEnvVars := collectEnvVars()
+
+			assert.EqualValues(t, tt.expectedEnv, actualEnvVars)
+		})
+	}
+}

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,33 @@
+# Configure Logging in MongoDB Community
+
+This section describes the components which are logging either to a file or stdout,
+how to configure them and what their defaults are.
+
+## MongoDB Processes
+### Configuration
+The exposed CRD options can be seen [in the crd yaml](https://github.com/mongodb/mongodb-kubernetes-operator/blob/74d13f189566574b862e5670b366b61ec5b65923/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml#L105-L117).
+Additionally, more information regarding configuring systemLog can be found [in the official documentation of systemLog](https://www.mongodb.com/docs/manual/reference/configuration-options/#core-options)].
+`spec.agent.systemLog.destination` configures the logging destination of the mongod process.
+### Default Values
+By default, MongoDB sends all log output to standard output. 
+
+## MongoDB Agent
+### Configuration
+`spec.agent.logFile` can be used to configure the output file of the mongoDB agent logging. 
+The agent will log to standard output with the following setting: `/dev/stdout`.
+### Default Values
+By default, the MongoDB agent logs to `/var/log/mongodb-mms-automation/automation-agent.log`
+ 
+## ReadinessProbe 
+### Configuration & Default Values
+The readinessProbe can be configured via Environment variables. 
+Below is a table with each environment variable, its explanation and its default value.
+
+| Environment Variable            | Explanation                                                             | Default Value                                 |
+|---------------------------------|-------------------------------------------------------------------------|-----------------------------------------------|
+| READINESS_PROBE_LOGGER_BACKUPS  | maximum number of old log files to retain                               | 5                                             |
+| READINESS_PROBE_LOGGER_MAX_SIZE | maximum size in megabytes                                               | 5                                             |
+| READINESS_PROBE_LOGGER_MAX_AGE  | maximum number of days to retain old log files                          | none                                          |
+| READINESS_PROBE_LOGGER_COMPRESS | if the rotated log files should be compressed                           | false                                         |
+| MDB_WITH_AGENT_FILE_LOGGING     | whether we should also log to stdout (which shows in kubectl describe)  | true                                          |
+| LOG_FILE_PATH                   | path of the logfile of the readinessProbe.                              | /var/log/mongodb-mms-automation/readiness.log |

--- a/pkg/readiness/config/config.go
+++ b/pkg/readiness/config/config.go
@@ -22,10 +22,10 @@ const (
 	automationConfigSecretEnv    = "AUTOMATION_CONFIG_MAP" //nolint
 	logPathEnv                   = "LOG_FILE_PATH"
 	hostNameEnv                  = "HOSTNAME"
-	readinessProbeLoggerBackups  = "READINESS_PROBE_LOGGER_BACKUPS"
-	readinessProbeLoggerMaxSize  = "READINESS_PROBE_LOGGER_MAX_SIZE"
-	readinessProbeLoggerMaxAge   = "READINESS_PROBE_LOGGER_MAX_AGE"
-	readinessProbeLoggerCompress = "READINESS_PROBE_LOGGER_COMPRESS"
+	ReadinessProbeLoggerBackups  = "READINESS_PROBE_LOGGER_BACKUPS"
+	ReadinessProbeLoggerMaxSize  = "READINESS_PROBE_LOGGER_MAX_SIZE"
+	ReadinessProbeLoggerMaxAge   = "READINESS_PROBE_LOGGER_MAX_AGE"
+	ReadinessProbeLoggerCompress = "READINESS_PROBE_LOGGER_COMPRESS"
 )
 
 type Config struct {
@@ -72,10 +72,10 @@ func BuildFromEnvVariables(clientSet kubernetes.Interface, isHeadless bool, file
 func GetLogger() *lumberjack.Logger {
 	logger := &lumberjack.Logger{
 		Filename:   readinessProbeLogFilePath(),
-		MaxBackups: readIntOrDefault(readinessProbeLoggerBackups, 5),
-		MaxSize:    readIntOrDefault(readinessProbeLoggerMaxSize, 5),
-		MaxAge:     readInt(readinessProbeLoggerMaxAge),
-		Compress:   ReadBoolWitDefault(readinessProbeLoggerCompress, "false"),
+		MaxBackups: readIntOrDefault(ReadinessProbeLoggerBackups, 5),
+		MaxSize:    readIntOrDefault(ReadinessProbeLoggerMaxSize, 5),
+		MaxAge:     readInt(ReadinessProbeLoggerMaxAge),
+		Compress:   ReadBoolWitDefault(ReadinessProbeLoggerCompress, "false"),
 	}
 	return logger
 }


### PR DESCRIPTION
### Summary:
This PR adds the following:
- inverting bool logic of agent configuration (easier for the eyes)
- expose readinessProbe env var settings
- document readinessProbe settings

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
