### PR TITLE
feat: customize connection string secret annotations

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -489,6 +489,10 @@ type MongoDBUser struct {
 	// +optional
 	ConnectionStringSecretNamespace string `json:"connectionStringSecretNamespace,omitempty"`
 
+	// ConnectionStringSecretAnnotations is the annotations of the secret object created by the operator which exposes the connection strings for the user.
+	// +optional
+	ConnectionStringSecretAnnotations map[string]string `json:"connectionStringSecretAnnotations,omitempty"`
+
 	// Additional options to be appended to the connection string.
 	// These options apply only to this user and will override any existing options in the resource.
 	// +kubebuilder:validation:Type=object
@@ -789,12 +793,13 @@ func (m *MongoDBCommunity) GetAuthUsers() []authtypes.User {
 		}
 
 		users[i] = authtypes.User{
-			Username:                        u.Name,
-			Database:                        u.DB,
-			Roles:                           roles,
-			ConnectionStringSecretName:      u.GetConnectionStringSecretName(m.Name),
-			ConnectionStringSecretNamespace: u.GetConnectionStringSecretNamespace(m.Namespace),
-			ConnectionStringOptions:         u.AdditionalConnectionStringConfig.Object,
+			Username:                          u.Name,
+			Database:                          u.DB,
+			Roles:                             roles,
+			ConnectionStringSecretName:        u.GetConnectionStringSecretName(m.Name),
+			ConnectionStringSecretNamespace:   u.GetConnectionStringSecretNamespace(m.Namespace),
+			ConnectionStringSecretAnnotations: u.ConnectionStringSecretAnnotations,
+			ConnectionStringOptions:           u.AdditionalConnectionStringConfig.Object,
 		}
 
 		if u.DB != constants.ExternalDB {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -314,6 +314,13 @@ func (in *MongoDBUser) DeepCopyInto(out *MongoDBUser) {
 		*out = make([]Role, len(*in))
 		copy(*out, *in)
 	}
+	if in.ConnectionStringSecretAnnotations != nil {
+		in, out := &in.ConnectionStringSecretAnnotations, &out.ConnectionStringSecretAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.AdditionalConnectionStringConfig.DeepCopyInto(&out.AdditionalConnectionStringConfig)
 }
 

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -552,6 +552,13 @@ spec:
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    connectionStringSecretAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: ConnectionStringSecretAnnotations is the annotations
+                        of the secret object created by the operator which exposes
+                        the connection strings for the user.
+                      type: object
                     connectionStringSecretName:
                       description: |-
                         ConnectionStringSecretName is the name of the secret object created by the operator which exposes the connection strings for the user.

--- a/controllers/mongodb_users.go
+++ b/controllers/mongodb_users.go
@@ -77,6 +77,7 @@ func (r ReplicaSetReconciler) updateConnectionStringSecrets(ctx context.Context,
 			SetField("username", user.Username).
 			SetField("password", pwd).
 			SetOwnerReferences(mdb.GetOwnerReferences()).
+			SetAnnotations(user.ConnectionStringSecretAnnotations).
 			Build()
 
 		if err := secret.CreateOrUpdate(ctx, r.client, connectionStringSecret); err != nil {

--- a/docs/users.md
+++ b/docs/users.md
@@ -42,6 +42,7 @@ You cannot disable SCRAM authentication.
    | `spec.users.roles` | array of objects | Configures roles assigned to the user. | Yes |
    | `spec.users.roles.role.name` | string | Name of the role. Valid values are [built-in roles](https://www.mongodb.com/docs/manual/reference/built-in-roles/#built-in-roles) and [custom roles](deploy-configure.md#define-a-custom-database-role) that you have defined. | Yes |
    | `spec.users.roles.role.db` | string | Database that the role applies to. | Yes |
+   | `spec.users.connectionStringSecretAnnotations` | object | Annotations of the secret object created by the operator which exposes the connection strings for the user. | No |
 
    ```yaml
    ---

--- a/pkg/authentication/authtypes/authtypes.go
+++ b/pkg/authentication/authtypes/authtypes.go
@@ -73,6 +73,9 @@ type User struct {
 	// ConnectionStringSecretNamespace is the namespace of the secret object created by the operator which exposes the connection strings for the user.
 	ConnectionStringSecretNamespace string `json:"connectionStringSecretNamespace,omitempty"`
 
+	// ConnectionStringSecretAnnotations is the annotations of the secret object created by the operator which exposes the connection strings for the user.
+	ConnectionStringSecretAnnotations map[string]string
+
 	// ConnectionStringOptions contains connection string options for this user
 	// These options will be appended at the end of the connection string and
 	// will override any existing options from the resources.

--- a/pkg/kube/secret/secret_builder.go
+++ b/pkg/kube/secret/secret_builder.go
@@ -11,6 +11,7 @@ type builder struct {
 	labels          map[string]string
 	name            string
 	namespace       string
+	annotations     map[string]string
 	ownerReferences []metav1.OwnerReference
 }
 
@@ -21,6 +22,11 @@ func (b *builder) SetName(name string) *builder {
 
 func (b *builder) SetNamespace(namespace string) *builder {
 	b.namespace = namespace
+	return b
+}
+
+func (b *builder) SetAnnotations(annotations map[string]string) *builder {
+	b.annotations = annotations
 	return b
 }
 
@@ -72,6 +78,7 @@ func (b builder) Build() corev1.Secret {
 			Namespace:       b.namespace,
 			OwnerReferences: b.ownerReferences,
 			Labels:          b.labels,
+			Annotations:     b.annotations,
 		},
 		Data: b.data,
 		Type: b.dataType,

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -205,6 +205,7 @@ func ConnectionStringSecretsAreConfigured(ctx context.Context, mdb *mdbv1.MongoD
 
 			assert.NoError(t, err)
 			assertEqualOwnerReference(t, "Secret", secretNamespacedName, secret.GetOwnerReferences(), expectedOwnerReference)
+			containsMetadata(t, secret.ObjectMeta, map[string]string{}, user.ConnectionStringSecretAnnotations, "secret "+secretNamespacedName.Name)
 		}
 	}
 }
@@ -677,6 +678,18 @@ func AddConnectionStringOptionToUser(ctx context.Context, mdb *mdbv1.MongoDBComm
 		t.Logf("Adding %s:%v to connection string to first user", key, value)
 		err := e2eutil.UpdateMongoDBResource(ctx, mdb, func(db *mdbv1.MongoDBCommunity) {
 			db.Spec.Users[0].AdditionalConnectionStringConfig.SetOption(key, value)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func AddConnectionStringAnnotationsToUser(ctx context.Context, mdb *mdbv1.MongoDBCommunity, annotations map[string]string) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Logf("Adding %v to connection string annotations", annotations)
+		err := e2eutil.UpdateMongoDBResource(ctx, mdb, func(db *mdbv1.MongoDBCommunity) {
+			db.Spec.Users[0].ConnectionStringSecretAnnotations = annotations
 		})
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
### Summary:

Closes #1522.

In this PR, I've added the ability to add custom annotations to the generated connection string secrets.

This is useful to handle more deployment scenarios, in particular, the scenarios where the operator is not deployed cluster-wide, but to a specific namespace. In these scenarios the `connectionStringSecretNamespace` property becomes useless, because, as stated in the [Kubernetes docs](https://kubernetes.io/docs/concepts/architecture/garbage-collection/#owners-dependents), cross-namespace owner references are disallowed, thus allowing for the secrets to be immediately garbage-collected, as stated in #1578. For the owner references to be valid, the secrets need to be generated in the namespace of the MDBC resource. However, if the user needs the secrets to be present in other namespaces, they can use [reflector](https://github.com/emberstack/kubernetes-reflector), for instance, which allows for the secrets to be copied to other namespaces. The problem is that reflector and other similar controllers require the source secrets to be annotated with specific properties.

As such, I've implemented a `connectionStringSecretAnnotations` property which allows mongodb-kubernetes-operator users to specify per-user connection string secret annotations.

I've done it in this way because I'm not very experienced with Go and this felt like the simplest way to do it. I could've also refactored all of the connection string secret to be grouped under a `connectionStringSecret` object, but this would break backwards compatibility.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
