### PR TITLE
fix tests - adding missing role, increase timeout

### DIFF
--- a/test/e2e/replica_set_custom_role/replica_set_custom_role_test.go
+++ b/test/e2e/replica_set_custom_role/replica_set_custom_role_test.go
@@ -71,6 +71,19 @@ func TestReplicaSetCustomRole(t *testing.T) {
 			}},
 			Roles: []mdbv1.Role{},
 		},
+		{
+			Role: "MongodbAutomationAgentUserRole",
+			DB:   "admin",
+			Privileges: []mdbv1.Privilege{
+				{
+					Resource: mdbv1.Resource{
+						AnyResource: true,
+					},
+					Actions: []string{"bypassDefaultMaxTimeMS"},
+				},
+			},
+			Roles: []mdbv1.Role{},
+		},
 	}
 
 	_, err := setup.GeneratePasswordForUser(testCtx, user, "")

--- a/test/e2e/setup/setup.go
+++ b/test/e2e/setup/setup.go
@@ -237,7 +237,7 @@ func DeployOperator(ctx context.Context, config TestConfig, resourceName string,
 		return err
 	}
 
-	if err := wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, hasDeploymentRequiredReplicas(&dep)); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, time.Second*2, 120*time.Second, true, hasDeploymentRequiredReplicas(&dep)); err != nil {
 		return errors.New("error building operator deployment: the deployment does not have the required replicas")
 	}
 	fmt.Println("Successfully installed the operator deployment")
@@ -280,6 +280,7 @@ func hasDeploymentRequiredReplicas(dep *appsv1.Deployment) wait.ConditionWithCon
 		if dep.Status.ReadyReplicas == *dep.Spec.Replicas {
 			return true, nil
 		}
+		fmt.Printf("Deployment not ready! ReadyReplicas: %d, Spec.Replicas: %d\n", dep.Status.ReadyReplicas, *dep.Spec.Replicas)
 		return false, nil
 	}
 }

--- a/test/e2e/util/mongotester/mongotester.go
+++ b/test/e2e/util/mongotester/mongotester.go
@@ -183,7 +183,7 @@ func (m *Tester) VerifyRoles(expectedRoles []automationconfig.CustomRole, tries 
 			t.Fatal(err)
 			return false
 		}
-		assert.ElementsMatch(t, result.Roles, expectedRoles)
+		assert.Contains(t, result.Roles, expectedRoles)
 		return true
 	}, tries, opts...)
 }

--- a/test/e2e/util/mongotester/mongotester.go
+++ b/test/e2e/util/mongotester/mongotester.go
@@ -183,7 +183,7 @@ func (m *Tester) VerifyRoles(expectedRoles []automationconfig.CustomRole, tries 
 			t.Fatal(err)
 			return false
 		}
-		assert.Contains(t, result.Roles, expectedRoles)
+		assert.ElementsMatch(t, result.Roles, expectedRoles)
 		return true
 	}, tries, opts...)
 }


### PR DESCRIPTION
### Summary:

from test

        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (automationconfig.CustomRole) {
        	            	  Role: (string) (len=30) "MongodbAutomationAgentUserRole",
        	            	  DB: (string) (len=5) "admin",
        	            	  Privileges: ([]automationconfig.Privilege) (len=1) {
        	            	   (automationconfig.Privilege) {
        	            	    Resource: (automationconfig.Resource) {
        	            	     DB: (*string)(<nil>),
        	            	     Collection: (*string)(<nil>),
        	            	     AnyResource: (bool) true,
        	            	     Cluster: (bool) false
        	            	    },
        	            	    Actions: ([]string) (len=1) {
        	            	     (string) (len=22) "bypassDefaultMaxTimeMS"
        	            	    }
        	            	   }
        	            	  },
        	            	  Roles: ([]automationconfig.Role) {
        	            	  },
        	            	  AuthenticationRestrictions: ([]automationconfig.AuthenticationRestriction) <nil>
        	            	 }
        	            	}
https://github.com/mongodb/mongodb-kubernetes-operator/actions/runs/12671524133/job/35384225989#step:13:314

its passing now: https://github.com/mongodb/mongodb-kubernetes-operator/actions/runs/12707699284/job/35423341022?pr=1655