### PR TITLE
fix logRotate and fix path naming add auditlogrotation 

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -373,6 +373,9 @@ type AgentConfiguration struct {
 	// LogRotate if enabled, will enable LogRotate for all processes.
 	LogRotate *automationconfig.CrdLogRotate `json:"logRotate,omitempty"`
 	// +optional
+	// AuditLogRotate if enabled, will enable AuditLogRotate for all processes.
+	AuditLogRotate *automationconfig.CrdLogRotate `json:"AuditLogRotate,omitempty"`
+	// +optional
 	// SystemLog configures system log of mongod
 	SystemLog *automationconfig.SystemLog `json:"systemLog,omitempty"`
 }

--- a/controllers/mongodb_tls_test.go
+++ b/controllers/mongodb_tls_test.go
@@ -329,6 +329,7 @@ func TestAutomationConfigIsCorrectlyConfiguredWithTLS(t *testing.T) {
 			assert.Equal(t, "/tmp/test", process.Args26.Get("systemLog.path").String())
 			assert.Equal(t, "file", process.Args26.Get("systemLog.destination").String())
 			assert.Equal(t, process.LogRotate, automationconfig.ConvertCrdLogRotateToAC(mdb.Spec.AgentConfiguration.LogRotate))
+			assert.Equal(t, process.AuditLogRotate, automationconfig.ConvertCrdLogRotateToAC(mdb.Spec.AgentConfiguration.AuditLogRotate))
 		}
 	})
 

--- a/controllers/replica_set_controller.go
+++ b/controllers/replica_set_controller.go
@@ -535,7 +535,7 @@ func buildAutomationConfig(mdb mdbv1.MongoDBCommunity, auth automationconfig.Aut
 		AddModifications(getMongodConfigModification(mdb)).
 		AddModifications(modifications...).
 		AddProcessModification(func(_ int, p *automationconfig.Process) {
-			automationconfig.ConfigureAgentConfiguration(mdb.Spec.AgentConfiguration.SystemLog, mdb.Spec.AgentConfiguration.LogRotate, p)
+			automationconfig.ConfigureAgentConfiguration(mdb.Spec.AgentConfiguration.SystemLog, mdb.Spec.AgentConfiguration.LogRotate, mdb.Spec.AgentConfiguration.AuditLogRotate, p)
 		}).
 		Build()
 }

--- a/controllers/replicaset_controller_test.go
+++ b/controllers/replicaset_controller_test.go
@@ -88,6 +88,9 @@ func newTestReplicaSetWithSystemLogAndLogRotate() mdbv1.MongoDBCommunity {
 				LogRotate: &automationconfig.CrdLogRotate{
 					SizeThresholdMB: "1",
 				},
+				AuditLogRotate: &automationconfig.CrdLogRotate{
+					SizeThresholdMB: "1",
+				},
 				SystemLog: &automationconfig.SystemLog{
 					Destination: automationconfig.File,
 					Path:        "/tmp/test",

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -485,7 +485,7 @@ func FromBytes(acBytes []byte) (AutomationConfig, error) {
 	return ac, nil
 }
 
-func ConfigureAgentConfiguration(systemLog *SystemLog, logRotate *CrdLogRotate, p *Process) {
+func ConfigureAgentConfiguration(systemLog *SystemLog, logRotate *CrdLogRotate, auditLR *CrdLogRotate, p *Process) {
 	if systemLog != nil {
 		p.SetSystemLog(*systemLog)
 	}
@@ -498,6 +498,7 @@ func ConfigureAgentConfiguration(systemLog *SystemLog, logRotate *CrdLogRotate, 
 			zap.S().Warn("Configuring LogRotate with systemLog.Destination = Syslog will not work")
 		}
 		p.SetLogRotate(logRotate)
+		p.SetAuditLogRotate(auditLR)
 	}
 
 }

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -181,7 +181,7 @@ func (p *Process) SetLogRotate(lr *CrdLogRotate) *Process {
 	return p
 }
 
-// SetLogRotate sets the acLogRotate by converting the CrdLogRotate to an acLogRotate.
+// SetAuditLogRotate sets the acLogRotate by converting the CrdLogRotate to an acLogRotate.
 func (p *Process) SetAuditLogRotate(lr *CrdLogRotate) *Process {
 	p.AuditLogRotate = ConvertCrdLogRotateToAC(lr)
 	return p

--- a/pkg/automationconfig/automation_config.go
+++ b/pkg/automationconfig/automation_config.go
@@ -135,7 +135,8 @@ type Process struct {
 	ProcessType                 ProcessType  `json:"processType"`
 	Version                     string       `json:"version"`
 	AuthSchemaVersion           int          `json:"authSchemaVersion"`
-	LogRotate                   *AcLogRotate `json:"LogRotate,omitempty"`
+	LogRotate                   *AcLogRotate `json:"logRotate,omitempty"`
+	AuditLogRotate              *AcLogRotate `json:"auditLogRotate,omitempty"`
 }
 
 func (p *Process) SetPort(port int) *Process {
@@ -177,6 +178,12 @@ func (p *Process) SetSystemLog(systemLog SystemLog) *Process {
 // SetLogRotate sets the acLogRotate by converting the CrdLogRotate to an acLogRotate.
 func (p *Process) SetLogRotate(lr *CrdLogRotate) *Process {
 	p.LogRotate = ConvertCrdLogRotateToAC(lr)
+	return p
+}
+
+// SetLogRotate sets the acLogRotate by converting the CrdLogRotate to an acLogRotate.
+func (p *Process) SetAuditLogRotate(lr *CrdLogRotate) *Process {
+	p.AuditLogRotate = ConvertCrdLogRotateToAC(lr)
 	return p
 }
 

--- a/pkg/automationconfig/automation_config_secret_test.go
+++ b/pkg/automationconfig/automation_config_secret_test.go
@@ -44,7 +44,7 @@ func TestEnsureSecret(t *testing.T) {
 		ctx := context.Background()
 
 		desiredAutomationConfig, err = NewBuilder().SetMembers(3).AddProcessModification(func(i_ int, p *Process) {
-			p.SetLogRotate(&CrdLogRotate{
+			lr := &CrdLogRotate{
 				SizeThresholdMB: "0.001",
 				LogRotate: LogRotate{
 					TimeThresholdHrs:                1,
@@ -53,7 +53,9 @@ func TestEnsureSecret(t *testing.T) {
 					IncludeAuditLogsWithMongoDBLogs: false,
 				},
 				PercentOfDiskspace: "1",
-			})
+			}
+			p.SetLogRotate(lr)
+			p.SetAuditLogRotate(lr)
 		}).Build()
 		assert.NoError(t, err)
 
@@ -72,7 +74,9 @@ func TestEnsureSecret(t *testing.T) {
 		acFromBytes, err := FromBytes(bytes)
 		assert.NoError(t, err)
 		assert.Equal(t, 0.001, acFromBytes.Processes[0].LogRotate.SizeThresholdMB)
+		assert.Equal(t, 0.001, acFromBytes.Processes[0].AuditLogRotate.SizeThresholdMB)
 		assert.Equal(t, float64(1), acFromBytes.Processes[0].LogRotate.PercentOfDiskspace)
+		assert.Equal(t, float64(1), acFromBytes.Processes[0].AuditLogRotate.PercentOfDiskspace)
 	})
 
 	t.Run("test LogRotate marshal and unmarshal if not set", func(t *testing.T) {


### PR DESCRIPTION
### Summary:
- This pr fixes the `LogRotate` json key to be lowerCases `logRotate`
- This pr adds auditlogrotation 

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
