### PR TITLE
CLOUDP-274724 - readinessProbe: use human readable timestamps instead

### DIFF
--- a/cmd/readiness/main.go
+++ b/cmd/readiness/main.go
@@ -208,15 +208,18 @@ func parseHealthStatus(reader io.Reader) (health.Status, error) {
 }
 
 func initLogger(l *lumberjack.Logger) {
+	encoderConfig := zap.NewProductionEncoderConfig()
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
 	consoleCore := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.NewJSONEncoder(encoderConfig),
 		zapcore.AddSync(os.Stdout),
 		zap.DebugLevel)
 
 	cores := []zapcore.Core{consoleCore}
 	if config.ReadBoolWitDefault(config.WithAgentFileLogging, "true") {
 		fileCore := zapcore.NewCore(
-			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+			zapcore.NewJSONEncoder(encoderConfig),
 			zapcore.AddSync(l),
 			zap.DebugLevel)
 		cores = append(cores, fileCore)

--- a/release.json
+++ b/release.json
@@ -2,7 +2,7 @@
   "golang-builder-image": "golang:1.22",
   "operator": "0.11.0",
   "version-upgrade-hook": "1.0.9",
-  "readiness-probe": "1.0.20",
+  "readiness-probe": "1.0.21",
   "agent": "108.0.0.8694-1",
   "agent-tools-version": "100.10.0"
 }


### PR DESCRIPTION
### Summary:
Change usage of zap as described by the lib:
```
// You may change these by setting the appropriate fields in the returned
// object.
// For example, use the following to change the time encoding format:
//
//	cfg := zap.NewProductionEncoderConfig()
//	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
```
