### PR TITLE
fix: use correct namespace for password secret

### DIFF
--- a/controllers/mongodb_users.go
+++ b/controllers/mongodb_users.go
@@ -62,7 +62,7 @@ func (r ReplicaSetReconciler) updateConnectionStringSecrets(ctx context.Context,
 		pwd := ""
 
 		if user.Database != constants.ExternalDB {
-			secretNamespacedName := types.NamespacedName{Name: user.PasswordSecretName, Namespace: secretNamespace}
+			secretNamespacedName := types.NamespacedName{Name: user.PasswordSecretName, Namespace: mdb.Namespace}
 			pwd, err = secret.ReadKey(ctx, r.client, user.PasswordSecretKey, secretNamespacedName)
 			if err != nil {
 				return err


### PR DESCRIPTION
### Summary:

Closes #1578.

I created this PR because, in our deployment of mongodb-kubernetes-operator at NIAEFEUP, we were having trouble creating the connection string secret in a namespace that was not the one the MDBC resource was deployed to. In particular, as described in the issue, one problem that we encountered was needing to have the password secret in both namespaces (the MDBC resource namespace and the connectionStringSecretNamespace namespace) for the connection string secret to be created. The logic was changed so that the password secret is always looked up in the namespace of the MDBC resource.

As a result, the password secret now only needs to be on the namespace of the MDBC resource (as was expected by the `ensureUserResources` function).

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
