### PR TITLE
Changed "repo" to "repository" for clarity and formality.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 The MongoDB Agent binary in the agent/ directory may be used under the "Free for Commercial Use - Oct 2020" license found in [agent/LICENSE](scripts/dev/templates/agent/LICENSE).
 
-The source code of this Operator, and all other content in this repo are available under the Apache v2 license. The text of this license is available in [APACHE2](APACHE2)
+The source code of this Operator, and all other content in this repository are available under the Apache v2 license. The text of this license is available in [APACHE2](APACHE2)
 
 To use this Operator, you must agree to both licenses.


### PR DESCRIPTION
Changed "repo" to "repository" for clarity and formality.

