### PR TITLE
Bump gh actions

### DIFF
--- a/.action_templates/steps/cancel-previous.yaml
+++ b/.action_templates/steps/cancel-previous.yaml
@@ -1,4 +1,4 @@
 - name: Cancel Previous Runs
-  uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc # 0.9.0
+  uses: styfle/cancel-workflow-action@0.12.1
   with:
     access_token: ${{ github.token }}

--- a/.action_templates/steps/checkout-fork.yaml
+++ b/.action_templates/steps/checkout-fork.yaml
@@ -2,7 +2,7 @@
 # Because we are using pull_request_target the Github Secrets will be passed
 # So code should be reviewed before labeling as "safe-to-test"
 - name: Checkout Code
-  uses: actions/checkout@v2
+  uses: actions/checkout@v4
   with:
     ref: ${{github.event.pull_request.head.sha}}
     repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.action_templates/steps/checkout.yaml
+++ b/.action_templates/steps/checkout.yaml
@@ -1,4 +1,4 @@
 - name: Checkout Code
-  uses: actions/checkout@v2
+  uses: actions/checkout@v4
   with:
     submodules: true

--- a/.action_templates/steps/quay-login.yaml
+++ b/.action_templates/steps/quay-login.yaml
@@ -1,5 +1,5 @@
 - name: Login to Quay.io
-  uses: docker/login-action@v1
+  uses: docker/login-action@v3
   with:
     registry: quay.io
     username: ${{ secrets.QUAY_USERNAME }}

--- a/.action_templates/steps/set-run-status.yaml
+++ b/.action_templates/steps/set-run-status.yaml
@@ -7,7 +7,7 @@
   # see https://github.com/actions/runner/issues/432
 - name: Restore last run status
   id: last_run
-  uses: actions/cache@v2
+  uses: actions/cache@v4
   with:
     path: last_run_status
     key: ${{ github.run_id }}-${{ matrix.test-name }}-${{ matrix.distro }}

--- a/.action_templates/steps/set-up-qemu.yaml
+++ b/.action_templates/steps/set-up-qemu.yaml
@@ -1,2 +1,2 @@
 - name: Set up QEMU
-  uses: docker/setup-qemu-action@v2
+  uses: docker/setup-qemu-action@v3

--- a/.action_templates/steps/setup-and-install-python.yaml
+++ b/.action_templates/steps/setup-and-install-python.yaml
@@ -1,9 +1,9 @@
 - name: Setup Python
-  uses: actions/setup-python@v2
+  uses: actions/setup-python@v5
   with:
     python-version: '3.10.4'
 - name: Cache Dependencies
-  uses: actions/cache@v2
+  uses: actions/cache@v4
   with:
     path: ~/.cache/pip
     key: ${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is being marked stale because it has been open for 60 days with no activity. Please comment if this issue is still affecting you. If there is no change, this issue will be closed in 30 days.'

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -15,7 +15,7 @@ jobs:
   Mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Mypy linting
         uses: jpetrucciani/mypy-check@179fdad632bf3ccf4cabb7ee4307ef25e51d2f96

--- a/.github/workflows/comment-release-pr.yml
+++ b/.github/workflows/comment-release-pr.yml
@@ -9,7 +9,7 @@ jobs:
     if: startsWith(github.event.pull_request.title, 'Release MongoDB Kubernetes Operator')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -48,16 +48,16 @@ jobs:
     steps:
     # template: .action_templates/steps/checkout.yaml
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     # template: .action_templates/steps/setup-and-install-python.yaml
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.4
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}
@@ -65,14 +65,14 @@ jobs:
       run: pip install -r requirements.txt
     # template: .action_templates/steps/quay-login.yaml
     - name: Login to Quay.io
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
     # template: .action_templates/steps/set-up-qemu.yaml
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
@@ -87,16 +87,16 @@ jobs:
     steps:
     # template: .action_templates/steps/checkout.yaml
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     # template: .action_templates/steps/setup-and-install-python.yaml
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.4
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/e2e-fork.yml
+++ b/.github/workflows/e2e-fork.yml
@@ -43,23 +43,23 @@ jobs:
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc # 0.9.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     # template: .action_templates/steps/checkout-fork.yaml
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.sha}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         submodules: true
     # template: .action_templates/steps/setup-and-install-python.yaml
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.4
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}
@@ -67,14 +67,14 @@ jobs:
       run: pip install -r requirements.txt
     # template: .action_templates/steps/quay-login.yaml
     - name: Login to Quay.io
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
     # template: .action_templates/steps/set-up-qemu.yaml
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
@@ -154,12 +154,12 @@ jobs:
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc # 0.9.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     # template: .action_templates/steps/checkout-fork.yaml
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.sha}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -174,7 +174,7 @@ jobs:
   # see https://github.com/actions/runner/issues/432
     - name: Restore last run status
       id: last_run
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: last_run_status
         key: ${{ github.run_id }}-${{ matrix.test-name }}-${{ matrix.distro }}
@@ -184,11 +184,11 @@ jobs:
       run: cat last_run_status
     # template: .action_templates/steps/setup-and-install-python.yaml
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.4
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,21 +51,21 @@ jobs:
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc # 0.9.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     # template: .action_templates/steps/checkout.yaml
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     # template: .action_templates/steps/setup-and-install-python.yaml
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.4
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}
@@ -73,14 +73,14 @@ jobs:
       run: pip install -r requirements.txt
     # template: .action_templates/steps/quay-login.yaml
     - name: Login to Quay.io
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
     # template: .action_templates/steps/set-up-qemu.yaml
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     # template: .action_templates/steps/build-and-push-development-images.yaml
     - name: Build and Push Images
       run: |
@@ -160,12 +160,12 @@ jobs:
     steps:
     # template: .action_templates/steps/cancel-previous.yaml
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc # 0.9.0
+      uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
     # template: .action_templates/steps/checkout.yaml
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     # template: .action_templates/steps/set-run-status.yaml
@@ -178,7 +178,7 @@ jobs:
   # see https://github.com/actions/runner/issues/432
     - name: Restore last run status
       id: last_run
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: last_run_status
         key: ${{ github.run_id }}-${{ matrix.test-name }}-${{ matrix.distro }}
@@ -188,11 +188,11 @@ jobs:
       run: cat last_run_status
     # template: .action_templates/steps/setup-and-install-python.yaml
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.10.4
     - name: Cache Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,10 +9,10 @@ jobs:
   UnitTests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.24'
 

--- a/.github/workflows/kubelinter-check.yml
+++ b/.github/workflows/kubelinter-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Scan directory ./deploy/clusterwide/ with kube-linter
       uses: stackrox/kube-linter-action@v1.0.3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Make sure we also get the helm-charts submodule!
           submodules: true

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10.4'
           architecture: 'x64'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ hashFiles('requirements.txt') }}
@@ -73,7 +73,7 @@ jobs:
     needs: [release-images]
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Determine Release Tag
       id: release_tag
       run: |

--- a/.github/workflows/release-single-image.yml
+++ b/.github/workflows/release-single-image.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10.4'
           architecture: 'x64'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ hashFiles('requirements.txt') }}


### PR DESCRIPTION
actions/cache@v2 is now removed and fails CI. While updating `actions/cache@v2` I also bumped other GH actions to the latest versions.