### PR TITLE
Adding the option to override the cluster domain

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -132,6 +132,9 @@ type MongoDBCommunitySpec struct {
 	// MemberConfig
 	// +optional
 	MemberConfig []automationconfig.MemberOptions `json:"memberConfig,omitempty"`
+
+	// OverrideClusterDomain overrides the cluster domain.
+	OverrideClusterDomain string `json:"overrideClusterDomain,omitempty"`
 }
 
 // MapWrapper is a wrapper for a map to be used by other structs.

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -223,6 +223,9 @@ spec:
               members:
                 description: Members is the number of members in the replica set
                 type: integer
+              overrideClusterDomain:
+                description: OverrideClusterDomain overrides the cluster domain.
+                type: string
               prometheus:
                 description: Prometheus configurations.
                 properties:

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -203,9 +203,12 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 			withMongoDBArbiters(mdb.AutomationConfigArbitersThisReconciliation()).
 			withPendingPhase(10))
 	}
-
+	mdbClusterDomain := mdb.Spec.OverrideClusterDomain
+	if mdbClusterDomain == "" {
+		mdbClusterDomain = os.Getenv(clusterDomain)
+	}
 	res, err := status.Update(ctx, r.client.Status(), &mdb, statusOptions().
-		withMongoURI(mdb.MongoURI(os.Getenv(clusterDomain))).
+		withMongoURI(mdb.MongoURI(mdbClusterDomain)).
 		withMongoDBMembers(mdb.AutomationConfigMembersThisReconciliation()).
 		withStatefulSetReplicas(mdb.StatefulSetReplicasThisReconciliation()).
 		withStatefulSetArbiters(mdb.StatefulSetArbitersThisReconciliation()).
@@ -218,7 +221,7 @@ func (r ReplicaSetReconciler) Reconcile(ctx context.Context, request reconcile.R
 		return res, err
 	}
 
-	if err := r.updateConnectionStringSecrets(ctx, mdb, os.Getenv(clusterDomain)); err != nil {
+	if err := r.updateConnectionStringSecrets(ctx, mdb, mdbClusterDomain); err != nil {
 		r.log.Errorf("Could not update connection string secrets: %s", err)
 	}
 
@@ -499,8 +502,12 @@ func (r ReplicaSetReconciler) ensureAutomationConfig(mdb mdbv1.MongoDBCommunity,
 }
 
 func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Auth, currentAc automationconfig.AutomationConfig, modifications ...automationconfig.Modification) (automationconfig.AutomationConfig, error) {
-	domain := getDomain(mdb.ServiceName(), mdb.Namespace, os.Getenv(clusterDomain))
-	arbiterDomain := getDomain(mdb.ServiceName(), mdb.Namespace, os.Getenv(clusterDomain))
+	mdbClusterDomain := mdb.Spec.OverrideClusterDomain
+	if mdbClusterDomain == "" {
+		mdbClusterDomain = os.Getenv(clusterDomain)
+	}
+	domain := getDomain(mdb.ServiceName(), mdb.Namespace, mdbClusterDomain)
+	arbiterDomain := getDomain(mdb.ServiceName(), mdb.Namespace, mdbClusterDomain)
 
 	zap.S().Debugw("AutomationConfigMembersThisReconciliation", "mdb.AutomationConfigMembersThisReconciliation()", mdb.AutomationConfigMembersThisReconciliation())
 


### PR DESCRIPTION
### Summary:
This option will help in cases of changes to the cluster domain or when configurations in the cluster's DNS know how to deal with other domains, such as customizations in CoreDNS.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
