### PR TITLE
Modify misleading or outdated documentation

### DIFF
--- a/docs/secure.md
+++ b/docs/secure.md
@@ -43,7 +43,8 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
    ```
 
 3. Create a TLS-secured MongoDBCommunity resource:
-This assumes you already have the operator installed in namespace `<namespace>`
+
+    This assumes you already have the operator installed in namespace `<namespace>`
 
    ```
    helm upgrade --install community-operator mongodb/community-operator \

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -50,7 +50,7 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
    helm upgrade --install community-operator mongodb/community-operator \
    --namespace <namespace> --set resource.tls.useCertManager=true \
    --set createResource=true --set resource.tls.enabled=true \
-   --set namespace=<namespace> --create-namespace
+   --set namespace=<namespace>
    ```
 
   This creates a resource secured with TLS and generates the necessary

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -36,20 +36,20 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
    helm repo update
    ```
 
-1. Install `cert-manager`:
+2. Install `cert-manager`:
 
    ```
-   helm install cert-manager jetstack/cert-manager --namespace cert-manager \ 
-   --create-namespace --set installCRDs=true
+   helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
    ```
 
-1. Create a TLS-secured MongoDBCommunity resource:
+3. Create a TLS-secured MongoDBCommunity resource:
+This assumes you already have the operator installed in namespace `<namespace>`
 
    ```
    helm upgrade --install community-operator mongodb/community-operator \
-   --namespace mongodb --set resource.tls.useCertManager=true \
+   --namespace <namespace> --set resource.tls.useCertManager=true \
    --set createResource=true --set resource.tls.enabled=true \
-   --set namespace=mongodb --create-namespace
+   --set namespace=<namespace> --create-namespace
    ```
 
   This creates a resource secured with TLS and generates the necessary
@@ -72,21 +72,21 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
 
 1. Test your connection over TLS by 
 
-   - Connecting to a `mongod` container using `kubectl`:
+   - Connecting to a `mongod` container inside a pod using `kubectl`:
 
    ```
-   kubectl exec -it mongodb-replica-set -c mongod -- bash
+   kubectl exec -it <mongodb-replica-set-pod> -c mongod -- bash
    ```
 
-   Where `mongodb-replica-set` is the name of your MongoDBCommunity resource
+   Where `mongodb-replica-set-pod` is the name of a pod from your MongoDBCommunity resource
 
    - Then, use `mongosh` to connect over TLS:
+   For how to get the connection string look at [Deploy A Replica Set](deploy-configure.md#deploy-a-replica-set)
 
    ```
-   mongosh --tls --tlsCAFile /var/lib/tls/ca/ca.crt --tlsCertificateKeyFile \
-   /var/lib/tls/server/*.pem \ 
-   --host <mongodb-replica-set>.<mongodb-replica-set>-svc.<namespace>.svc.cluster.local
+   mongosh "<connection-string>" --tls --tlsCAFile /var/lib/tls/ca/ca.crt --tlsCertificateKeyFile /var/lib/tls/server/*.pem 
    ```
 
    Where `mongodb-replica-set` is the name of your MongoDBCommunity 
-   resource and `namespace` is the namespace of your deployment.
+   resource, `namespace` is the namespace of your deployment
+   and  `connection-string` is a connection string for your `<mongodb-replica-set>-svc` service.

--- a/docs/users.md
+++ b/docs/users.md
@@ -84,6 +84,6 @@ You cannot disable SCRAM authentication.
 
 - To authenticate to your MongoDBCommunity resource, run the following command:
    ```
-   mongo "mongodb://<service-object-name>.<my-namespace>.svc.cluster.local:27017/?replicaSet=<replica-set-name>" --username <username> --password <password> --authenticationDatabase <authentication-database>
+   mongosh "mongodb://<replica-set-name>-svc.<my-namespace>.svc.cluster.local:27017/?replicaSet=<replica-set-name>" --username <username> --password <password> --authenticationDatabase <authentication-database>
    ```
 - To change a user's password, create and apply a new secret resource definition with a `metadata.name` that is the same as the name specified in `passwordSecretRef.name` of the MongoDB CRD. The Operator will automatically regenerate credentials.


### PR DESCRIPTION
### Summary:
This PR changes the documentation in 2 files: 
- secure.md
- users.md

Some commands are modified because their previous versions were not producing the expected results or were incorrect:

```
helm install cert-manager jetstack/cert-manager --namespace cert-manager \ 
--create-namespace --set installCRDs=true
```
was changed to
```
helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
```
because it did not work because of the way it was split.

```
mongosh --tls --tlsCAFile /var/lib/tls/ca/ca.crt --tlsCertificateKeyFile \
/var/lib/tls/server/*.pem \ 
--host <mongodb-replica-set>.<mongodb-replica-set>-svc.<namespace>.svc.cluster.local
```
was changed to
```
mongosh "<connection-string>" --tls --tlsCAFile /var/lib/tls/ca/ca.crt --tlsCertificateKeyFile /var/lib/tls/server/*.pem
```
because it did not use the proper connection string.

Other modifications were also made to improve clarity.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
