### PR TITLE
Update dependabot and CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mircea-cosbuc @lsierant @slaskawi @nammn @Julien-Ben @MaciejKaras @lucian-tosa @fealebenpae
+* @mircea-cosbuc @lsierant @nammn @Julien-Ben @MaciejKaras @lucian-tosa @fealebenpae @m1kola

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    reviewers:
-      - "slaskawi"
-      - "lsierant"
-      - "mircea-cosbuc"
-      - "nammn"
-      - "Julien-Ben"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
### Summary:
<!---
Please describe your changes here:
Why did you open this PR? 
What are you trying to accomplish?
what have you done? 
Why in this particular way? 
--->

Updates `dependabot.yml` and `CODEOWNERS` to fix issue:
```
Dependabot tried to add @slaskawi, @lsierant, @mircea-cosbuc, @nammn and @Julien-Ben as reviewers to this PR, but received the following error from GitHub:

POST https://api.github.com/repos/mongodb/mongodb-kubernetes-operator/pulls/1657/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the mongodb/mongodb-kubernetes-operator repository. // See: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
```

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
