### PR TITLE
remove WithLabels in BuildMongoDBReplicaSetStatefulSetModificationFun

### DIFF
--- a/controllers/construct/mongodbstatefulset.go
+++ b/controllers/construct/mongodbstatefulset.go
@@ -224,7 +224,6 @@ func BuildMongoDBReplicaSetStatefulSetModificationFunction(mdb MongoDBStatefulSe
 		statefulset.WithName(mdb.GetName()),
 		statefulset.WithNamespace(mdb.GetNamespace()),
 		statefulset.WithServiceName(mdb.ServiceName()),
-		statefulset.WithLabels(labels),
 		statefulset.WithMatchLabels(labels),
 		statefulset.WithReplicas(scale.ReplicasThisReconciliation(scaler)),
 		statefulset.WithUpdateStrategyType(mdb.GetUpdateStrategyType()),


### PR DESCRIPTION
…ction

### Summary:
the label of sts is set by statefulSet.metadata.labels, no need to invoke WithLabels in BuildMongoDBReplicaSetStatefulSetModificationFun

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
