### PR TITLE
allow scaling a mongodb to 0 replicas

### DIFF
--- a/controllers/validation/validation.go
+++ b/controllers/validation/validation.go
@@ -143,7 +143,7 @@ func validateArbiterSpec(mdb mdbv1.MongoDBCommunity) error {
 	if mdb.Spec.Arbiters < 0 {
 		return fmt.Errorf("number of arbiters must be greater or equal than 0")
 	}
-	if mdb.Spec.Arbiters >= mdb.Spec.Members {
+	if mdb.Spec.Arbiters >= mdb.Spec.Members && !(mdb.Spec.Members == 0 && mdb.Spec.Arbiter == 0) {
 		return fmt.Errorf("number of arbiters specified (%v) is greater or equal than the number of members in the replicaset (%v). At least one member must not be an arbiter", mdb.Spec.Arbiters, mdb.Spec.Members)
 	}
 


### PR DESCRIPTION
### Summary:

It is possible to set the number of mongodb members and arbiters to 0 (at the same time).
Therefore it is possible to scale the mongodb down if it is not needed. 
The edge case is has been included that the number of members and arbiters can be equal if both are 0.

closes #1635