### PR TITLE
Ignore X.509 users in scram secret collision validation

### DIFF
--- a/controllers/validation/validation.go
+++ b/controllers/validation/validation.go
@@ -83,16 +83,18 @@ func validateUsers(mdb mdbv1.MongoDBCommunity) error {
 			connectionStringSecretNameMap[connectionStringSecretName] = user
 		}
 
-		// Ensure no collisions in the secret holding scram credentials
-		scramSecretName := user.ScramCredentialsSecretName
-		if previousUser, exists := scramSecretNameMap[scramSecretName]; exists {
-			scramSecretNameCollisions = append(scramSecretNameCollisions,
-				fmt.Sprintf(`[scram secret name: "%s" for user: "%s" and user: "%s"]`,
-					scramSecretName,
-					previousUser.Username,
-					user.Username))
-		} else {
-			scramSecretNameMap[scramSecretName] = user
+		if user.Database != constants.ExternalDB {
+			// Ensure no collisions in the secret holding scram credentials
+			scramSecretName := user.ScramCredentialsSecretName
+			if previousUser, exists := scramSecretNameMap[scramSecretName]; exists {
+				scramSecretNameCollisions = append(scramSecretNameCollisions,
+					fmt.Sprintf(`[scram secret name: "%s" for user: "%s" and user: "%s"]`,
+						scramSecretName,
+						previousUser.Username,
+						user.Username))
+			} else {
+				scramSecretNameMap[scramSecretName] = user
+			}
 		}
 
 		if user.Database == constants.ExternalDB {


### PR DESCRIPTION
### Summary:
During validation, users without the scramCredentialsSecretName parameter are [added](https://github.com/mongodb/mongodb-kubernetes-operator/blob/39025950721c5e2a2b7e69665729018adceb7ce7/controllers/validation/validation.go#L95) to a dictionary with an empty key, which leads to the error mentioned above.

I think we should skip the scram secret collision validation for users authenticated with x509 certificates.

This PR closes #1707 .

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
