### PR TITLE
Fixing validation of collisions in scram secret's name

### DIFF
--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -74,6 +74,40 @@ spec:
                 description: AgentConfiguration sets options for the MongoDB automation
                   agent
                 properties:
+                  AuditLogRotate:
+                    description: AuditLogRotate if enabled, will enable AuditLogRotate
+                      for all processes.
+                    properties:
+                      includeAuditLogsWithMongoDBLogs:
+                        description: |-
+                          set to 'true' to have the Automation Agent rotate the audit files along
+                          with mongodb log files
+                        type: boolean
+                      numTotal:
+                        description: maximum number of log files to have total
+                        type: integer
+                      numUncompressed:
+                        description: maximum number of log files to leave uncompressed
+                        type: integer
+                      percentOfDiskspace:
+                        description: |-
+                          Maximum percentage of the total disk space these log files should take up.
+                          The string needs to be able to be converted to float64
+                        type: string
+                      sizeThresholdMB:
+                        description: |-
+                          Maximum size for an individual log file before rotation.
+                          The string needs to be able to be converted to float64.
+                          Fractional values of MB are supported.
+                        type: string
+                      timeThresholdHrs:
+                        description: maximum hours for an individual log file before
+                          rotation
+                        type: integer
+                    required:
+                    - sizeThresholdMB
+                    - timeThresholdHrs
+                    type: object
                   logFile:
                     type: string
                   logLevel:

--- a/controllers/validation/validation.go
+++ b/controllers/validation/validation.go
@@ -92,7 +92,7 @@ func validateUsers(mdb mdbv1.MongoDBCommunity) error {
 					previousUser.Username,
 					user.Username))
 		} else {
-			connectionStringSecretNameMap[connectionStringSecretName] = user
+			scramSecretNameMap[scramSecretName] = user
 		}
 
 		if user.Database == constants.ExternalDB {
@@ -100,7 +100,7 @@ func validateUsers(mdb mdbv1.MongoDBCommunity) error {
 				return fmt.Errorf("X.509 user %s present but X.509 is not enabled", user.Username)
 			}
 			if user.PasswordSecretKey != "" {
-				return fmt.Errorf("X509 user %s shoul not have a password secret key", user.Username)
+				return fmt.Errorf("X509 user %s should not have a password secret key", user.Username)
 			}
 			if user.PasswordSecretName != "" {
 				return fmt.Errorf("X509 user %s should not have a password secret name", user.Username)

--- a/go.mod
+++ b/go.mod
@@ -66,13 +66,14 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.23.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
-golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=
 golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
@@ -246,8 +246,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.23.0 h1:SGsXPZ+2l4JsgaCKkx+FQ9YZ5XEtA1GZYuoDjenLjvg=
+golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -5,7 +5,7 @@
 function go_imports() {
     if ! type goimports &> /dev/null; then
         echo "Installing goimports"
-        go get golang.org/x/tools/cmd/goimports
+        go install golang.org/x/tools/cmd/goimports
     fi
 
     # Formats each file that was changed.

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -5,7 +5,7 @@
 function go_imports() {
     if ! type goimports &> /dev/null; then
         echo "Installing goimports"
-        GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+        go get golang.org/x/tools/cmd/goimports
     fi
 
     # Formats each file that was changed.


### PR DESCRIPTION
### Summary:
I have noticed a small mistake in the `controllers/validation/validation.go` file. It seems like the logic to check for collisions in the name of scram secretes was making use of the map for connection string secret names.

#### Initial behaviour
When a MongoDBCommunity resource was deployed with 2 users using the same scram secret name the resource would be stuck in the Pending phase

#### Behaviour after change
When a MongoDBCommunity resource was deployed with 2 users using the same scram secret name the resource would fail with the following error message `scram credential secret names collision, update at least one of the users: %s`

This PR adds:
- `scramSecretNameMap` instead of `connectionStringSecretNameMap` for checking collisions as the later was already used for checking connection string secrets collisions
- Changes made automatically by the pre-commit hook to the CRD
- Removed `GO111MODULE=off` from the pre-commit hook
- Update go dependencies
- Change command in pre commit hook to `go install` instead of `go get`

### All Submissions:
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
