### PR TITLE
Changed the order of CreateOrUpdate functions

### DIFF
--- a/pkg/kube/client/mocked_client.go
+++ b/pkg/kube/client/mocked_client.go
@@ -59,6 +59,9 @@ func (m mockedClient) Create(_ context.Context, obj k8sClient.Object, _ ...k8sCl
 func (m mockedClient) Update(_ context.Context, obj k8sClient.Object, _ ...k8sClient.UpdateOption) error {
 	relevantMap := m.ensureMapFor(obj)
 	objKey := k8sClient.ObjectKeyFromObject(obj)
+	if _, ok := relevantMap[objKey]; !ok {
+		return errors.NewNotFound(schema.GroupResource{}, obj.GetName())
+	}
 	relevantMap[objKey] = obj
 	return nil
 }

--- a/pkg/kube/configmap/configmap.go
+++ b/pkg/kube/configmap/configmap.go
@@ -85,14 +85,14 @@ func UpdateField(ctx context.Context, getUpdater GetUpdater, objectKey client.Ob
 // CreateOrUpdate creates the given ConfigMap if it doesn't exist,
 // or updates it if it does.
 func CreateOrUpdate(ctx context.Context, getUpdateCreator GetUpdateCreator, cm corev1.ConfigMap) error {
-	_, err := getUpdateCreator.GetConfigMap(ctx, types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace})
-	if err != nil {
+	if err := getUpdateCreator.UpdateConfigMap(ctx, cm); err != nil {
 		if apiErrors.IsNotFound(err) {
 			return getUpdateCreator.CreateConfigMap(ctx, cm)
+		} else {
+			return err
 		}
-		return err
 	}
-	return getUpdateCreator.UpdateConfigMap(ctx, cm)
+	return nil
 }
 
 // filelikePropertiesToMap converts a file-like field in a ConfigMap to a map[string]string.

--- a/pkg/kube/secret/secret.go
+++ b/pkg/kube/secret/secret.go
@@ -99,14 +99,14 @@ func UpdateField(ctx context.Context, getUpdater GetUpdater, objectKey client.Ob
 
 // CreateOrUpdate creates the Secret if it doesn't exist, other wise it updates it
 func CreateOrUpdate(ctx context.Context, getUpdateCreator GetUpdateCreator, secret corev1.Secret) error {
-	_, err := getUpdateCreator.GetSecret(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace})
-	if err != nil {
+	if err := getUpdateCreator.UpdateSecret(ctx, secret); err != nil {
 		if SecretNotExist(err) {
 			return getUpdateCreator.CreateSecret(ctx, secret)
+		} else {
+			return err
 		}
-		return err
 	}
-	return getUpdateCreator.UpdateSecret(ctx, secret)
+	return nil
 }
 
 // HasAllKeys returns true if the provided secret contains an element for every

--- a/pkg/kube/statefulset/statefulset.go
+++ b/pkg/kube/statefulset/statefulset.go
@@ -53,15 +53,16 @@ type GetUpdateCreateDeleter interface {
 
 // CreateOrUpdate creates the given StatefulSet if it doesn't exist,
 // or updates it if it does.
-func CreateOrUpdate(ctx context.Context, getUpdateCreator GetUpdateCreator, sts appsv1.StatefulSet) (appsv1.StatefulSet, error) {
-	_, err := getUpdateCreator.GetStatefulSet(ctx, types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace})
-	if err != nil {
+func CreateOrUpdate(ctx context.Context, getUpdateCreator GetUpdateCreator, statefulSet appsv1.StatefulSet) (appsv1.StatefulSet, error) {
+	if sts, err := getUpdateCreator.UpdateStatefulSet(ctx, statefulSet); err != nil {
 		if apiErrors.IsNotFound(err) {
-			return appsv1.StatefulSet{}, getUpdateCreator.CreateStatefulSet(ctx, sts)
+			return statefulSet, getUpdateCreator.CreateStatefulSet(ctx, statefulSet)
+		} else {
+			return appsv1.StatefulSet{}, err
 		}
-		return appsv1.StatefulSet{}, err
+	} else {
+		return sts, nil
 	}
-	return getUpdateCreator.UpdateStatefulSet(ctx, sts)
 }
 
 // GetAndUpdate applies the provided function to the most recent version of the object


### PR DESCRIPTION
This PR changes the way we do `CreateOrUpdate` functions. 

It was: Get the Update if exists else Create. 
For some cases after the resource was created in the same reconcile event, another execution will again hit into Create case as the informer caches weren't yet refreshed. And that resulted in errors.