### PR TITLE
add missing releasenotes

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -3,3 +3,17 @@
 ## Released images signed
 
 All container images published for the community operator are signed with our private key. This is visible on our Quay registry. Signature can be verified using our public key, which is available at [this address](https://cosign.mongodb.com/mongodb-enterprise-kubernetes-operator.pem).
+
+## Logging changes
+- The agent logging can be configured to stdout
+- ReadinessProbe logging configuration can now be configured
+- More can be found [here](logging.md).
+
+## Overriding Mongod settings via the CRD 
+- Example can be found [here](../config/samples/mongodb.com_v1_mongodbcommunity_override_ac_setting.yaml).
+
+## ReadinessProbe error logging
+- fixed a red herring which caused the probe to panic when the health status is not available. Instead it will just log the error
+
+## Important Bumps
+- Bumped K8S libs to 1.27


### PR DESCRIPTION
### Summary:
Distilled and Based on, I basically ignored all bump prs except kube bump:

```
83a7e14 - CLOUDP-242559 - expose readinessProbe settings, add documentation (#1566)
08428a4 - Bump pymongo from 4.0.1 to 4.6.3 in /test/test-app (#1519)
6c9f5a0 - Bump dnspython from 2.2.0 to 2.6.1 in /test/test-app (#1524)
0c330a2 - Bump github.com/go-logr/logr from 1.4.1 to 1.4.2 (#1555)
90e9374 - CLOUDP-253916 - readinessProbe: send to stdout as well, give option for compression and reduce default size (#1561)
e4b4e7b - CLOUDP-252271 Use golangci-lint and gosec (#1558)
8f69586 - CLOUDP-250100 CVE-2024-35195  fix (#1556)
31a4675 - CLOUDP-212060 Document linting rules (#1550)
a8a30ff - bump tqdm (#1537)
212f825 - Bump jinja2 from 3.1.3 to 3.1.4 (#1540)
771c8cd - Bump pymongo from 4.6.2 to 4.6.3 (#1520)
c9b0796 - Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#1502)
9430f5d - Bump go.mongodb.org/mongo-driver from 1.14.0 to 1.15.0 (#1526)
7cfc2f7 - Sign images (#1533)
ea008d7 - Bump golang.org/x/net from 0.19.0 to 0.23.0 (#1529)
74d13f1 - Bump k8s apis to 1.27, refactor to support contexts (#1523)
376ed2a - Update PULL_REQUEST_TEMPLATE.md (#1505)
f53c878 - bumping protobuf (#1517)
37a0a97 - Bump black from 22.3.0 to 24.3.0 (#1512)
24d99ac - Bump github.com/stretchr/objx from 0.5.1 to 0.5.2 (#1516)
48de7c9 - Bump go.uber.org/zap from 1.26.0 to 1.27.0 (#1515)
9e32503 - CLOUDP-204105 Conditionally run the upgrade hook (#1513)
a07365e - fix red herring in the readinessProbe (#1504)
2b18764 - make ensuring a poll (#1506)
a87bda5 - Removed unused code (#1501)
c81c05c - CLOUDP-229252 - update dnspython (#1499)
238e094 - Fix logging to stdout (#1489)
353fb62 - Bump go.mongodb.org/mongo-driver from 1.13.1 to 1.14.0 (#1497)
ffb658e - Preparation to make the operator static (#1488)
240be3b - CLOUDP-206784: Check licenses from CI (#1464)
b18ad3e - Revert kube dependency upgrade (#1487)
f33768e - fix confusing error message (#1479)
a986f2e - CLOUDP-226357 - fix logRotate & add local dev imp & update examples (#1480)
352329e - bump protobuf (#1485)
fcab6a8 - Update bug_report.md (#1483)
4fceff5 - Update codeowners (#1481)
280ac15 - Add overriding Mongod settings via the CRD (#1472)
48aa4d6 - Fix Custom Persistent Volume test (#1477)
9f09175 - Bump sigs.k8s.io/controller-runtime from 0.16.3 to 0.17.0 (#1470)
79bb58f - Remove envtest script (#1471)
0ba5ac6 - Update dependabot reviewers (#1469)
8bde94b - cleanup: remove use of deprecated Go APIs (#1468)
4ea4b42 - Bump github.com/spf13/cast from 1.5.1 to 1.6.0 (#1466)
ee1aadb - Configure vote / tag / priority (#1467)
38a0eff - feat: set namespace connectionStringSecret per user (#1463)
d4cc3d3 - Bump jinja2 from 2.11.3 to 3.1.3 (#1461)
0fe9047 - Bump controller runtime and Kube libs (#1462)
40d04dd - Start tracking and checking licenses (#1421)
6534d40 - Bump github.com/go-logr/logr from 1.3.0 to 1.4.1 (#1459)
f780087 - Bump agent corresponding to OM 7.0.1 (#1460)
e947b4a - CLOUDP-204105 Additional Agent image dependencies (#1455)
d48d322 - Bump sigs.k8s.io/yaml from 1.3.0 to 1.4.0 (#1458)
af5f064 - Add default resource requirements for init-containers (#1457)
7746194 - Bump dependencies  (#1454)
8e3fce0 - CLOUDP-204110 Add jq to the Agent (#1450)
0ee0adb - Remove Ubuntu dockerfile for agent (#1449)
6cf2f5d - Do not install weak dependencies for nss_wrapper (#1448)
5415e7b - CLOUDP-204109 Additional tests for WaitForCorrectBinaries (#1444)
b00b2ce - Local dev / documentation improvement (#1441)
f3ff90f - CLOUDP-211733 - Pipeline and build process refactoring (#1427)
bf054bd - Bump github.com/go-logr/logr from 1.2.4 to 1.3.0 (#1419)
fd3db0d - bump helm charts (#1437)
```
### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
