### PR TITLE
CLOUDP-196371: Delete users removed from the resource

### DIFF
--- a/.action_templates/jobs/tests.yaml
+++ b/.action_templates/jobs/tests.yaml
@@ -62,3 +62,5 @@ tests:
           distro: ubi
         - test-name: replica_set_x509
           distro: ubi
+        - test-name: replica_set_remove_user
+          distro: ubi

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -147,6 +147,8 @@ jobs:
           distro: ubi
         - test-name: replica_set_x509
           distro: ubi
+        - test-name: replica_set_remove_user
+          distro: ubi
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,6 +153,8 @@ jobs:
           distro: ubi
         - test-name: replica_set_x509
           distro: ubi
+        - test-name: replica_set_remove_user
+          distro: ubi
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ AGENT_IMAGE_NAME := $(shell jq -r .agent_image_ubi < $(MONGODB_COMMUNITY_CONFIG)
 
 HELM_CHART ?= ./helm-charts/charts/community-operator
 
-STRING_SET_VALUES := --set namespace=$(NAMESPACE),versionUpgradeHook.name=$(UPGRADE_HOOK_IMG),readinessProbe.name=$(READINESS_PROBE_IMG),registry.operator=$(REPO_URL),operator.operatorImageName=$(OPERATOR_IMAGE),operator.version=0.9.0-arm64,registry.agent=$(REGISTRY),registry.versionUpgradeHook=$(REGISTRY),registry.readinessProbe=$(REGISTRY),registry.operator=$(REGISTRY),versionUpgradeHook.version=1.0.8-arm64,readinessProbe.version=1.0.19-arm64,agent.version=13.19.0.8951-1-arm64,agent.name=$(AGENT_IMAGE_NAME)
+STRING_SET_VALUES := --set namespace=$(NAMESPACE),versionUpgradeHook.name=$(UPGRADE_HOOK_IMG),readinessProbe.name=$(READINESS_PROBE_IMG),registry.operator=$(REPO_URL),operator.operatorImageName=$(OPERATOR_IMAGE),operator.version=latest,registry.agent=$(REGISTRY),registry.versionUpgradeHook=$(REGISTRY),registry.readinessProbe=$(REGISTRY),registry.operator=$(REGISTRY),versionUpgradeHook.version=latest,readinessProbe.version=latest,agent.version=latest,agent.name=$(AGENT_IMAGE_NAME)
 STRING_SET_VALUES_LOCAL := $(STRING_SET_VALUES) --set operator.replicas=0
 
 DOCKERFILE ?= operator
@@ -134,7 +134,7 @@ install-rbac:
 	$(HELM) template $(STRING_SET_VALUES) -s templates/operator_roles.yaml $(HELM_CHART) | kubectl apply -f -
 
 uninstall-crd:
-	kubectl delete crd --ignore-not-found=true mongodbcommunity.mongodbcommunity.mongodb.com
+	kubectl delete crd mongodbcommunity.mongodbcommunity.mongodb.com
 
 uninstall-chart:
 	$(HELM) uninstall $(RELEASE_NAME_HELM) -n $(NAMESPACE)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ AGENT_IMAGE_NAME := $(shell jq -r .agent_image_ubi < $(MONGODB_COMMUNITY_CONFIG)
 
 HELM_CHART ?= ./helm-charts/charts/community-operator
 
-STRING_SET_VALUES := --set namespace=$(NAMESPACE),versionUpgradeHook.name=$(UPGRADE_HOOK_IMG),readinessProbe.name=$(READINESS_PROBE_IMG),registry.operator=$(REPO_URL),operator.operatorImageName=$(OPERATOR_IMAGE),operator.version=latest,registry.agent=$(REGISTRY),registry.versionUpgradeHook=$(REGISTRY),registry.readinessProbe=$(REGISTRY),registry.operator=$(REGISTRY),versionUpgradeHook.version=latest,readinessProbe.version=latest,agent.version=latest,agent.name=$(AGENT_IMAGE_NAME)
+STRING_SET_VALUES := --set namespace=$(NAMESPACE),versionUpgradeHook.name=$(UPGRADE_HOOK_IMG),readinessProbe.name=$(READINESS_PROBE_IMG),registry.operator=$(REPO_URL),operator.operatorImageName=$(OPERATOR_IMAGE),operator.version=0.9.0-arm64,registry.agent=$(REGISTRY),registry.versionUpgradeHook=$(REGISTRY),registry.readinessProbe=$(REGISTRY),registry.operator=$(REGISTRY),versionUpgradeHook.version=1.0.8-arm64,readinessProbe.version=1.0.19-arm64,agent.version=13.19.0.8951-1-arm64,agent.name=$(AGENT_IMAGE_NAME)
 STRING_SET_VALUES_LOCAL := $(STRING_SET_VALUES) --set operator.replicas=0
 
 DOCKERFILE ?= operator
@@ -134,7 +134,7 @@ install-rbac:
 	$(HELM) template $(STRING_SET_VALUES) -s templates/operator_roles.yaml $(HELM_CHART) | kubectl apply -f -
 
 uninstall-crd:
-	kubectl delete crd mongodbcommunity.mongodbcommunity.mongodb.com
+	kubectl delete crd --ignore-not-found=true mongodbcommunity.mongodbcommunity.mongodb.com
 
 uninstall-chart:
 	$(HELM) uninstall $(RELEASE_NAME_HELM) -n $(NAMESPACE)

--- a/controllers/mongodb_cleanup.go
+++ b/controllers/mongodb_cleanup.go
@@ -46,6 +46,22 @@ func (r *ReplicaSetReconciler) cleanupScramSecrets(ctx context.Context, currentM
 	}
 }
 
+// cleanupConnectionStringSecrets cleans up old scram secrets based on the last successful applied mongodb spec.
+func (r *ReplicaSetReconciler) cleanupConnectionStringSecrets(ctx context.Context, currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string, resourceName string) {
+	secretsToDelete := getConnectionStringSecretsToDelete(currentMDB, lastAppliedMDBSpec, resourceName)
+
+	for _, s := range secretsToDelete {
+		if err := r.client.DeleteSecret(ctx, types.NamespacedName{
+			Name:      s,
+			Namespace: namespace,
+		}); err != nil {
+			r.log.Warnf("Could not cleanup old secret %s", s)
+		} else {
+			r.log.Debugf("Sucessfully cleaned up secret: %s", s)
+		}
+	}
+}
+
 func getScramSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec) []string {
 	type user struct {
 		db   string
@@ -69,6 +85,34 @@ func getScramSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedM
 			secretsToDelete = append(secretsToDelete, mongoDBUser.GetScramCredentialsSecretName())
 		} else if currentScramSecretName != mongoDBUser.GetScramCredentialsSecretName() { // have changed
 			secretsToDelete = append(secretsToDelete, mongoDBUser.GetScramCredentialsSecretName())
+		}
+	}
+	return secretsToDelete
+}
+
+func getConnectionStringSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, resourceName string) []string {
+	type user struct {
+		db   string
+		name string
+	}
+	m := map[user]string{}
+	var secretsToDelete []string
+
+	for _, mongoDBUser := range currentMDB.Users {
+		if mongoDBUser.DB != constants.ExternalDB {
+			m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = mongoDBUser.GetConnectionStringSecretName(resourceName)
+		}
+	}
+
+	for _, mongoDBUser := range lastAppliedMDBSpec.Users {
+		if mongoDBUser.DB == constants.ExternalDB {
+			continue
+		}
+		currentConnectionStringSecretName, ok := m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}]
+		if !ok { // not used anymore
+			secretsToDelete = append(secretsToDelete, mongoDBUser.GetConnectionStringSecretName(resourceName))
+		} else if currentConnectionStringSecretName != mongoDBUser.GetConnectionStringSecretName(resourceName) { // have changed
+			secretsToDelete = append(secretsToDelete, mongoDBUser.GetConnectionStringSecretName(resourceName))
 		}
 	}
 	return secretsToDelete

--- a/controllers/mongodb_cleanup.go
+++ b/controllers/mongodb_cleanup.go
@@ -10,12 +10,12 @@ import (
 )
 
 // cleanupPemSecret cleans up the old pem secret generated for the agent certificate.
-func (r *ReplicaSetReconciler) cleanupPemSecret(ctx context.Context, currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
-	if currentMDB.GetAgentAuthMode() == lastAppliedMDBSpec.GetAgentAuthMode() {
+func (r *ReplicaSetReconciler) cleanupPemSecret(ctx context.Context, currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
+	if currentMDBSpec.GetAgentAuthMode() == lastAppliedMDBSpec.GetAgentAuthMode() {
 		return
 	}
 
-	if !currentMDB.IsAgentX509() && lastAppliedMDBSpec.IsAgentX509() {
+	if !currentMDBSpec.IsAgentX509() && lastAppliedMDBSpec.IsAgentX509() {
 		agentCertSecret := lastAppliedMDBSpec.GetAgentCertificateRef()
 		if err := r.client.DeleteSecret(ctx, types.NamespacedName{
 			Namespace: namespace,
@@ -31,15 +31,15 @@ func (r *ReplicaSetReconciler) cleanupPemSecret(ctx context.Context, currentMDB 
 }
 
 // cleanupScramSecrets cleans up old scram secrets based on the last successful applied mongodb spec.
-func (r *ReplicaSetReconciler) cleanupScramSecrets(ctx context.Context, currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
-	secretsToDelete := getScramSecretsToDelete(currentMDB, lastAppliedMDBSpec)
+func (r *ReplicaSetReconciler) cleanupScramSecrets(ctx context.Context, currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string) {
+	secretsToDelete := getScramSecretsToDelete(currentMDBSpec, lastAppliedMDBSpec)
 
 	for _, s := range secretsToDelete {
 		if err := r.client.DeleteSecret(ctx, types.NamespacedName{
 			Name:      s,
 			Namespace: namespace,
 		}); err != nil {
-			r.log.Warnf("Could not cleanup old secret %s", s)
+			r.log.Warnf("Could not cleanup old secret %s: %s", s, err)
 		} else {
 			r.log.Debugf("Sucessfully cleaned up secret: %s", s)
 		}
@@ -47,22 +47,22 @@ func (r *ReplicaSetReconciler) cleanupScramSecrets(ctx context.Context, currentM
 }
 
 // cleanupConnectionStringSecrets cleans up old scram secrets based on the last successful applied mongodb spec.
-func (r *ReplicaSetReconciler) cleanupConnectionStringSecrets(ctx context.Context, currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string, resourceName string) {
-	secretsToDelete := getConnectionStringSecretsToDelete(currentMDB, lastAppliedMDBSpec, resourceName)
+func (r *ReplicaSetReconciler) cleanupConnectionStringSecrets(ctx context.Context, currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, namespace string, resourceName string) {
+	secretsToDelete := getConnectionStringSecretsToDelete(currentMDBSpec, lastAppliedMDBSpec, resourceName)
 
 	for _, s := range secretsToDelete {
 		if err := r.client.DeleteSecret(ctx, types.NamespacedName{
 			Name:      s,
 			Namespace: namespace,
 		}); err != nil {
-			r.log.Warnf("Could not cleanup old secret %s", s)
+			r.log.Warnf("Could not cleanup old secret %s: %s", s, err)
 		} else {
 			r.log.Debugf("Sucessfully cleaned up secret: %s", s)
 		}
 	}
 }
 
-func getScramSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec) []string {
+func getScramSecretsToDelete(currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec) []string {
 	type user struct {
 		db   string
 		name string
@@ -70,10 +70,11 @@ func getScramSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedM
 	m := map[user]string{}
 	var secretsToDelete []string
 
-	for _, mongoDBUser := range currentMDB.Users {
-		if mongoDBUser.DB != constants.ExternalDB {
-			m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = mongoDBUser.GetScramCredentialsSecretName()
+	for _, mongoDBUser := range currentMDBSpec.Users {
+		if mongoDBUser.DB == constants.ExternalDB {
+			continue
 		}
+		m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = mongoDBUser.GetScramCredentialsSecretName()
 	}
 
 	for _, mongoDBUser := range lastAppliedMDBSpec.Users {
@@ -90,7 +91,7 @@ func getScramSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedM
 	return secretsToDelete
 }
 
-func getConnectionStringSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, resourceName string) []string {
+func getConnectionStringSecretsToDelete(currentMDBSpec mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec mdbv1.MongoDBCommunitySpec, resourceName string) []string {
 	type user struct {
 		db   string
 		name string
@@ -98,10 +99,11 @@ func getConnectionStringSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, l
 	m := map[user]string{}
 	var secretsToDelete []string
 
-	for _, mongoDBUser := range currentMDB.Users {
-		if mongoDBUser.DB != constants.ExternalDB {
-			m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = mongoDBUser.GetConnectionStringSecretName(resourceName)
+	for _, mongoDBUser := range currentMDBSpec.Users {
+		if mongoDBUser.DB == constants.ExternalDB {
+			continue
 		}
+		m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = mongoDBUser.GetConnectionStringSecretName(resourceName)
 	}
 
 	for _, mongoDBUser := range lastAppliedMDBSpec.Users {
@@ -109,9 +111,10 @@ func getConnectionStringSecretsToDelete(currentMDB mdbv1.MongoDBCommunitySpec, l
 			continue
 		}
 		currentConnectionStringSecretName, ok := m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}]
-		if !ok { // not used anymore
+		if !ok { // user was removed
 			secretsToDelete = append(secretsToDelete, mongoDBUser.GetConnectionStringSecretName(resourceName))
-		} else if currentConnectionStringSecretName != mongoDBUser.GetConnectionStringSecretName(resourceName) { // have changed
+		} else if currentConnectionStringSecretName != mongoDBUser.GetConnectionStringSecretName(resourceName) {
+			// this happens when a new ConnectionStringSecretName was set for the old user
 			secretsToDelete = append(secretsToDelete, mongoDBUser.GetConnectionStringSecretName(resourceName))
 		}
 	}

--- a/controllers/mongodb_cleanup_test.go
+++ b/controllers/mongodb_cleanup_test.go
@@ -22,8 +22,7 @@ func TestReplicaSetReconcilerCleanupScramSecrets(t *testing.T) {
 	t.Run("no change same resource", func(t *testing.T) {
 		actual := getScramSecretsToDelete(lastApplied.Spec, lastApplied.Spec)
 
-		var expected []string
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, []string{}, actual)
 	})
 
 	t.Run("new user new secret", func(t *testing.T) {
@@ -44,10 +43,9 @@ func TestReplicaSetReconcilerCleanupScramSecrets(t *testing.T) {
 			},
 		)
 
-		var expected []string
 		actual := getScramSecretsToDelete(current.Spec, lastApplied.Spec)
 
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, []string{}, actual)
 	})
 
 	t.Run("old user new secret", func(t *testing.T) {
@@ -167,11 +165,10 @@ func TestReplicaSetReconcilerCleanupConnectionStringSecrets(t *testing.T) {
 	t.Run("no change same resource", func(t *testing.T) {
 		actual := getConnectionStringSecretsToDelete(lastApplied.Spec, lastApplied.Spec, "my-rs")
 
-		var expected []string
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, []string{}, actual)
 	})
 
-	t.Run("new user new secret", func(t *testing.T) {
+	t.Run("new user does not require existing user cleanup", func(t *testing.T) {
 		current := newScramReplicaSet(
 			mdbv1.MongoDBUser{
 				Name: "testUser",
@@ -189,10 +186,9 @@ func TestReplicaSetReconcilerCleanupConnectionStringSecrets(t *testing.T) {
 			},
 		)
 
-		var expected []string
 		actual := getConnectionStringSecretsToDelete(current.Spec, lastApplied.Spec, "my-rs")
 
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, []string{}, actual)
 	})
 
 	t.Run("old user new secret", func(t *testing.T) {
@@ -210,7 +206,7 @@ func TestReplicaSetReconcilerCleanupConnectionStringSecrets(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("removed one user", func(t *testing.T) {
+	t.Run("removed one user and changed secret of the other", func(t *testing.T) {
 		lastApplied = newScramReplicaSet(
 			mdbv1.MongoDBUser{
 				Name: "testUser",

--- a/controllers/mongodb_cleanup_test.go
+++ b/controllers/mongodb_cleanup_test.go
@@ -22,7 +22,7 @@ func TestReplicaSetReconcilerCleanupScramSecrets(t *testing.T) {
 	t.Run("no change same resource", func(t *testing.T) {
 		actual := getScramSecretsToDelete(lastApplied.Spec, lastApplied.Spec)
 
-		assert.Equal(t, []string{}, actual)
+		assert.Equal(t, []string(nil), actual)
 	})
 
 	t.Run("new user new secret", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestReplicaSetReconcilerCleanupScramSecrets(t *testing.T) {
 
 		actual := getScramSecretsToDelete(current.Spec, lastApplied.Spec)
 
-		assert.Equal(t, []string{}, actual)
+		assert.Equal(t, []string(nil), actual)
 	})
 
 	t.Run("old user new secret", func(t *testing.T) {
@@ -165,7 +165,7 @@ func TestReplicaSetReconcilerCleanupConnectionStringSecrets(t *testing.T) {
 	t.Run("no change same resource", func(t *testing.T) {
 		actual := getConnectionStringSecretsToDelete(lastApplied.Spec, lastApplied.Spec, "my-rs")
 
-		assert.Equal(t, []string{}, actual)
+		assert.Equal(t, []string(nil), actual)
 	})
 
 	t.Run("new user does not require existing user cleanup", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestReplicaSetReconcilerCleanupConnectionStringSecrets(t *testing.T) {
 
 		actual := getConnectionStringSecretsToDelete(current.Spec, lastApplied.Spec, "my-rs")
 
-		assert.Equal(t, []string{}, actual)
+		assert.Equal(t, []string(nil), actual)
 	})
 
 	t.Run("old user new secret", func(t *testing.T) {

--- a/controllers/mongodb_cleanup_test.go
+++ b/controllers/mongodb_cleanup_test.go
@@ -154,3 +154,92 @@ func TestReplicaSetReconcilerCleanupPemSecret(t *testing.T) {
 	_, err = r.client.GetSecret(ctx, mdb.AgentCertificatePemSecretNamespacedName())
 	assert.Error(t, err)
 }
+
+func TestReplicaSetReconcilerCleanupConnectionStringSecrets(t *testing.T) {
+	lastApplied := newScramReplicaSet(mdbv1.MongoDBUser{
+		Name: "testUser",
+		PasswordSecretRef: mdbv1.SecretKeyReference{
+			Name: "password-secret-name",
+		},
+		ConnectionStringSecretName: "connection-string-secret",
+	})
+
+	t.Run("no change same resource", func(t *testing.T) {
+		actual := getConnectionStringSecretsToDelete(lastApplied.Spec, lastApplied.Spec, "my-rs")
+
+		var expected []string
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("new user new secret", func(t *testing.T) {
+		current := newScramReplicaSet(
+			mdbv1.MongoDBUser{
+				Name: "testUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ConnectionStringSecretName: "connection-string-secret",
+			},
+			mdbv1.MongoDBUser{
+				Name: "newUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ConnectionStringSecretName: "connection-string-secret-2",
+			},
+		)
+
+		var expected []string
+		actual := getConnectionStringSecretsToDelete(current.Spec, lastApplied.Spec, "my-rs")
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("old user new secret", func(t *testing.T) {
+		current := newScramReplicaSet(mdbv1.MongoDBUser{
+			Name: "testUser",
+			PasswordSecretRef: mdbv1.SecretKeyReference{
+				Name: "password-secret-name",
+			},
+			ConnectionStringSecretName: "connection-string-secret-2",
+		})
+
+		expected := []string{"connection-string-secret"}
+		actual := getConnectionStringSecretsToDelete(current.Spec, lastApplied.Spec, "my-rs")
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("removed one user", func(t *testing.T) {
+		lastApplied = newScramReplicaSet(
+			mdbv1.MongoDBUser{
+				Name: "testUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ConnectionStringSecretName: "connection-string-secret",
+			},
+			mdbv1.MongoDBUser{
+				Name: "anotherUser",
+				PasswordSecretRef: mdbv1.SecretKeyReference{
+					Name: "password-secret-name",
+				},
+				ConnectionStringSecretName: "connection-string-secret-2",
+			},
+		)
+
+		current := newScramReplicaSet(mdbv1.MongoDBUser{
+			Name: "testUser",
+			PasswordSecretRef: mdbv1.SecretKeyReference{
+				Name: "password-secret-name",
+			},
+			ConnectionStringSecretName: "connection-string-secret-1",
+		})
+
+		expected := []string{"connection-string-secret", "connection-string-secret-2"}
+		actual := getConnectionStringSecretsToDelete(current.Spec, lastApplied.Spec, "my-rs")
+
+		assert.Equal(t, expected, actual)
+	})
+
+}

--- a/controllers/mongodb_users.go
+++ b/controllers/mongodb_users.go
@@ -83,7 +83,7 @@ func (r ReplicaSetReconciler) updateConnectionStringSecrets(ctx context.Context,
 			return err
 		}
 
-		secretNamespacedName := types.NamespacedName{Name: user.PasswordSecretName, Namespace: secretNamespace}
+		secretNamespacedName := types.NamespacedName{Name: connectionStringSecret.Name, Namespace: connectionStringSecret.Namespace}
 		r.secretWatcher.Watch(ctx, secretNamespacedName, mdb.NamespacedName())
 	}
 

--- a/controllers/mongodb_users.go
+++ b/controllers/mongodb_users.go
@@ -82,6 +82,9 @@ func (r ReplicaSetReconciler) updateConnectionStringSecrets(ctx context.Context,
 		if err := secret.CreateOrUpdate(ctx, r.client, connectionStringSecret); err != nil {
 			return err
 		}
+
+		secretNamespacedName := types.NamespacedName{Name: user.PasswordSecretName, Namespace: secretNamespace}
+		r.secretWatcher.Watch(ctx, secretNamespacedName, mdb.NamespacedName())
 	}
 
 	return nil

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -43,7 +43,8 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
    ```
 
 3. Create a TLS-secured MongoDBCommunity resource:
-This assumes you already have the operator installed in namespace `<namespace>`
+
+    This assumes you already have the operator installed in namespace `<namespace>`
 
    ```
    helm upgrade --install community-operator mongodb/community-operator \

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -50,7 +50,7 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
    helm upgrade --install community-operator mongodb/community-operator \
    --namespace <namespace> --set resource.tls.useCertManager=true \
    --set createResource=true --set resource.tls.enabled=true \
-   --set namespace=<namespace> --create-namespace
+   --set namespace=<namespace>
    ```
 
   This creates a resource secured with TLS and generates the necessary

--- a/docs/secure.md
+++ b/docs/secure.md
@@ -36,20 +36,20 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
    helm repo update
    ```
 
-1. Install `cert-manager`:
+2. Install `cert-manager`:
 
    ```
-   helm install cert-manager jetstack/cert-manager --namespace cert-manager \ 
-   --create-namespace --set installCRDs=true
+   helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
    ```
 
-1. Create a TLS-secured MongoDBCommunity resource:
+3. Create a TLS-secured MongoDBCommunity resource:
+This assumes you already have the operator installed in namespace `<namespace>`
 
    ```
    helm upgrade --install community-operator mongodb/community-operator \
-   --namespace mongodb --set resource.tls.useCertManager=true \
+   --namespace <namespace> --set resource.tls.useCertManager=true \
    --set createResource=true --set resource.tls.enabled=true \
-   --set namespace=mongodb --create-namespace
+   --set namespace=<namespace> --create-namespace
    ```
 
   This creates a resource secured with TLS and generates the necessary
@@ -72,21 +72,21 @@ To secure connections to MongoDBCommunity resources with TLS using `cert-manager
 
 1. Test your connection over TLS by 
 
-   - Connecting to a `mongod` container using `kubectl`:
+   - Connecting to a `mongod` container inside a pod using `kubectl`:
 
    ```
-   kubectl exec -it mongodb-replica-set -c mongod -- bash
+   kubectl exec -it <mongodb-replica-set-pod> -c mongod -- bash
    ```
 
-   Where `mongodb-replica-set` is the name of your MongoDBCommunity resource
+   Where `mongodb-replica-set-pod` is the name of a pod from your MongoDBCommunity resource
 
    - Then, use `mongosh` to connect over TLS:
+   For how to get the connection string look at [Deploy A Replica Set](deploy-configure.md#deploy-a-replica-set)
 
    ```
-   mongosh --tls --tlsCAFile /var/lib/tls/ca/ca.crt --tlsCertificateKeyFile \
-   /var/lib/tls/server/*.pem \ 
-   --host <mongodb-replica-set>.<mongodb-replica-set>-svc.<namespace>.svc.cluster.local
+   mongosh "<connection-string>" --tls --tlsCAFile /var/lib/tls/ca/ca.crt --tlsCertificateKeyFile /var/lib/tls/server/*.pem 
    ```
 
    Where `mongodb-replica-set` is the name of your MongoDBCommunity 
-   resource and `namespace` is the namespace of your deployment.
+   resource, `namespace` is the namespace of your deployment
+   and  `connection-string` is a connection string for your `<mongodb-replica-set>-svc` service.

--- a/docs/users.md
+++ b/docs/users.md
@@ -84,6 +84,6 @@ You cannot disable SCRAM authentication.
 
 - To authenticate to your MongoDBCommunity resource, run the following command:
    ```
-   mongo "mongodb://<service-object-name>.<my-namespace>.svc.cluster.local:27017/?replicaSet=<replica-set-name>" --username <username> --password <password> --authenticationDatabase <authentication-database>
+   mongosh "mongodb://<replica-set-name>-svc.<my-namespace>.svc.cluster.local:27017/?replicaSet=<replica-set-name>" --username <username> --password <password> --authenticationDatabase <authentication-database>
    ```
 - To change a user's password, create and apply a new secret resource definition with a `metadata.name` that is the same as the name specified in `passwordSecretRef.name` of the MongoDB CRD. The Operator will automatically regenerate credentials.

--- a/pkg/authentication/authentication.go
+++ b/pkg/authentication/authentication.go
@@ -36,12 +36,12 @@ func Enable(ctx context.Context, auth *automationconfig.Auth, secretGetUpdateCre
 }
 
 func AddRemovedUsers(auth *automationconfig.Auth, mdb mdbv1.MongoDBCommunity, lastAppliedSpec *mdbv1.MongoDBCommunitySpec) {
-	deletedUsers := getDeletedUsers(mdb.Spec, lastAppliedSpec)
+	deletedUsers := getRemovedUsersFromSpec(mdb.Spec, lastAppliedSpec)
 
 	auth.UsersDeleted = append(auth.UsersDeleted, deletedUsers...)
 }
 
-func getDeletedUsers(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec *mdbv1.MongoDBCommunitySpec) []automationconfig.DeletedUser {
+func getRemovedUsersFromSpec(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec *mdbv1.MongoDBCommunitySpec) []automationconfig.DeletedUser {
 	type user struct {
 		db   string
 		name string
@@ -50,9 +50,10 @@ func getDeletedUsers(currentMDB mdbv1.MongoDBCommunitySpec, lastAppliedMDBSpec *
 	var deletedUsers []automationconfig.DeletedUser
 
 	for _, mongoDBUser := range currentMDB.Users {
-		if mongoDBUser.DB != constants.ExternalDB {
-			m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = true
+		if mongoDBUser.DB == constants.ExternalDB {
+			continue
 		}
+		m[user{db: mongoDBUser.DB, name: mongoDBUser.Name}] = true
 	}
 
 	for _, mongoDBUser := range lastAppliedMDBSpec.Users {

--- a/pkg/authentication/authentication_test.go
+++ b/pkg/authentication/authentication_test.go
@@ -157,7 +157,7 @@ func TestGetDeletedUsers(t *testing.T) {
 	}
 
 	t.Run("no change same resource", func(t *testing.T) {
-		actual := getDeletedUsers(lastAppliedSpec, &lastAppliedSpec)
+		actual := getRemovedUsersFromSpec(lastAppliedSpec, &lastAppliedSpec)
 
 		var expected []automationconfig.DeletedUser
 		assert.Equal(t, expected, actual)
@@ -195,7 +195,7 @@ func TestGetDeletedUsers(t *testing.T) {
 		}
 
 		var expected []automationconfig.DeletedUser
-		actual := getDeletedUsers(current, &lastAppliedSpec)
+		actual := getRemovedUsersFromSpec(current, &lastAppliedSpec)
 
 		assert.Equal(t, expected, actual)
 	})
@@ -220,7 +220,7 @@ func TestGetDeletedUsers(t *testing.T) {
 				Dbs:  []string{"admin"},
 			},
 		}
-		actual := getDeletedUsers(current, &lastAppliedSpec)
+		actual := getRemovedUsersFromSpec(current, &lastAppliedSpec)
 
 		assert.Equal(t, expected, actual)
 	})

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -327,6 +327,15 @@ type Auth struct {
 	KeyFileWindows string `json:"keyfileWindows,omitempty"`
 	// AutoPwd is a required field when going from `Disabled=false` to `Disabled=true`
 	AutoPwd string `json:"autoPwd,omitempty"`
+	// UsersDeleted is an array of DeletedUser objects that define the authenticated users to be deleted from specified databases
+	UsersDeleted []DeletedUser `json:"usersDeleted,omitempty"`
+}
+
+type DeletedUser struct {
+	// User is the username that should be deleted
+	User string `json:"user",omitempty`
+	// Dbs is the array of database names from which the authenticated user should be deleted
+	Dbs []string `json:"dbs",omitempty`
 }
 
 type Prometheus struct {

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -333,9 +333,9 @@ type Auth struct {
 
 type DeletedUser struct {
 	// User is the username that should be deleted
-	User string `json:"user",omitempty`
+	User string `json:"user,omitempty"`
 	// Dbs is the array of database names from which the authenticated user should be deleted
-	Dbs []string `json:"dbs",omitempty`
+	Dbs []string `json:"dbs,omitempty"`
 }
 
 type Prometheus struct {

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -772,7 +772,7 @@ func assertEqualOwnerReference(t *testing.T, resourceType string, resourceNamesp
 	assert.Equal(t, expectedOwnerReference.UID, ownerReferences[0].UID)
 }
 
-func RemoveUserFromResource(ctx context.Context, mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
+func RemoveAllUsersFromResource(ctx context.Context, mdb *mdbv1.MongoDBCommunity) func(*testing.T) {
 	return func(t *testing.T) {
 		err := e2eutil.UpdateMongoDBResource(ctx, mdb, func(db *mdbv1.MongoDBCommunity) {
 			db.Spec.Users = []mdbv1.MongoDBUser{}
@@ -789,6 +789,7 @@ func ConnectionStringSecretIsCleanedUp(ctx context.Context, mdb *mdbv1.MongoDBCo
 		connectionStringSecret := corev1.Secret{}
 		newErr := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: removedConnectionString, Namespace: mdb.Namespace}, &connectionStringSecret)
 
+		fmt.Println(newErr)
 		assert.Error(t, newErr)
 	}
 }

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -784,7 +784,7 @@ func RemoveUserFromResource(ctx context.Context, mdb *mdbv1.MongoDBCommunity) fu
 	}
 }
 
-func ConnectionStringSecretsAreCleanedUp(ctx context.Context, mdb *mdbv1.MongoDBCommunity, removedConnectionString string) func(t *testing.T) {
+func ConnectionStringSecretIsCleanedUp(ctx context.Context, mdb *mdbv1.MongoDBCommunity, removedConnectionString string) func(t *testing.T) {
 	return func(t *testing.T) {
 		connectionStringSecret := corev1.Secret{}
 		newErr := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: removedConnectionString, Namespace: mdb.Namespace}, &connectionStringSecret)
@@ -795,7 +795,7 @@ func ConnectionStringSecretsAreCleanedUp(ctx context.Context, mdb *mdbv1.MongoDB
 
 func AuthUsersDeletedIsUpdated(ctx context.Context, mdb *mdbv1.MongoDBCommunity, mdbUser mdbv1.MongoDBUser) func(t *testing.T) {
 	return func(t *testing.T) {
-		deletedUser := automationconfig.DeletedUser{User: mdbUser.Name, Dbs: []string{"admin"}}
+		deletedUser := automationconfig.DeletedUser{User: mdbUser.Name, Dbs: []string{mdbUser.DB}}
 
 		currentAc := getAutomationConfig(ctx, t, mdb)
 

--- a/test/e2e/mongodbtests/mongodbtests.go
+++ b/test/e2e/mongodbtests/mongodbtests.go
@@ -800,8 +800,7 @@ func ConnectionStringSecretIsCleanedUp(ctx context.Context, mdb *mdbv1.MongoDBCo
 	return func(t *testing.T) {
 		connectionStringSecret := corev1.Secret{}
 		newErr := e2eutil.TestClient.Get(ctx, types.NamespacedName{Name: removedConnectionString, Namespace: mdb.Namespace}, &connectionStringSecret)
-
-		fmt.Println(newErr)
+		
 		assert.EqualError(t, newErr, fmt.Sprintf("secrets \"%s\" not found", removedConnectionString))
 	}
 }

--- a/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
+++ b/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
@@ -99,7 +99,7 @@ func TestCleanupUsers(t *testing.T) {
 	deletedUser := mdb.Spec.Users[0]
 	t.Run("Delete user from MongoDB Resource", mongodbtests.RemoveUserFromResource(ctx, &mdb))
 	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
-	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, user))
-	t.Run("Connection string secrets are cleaned up", mongodbtests.ConnectionStringSecretsAreCleanedUp(ctx, &mdb, deletedUser.GetConnectionStringSecretName(mdb.Name)))
+	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, deletedUser))
+	t.Run("Connection string secrets are cleaned up", mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, deletedUser.GetConnectionStringSecretName(mdb.Name)))
 	t.Run("Delete MongoDB Resource", mongodbtests.DeleteMongoDBResource(&mdb, testCtx))
 }

--- a/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
+++ b/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
@@ -3,7 +3,7 @@ package replica_set_remove_user
 import (
 	"context"
 	"fmt"
-	v1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
 	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
 	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
@@ -36,28 +36,6 @@ func TestCleanupUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lcr := automationconfig.CrdLogRotate{
-		// fractional values are supported
-		SizeThresholdMB: "0.1",
-		LogRotate: automationconfig.LogRotate{
-			TimeThresholdHrs:                1,
-			NumUncompressed:                 10,
-			NumTotal:                        10,
-			IncludeAuditLogsWithMongoDBLogs: false,
-		},
-		PercentOfDiskspace: "1",
-	}
-
-	systemLog := automationconfig.SystemLog{
-		Destination: automationconfig.File,
-		Path:        "/tmp/mongod.log",
-		LogAppend:   false,
-	}
-
-	// logRotate can only be configured if systemLog to file has been configured
-	mdb.Spec.AgentConfiguration.LogRotate = &lcr
-	mdb.Spec.AgentConfiguration.SystemLog = &systemLog
-
 	// config member options
 	memberOptions := []automationconfig.MemberOptions{
 		{
@@ -81,8 +59,46 @@ func TestCleanupUsers(t *testing.T) {
 	settings := map[string]interface{}{
 		"electionTimeoutMillis": float64(20),
 	}
-	mdb.Spec.AutomationConfigOverride = &v1.AutomationConfigOverride{
-		ReplicaSet: v1.OverrideReplicaSet{Settings: v1.MapWrapper{Object: settings}},
+	mdb.Spec.AutomationConfigOverride = &mdbv1.AutomationConfigOverride{
+		ReplicaSet: mdbv1.OverrideReplicaSet{Settings: mdbv1.MapWrapper{Object: settings}},
+	}
+
+	newUser := mdbv1.MongoDBUser{
+		Name: fmt.Sprintf("%s-user-2", "mdb-0"),
+		PasswordSecretRef: mdbv1.SecretKeyReference{
+			Key:  fmt.Sprintf("%s-password-2", "mdb-0"),
+			Name: fmt.Sprintf("%s-%s-password-secret-2", "mdb-0", testCtx.ExecutionId),
+		},
+		Roles: []mdbv1.Role{
+			// roles on testing db for general connectivity
+			{
+				DB:   "testing",
+				Name: "readWrite",
+			},
+			{
+				DB:   "testing",
+				Name: "clusterAdmin",
+			},
+			// admin roles for reading FCV
+			{
+				DB:   "admin",
+				Name: "readWrite",
+			},
+			{
+				DB:   "admin",
+				Name: "clusterAdmin",
+			},
+			{
+				DB:   "admin",
+				Name: "userAdmin",
+			},
+		},
+		ScramCredentialsSecretName: fmt.Sprintf("%s-my-scram-2", "mdb-0"),
+	}
+
+	_, err = setup.GeneratePasswordForUser(testCtx, newUser, "")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tester, err := FromResource(ctx, t, mdb)
@@ -93,11 +109,16 @@ func TestCleanupUsers(t *testing.T) {
 	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, testCtx))
 	t.Run("Basic tests", mongodbtests.BasicFunctionality(ctx, &mdb))
 	t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
-	t.Run("AutomationConfig has the correct logRotateConfig", mongodbtests.AutomationConfigHasLogRotationConfig(ctx, &mdb, &lcr))
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet(mdb.Name)))
-	deletedUser := mdb.Spec.Users[0]
-	t.Run("Delete user from MongoDB Resource", mongodbtests.RemoveAllUsersFromResource(ctx, &mdb))
+	t.Run("Add new user to MongoDB Resource", mongodbtests.AddUserToMongoDBCommunity(ctx, &mdb, newUser))
+	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
+	editedUser := mdb.Spec.Users[1]
+	t.Run("Edit connection string secret name of the added user", mongodbtests.EditConnectionStringSecretNameOfLastUser(ctx, &mdb, "other-secret-name"))
+	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
+	t.Run("Old connection string secret is cleaned up", mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, editedUser.GetConnectionStringSecretName(mdb.Name)))
+	deletedUser := mdb.Spec.Users[1]
+	t.Run("Remove last user from MongoDB Resource", mongodbtests.RemoveLastUserFromMongoDBCommunity(ctx, &mdb))
 	t.Run("MongoDB reaches Pending phase", mongodbtests.MongoDBReachesPendingPhase(ctx, &mdb))
 	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, deletedUser))
 	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))

--- a/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
+++ b/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
@@ -98,8 +98,9 @@ func TestCleanupUsers(t *testing.T) {
 	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet(mdb.Name)))
 	deletedUser := mdb.Spec.Users[0]
 	t.Run("Delete user from MongoDB Resource", mongodbtests.RemoveUserFromResource(ctx, &mdb))
-	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
+	t.Run("MongoDB reaches Pending phase", mongodbtests.MongoDBReachesPendingPhase(ctx, &mdb))
 	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, deletedUser))
+	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
 	t.Run("Connection string secrets are cleaned up", mongodbtests.ConnectionStringSecretIsCleanedUp(ctx, &mdb, deletedUser.GetConnectionStringSecretName(mdb.Name)))
 	t.Run("Delete MongoDB Resource", mongodbtests.DeleteMongoDBResource(&mdb, testCtx))
 }

--- a/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
+++ b/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
@@ -97,7 +97,7 @@ func TestCleanupUsers(t *testing.T) {
 	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
 	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet(mdb.Name)))
 	deletedUser := mdb.Spec.Users[0]
-	t.Run("Delete user from MongoDB Resource", mongodbtests.RemoveUserFromResource(ctx, &mdb))
+	t.Run("Delete user from MongoDB Resource", mongodbtests.RemoveAllUsersFromResource(ctx, &mdb))
 	t.Run("MongoDB reaches Pending phase", mongodbtests.MongoDBReachesPendingPhase(ctx, &mdb))
 	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, deletedUser))
 	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))

--- a/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
+++ b/test/e2e/replica_set_remove_user/replica_set_remove_user_test.go
@@ -1,0 +1,105 @@
+package replica_set_remove_user
+
+import (
+	"context"
+	"fmt"
+	v1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/automationconfig"
+	e2eutil "github.com/mongodb/mongodb-kubernetes-operator/test/e2e"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/mongodbtests"
+	"github.com/mongodb/mongodb-kubernetes-operator/test/e2e/setup"
+	. "github.com/mongodb/mongodb-kubernetes-operator/test/e2e/util/mongotester"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	code, err := e2eutil.RunTest(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(code)
+}
+
+func intPtr(x int) *int       { return &x }
+func strPtr(s string) *string { return &s }
+
+func TestCleanupUsers(t *testing.T) {
+	ctx := context.Background()
+	testCtx := setup.Setup(ctx, t)
+	defer testCtx.Teardown()
+
+	mdb, user := e2eutil.NewTestMongoDB(testCtx, "mdb0", "")
+
+	_, err := setup.GeneratePasswordForUser(testCtx, user, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lcr := automationconfig.CrdLogRotate{
+		// fractional values are supported
+		SizeThresholdMB: "0.1",
+		LogRotate: automationconfig.LogRotate{
+			TimeThresholdHrs:                1,
+			NumUncompressed:                 10,
+			NumTotal:                        10,
+			IncludeAuditLogsWithMongoDBLogs: false,
+		},
+		PercentOfDiskspace: "1",
+	}
+
+	systemLog := automationconfig.SystemLog{
+		Destination: automationconfig.File,
+		Path:        "/tmp/mongod.log",
+		LogAppend:   false,
+	}
+
+	// logRotate can only be configured if systemLog to file has been configured
+	mdb.Spec.AgentConfiguration.LogRotate = &lcr
+	mdb.Spec.AgentConfiguration.SystemLog = &systemLog
+
+	// config member options
+	memberOptions := []automationconfig.MemberOptions{
+		{
+			Votes:    intPtr(1),
+			Tags:     map[string]string{"foo1": "bar1"},
+			Priority: strPtr("1.5"),
+		},
+		{
+			Votes:    intPtr(1),
+			Tags:     map[string]string{"foo2": "bar2"},
+			Priority: strPtr("1"),
+		},
+		{
+			Votes:    intPtr(1),
+			Tags:     map[string]string{"foo3": "bar3"},
+			Priority: strPtr("2.5"),
+		},
+	}
+	mdb.Spec.MemberConfig = memberOptions
+
+	settings := map[string]interface{}{
+		"electionTimeoutMillis": float64(20),
+	}
+	mdb.Spec.AutomationConfigOverride = &v1.AutomationConfigOverride{
+		ReplicaSet: v1.OverrideReplicaSet{Settings: v1.MapWrapper{Object: settings}},
+	}
+
+	tester, err := FromResource(ctx, t, mdb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Create MongoDB Resource", mongodbtests.CreateMongoDBResource(&mdb, testCtx))
+	t.Run("Basic tests", mongodbtests.BasicFunctionality(ctx, &mdb))
+	t.Run("Keyfile authentication is configured", tester.HasKeyfileAuth(3))
+	t.Run("AutomationConfig has the correct logRotateConfig", mongodbtests.AutomationConfigHasLogRotationConfig(ctx, &mdb, &lcr))
+	t.Run("Test Basic Connectivity", tester.ConnectivitySucceeds())
+	t.Run("Test SRV Connectivity", tester.ConnectivitySucceeds(WithURI(mdb.MongoSRVURI("")), WithoutTls(), WithReplicaSet(mdb.Name)))
+	deletedUser := mdb.Spec.Users[0]
+	t.Run("Delete user from MongoDB Resource", mongodbtests.RemoveUserFromResource(ctx, &mdb))
+	t.Run("MongoDB reaches Running phase", mongodbtests.MongoDBReachesRunningPhase(ctx, &mdb))
+	t.Run("Removed users are added to automation config", mongodbtests.AuthUsersDeletedIsUpdated(ctx, &mdb, user))
+	t.Run("Connection string secrets are cleaned up", mongodbtests.ConnectionStringSecretsAreCleanedUp(ctx, &mdb, deletedUser.GetConnectionStringSecretName(mdb.Name)))
+	t.Run("Delete MongoDB Resource", mongodbtests.DeleteMongoDBResource(&mdb, testCtx))
+}


### PR DESCRIPTION
### Summary:
This PR adds changes that will cleanup connection string secrets after a user is removed from the resource and ensure that it will also be removed from the database.

Connection string secrets are removed by comparing the `lastAppliedSpec` with the current spec to retrieve the users that have been removed and then their corresponding connection string secrets.

Users are deleted from the database by adding a corresponding `DeletedUser` object to the `usersDeleted` field in the `auth` object of the `AutomationConfig`. This ensures the users will be deleted according to the [documentation](https://www.mongodb.com/docs/ops-manager/current/reference/cluster-configuration/#authentication:~:text=auth.-,usersDeleted,-array%20of%20objects)

The PR adds:
- 2 new methods in the `controllers/mongodb_cleanup.go` file:
    - `getConnectionStringSecretsToDelete` that compares the previous spec with the current one and returns a slice containing the secrets corresponding to removed users
    - `cleanupConnectionStringSecrets` that deletes the secrets returned by the previous method
- The `lastAppliedSpec` parameter to `r.deployMongoDBReplicaSet`, `r.deployAutomationConfig`, `r.ensureAutomationConfig`, `r.buildAutomationConfig` to allow it to be used to retrieve removed users
- 2 new methods in the `pkg/authentication/authentication.go` file:
    - `getDeletedUsers` that usses `lastAppliedSpec` to return a slice of `DeletedUser`s corresponding to the removed users from the spec
    - `AddRemovedUsers` that adds the users returned by the previous method to the `usersDeleted` field in the `auth`
- The `UsersDeleted` field to the `Auth` type. This contains of a slice of objects of type `DeletedUser`, which contain 2 fields:
    - `User`: The user that will be deleted
    - `Dbs`: A list of databses from which the user should be deleted
- 3 methods in the `test/e2e/mongodbtests/mongodbtests.go` file:
    - `RemoveUserFromResource` that sets the `users` field in the spec of the resource to an empty list
    - `ConnectionStringSecretsAreCleanedUp` that checks that a specific connection string secret is not found in the cluster anymore
    - `AuthUsersDeletedIsUpdated` that checks that the `auth` was updated to contain the specified user
- An e2e test to check the behaviour of cleaning up users that:
    - Creates a MongoDBCommunity resource
    - Asserts basic functionality of that resource
    - Removed the users from it
    - Waits for the resource to be ready
    - Checks for the `auth` to be updated
    - Checks for the connection string secret to be deleted
    - Deletes the resource

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
