### PR TITLE
fix: swap MD5 with SHA256 for TLS to work with FIPS operator image

### DIFF
--- a/pkg/authentication/scramcredentials/scram_credentials.go
+++ b/pkg/authentication/scramcredentials/scram_credentials.go
@@ -2,7 +2,6 @@ package scramcredentials
 
 import (
 	"crypto/hmac"
-	"crypto/md5"  //nolint
 	"crypto/sha1" //nolint
 	"crypto/sha256"
 	"encoding/base64"
@@ -38,12 +37,12 @@ func ComputeScramSha256Creds(password string, salt []byte) (ScramCreds, error) {
 
 func ComputeScramSha1Creds(username, password string, salt []byte) (ScramCreds, error) {
 	base64EncodedSalt := base64.StdEncoding.EncodeToString(salt)
-	password = md5Hex(username + ":mongo:" + password)
+	password = sha256Hex(username + ":mongo:" + password)
 	return computeScramCredentials(sha1.New, DefaultScramSha1Iterations, base64EncodedSalt, password)
 }
 
-func md5Hex(s string) string {
-	h := md5.New()     // nolint
+func sha256Hex(s string) string {
+	h := sha256.New()     // nolint
 	h.Write([]byte(s)) //nolint
 	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
### Summary:

This PR updates the MongoDB Kubernetes Operator to support FIPS-compliant environments by replacing the MD5 hash algorithm with SHA-256 during SCRAM credential generation. 

The motivation behind this change is a runtime panic triggered by OpenSSL when MD5 is used in environments with FIPS mode enabled. The crash occurs specifically during SCRAM credential creation, with errors like:

```
panic: EVP_DigestInit_ex
openssl error(s):
error:0308010C:digital envelope routines::unsupported
error:03000086:digital envelope routines::initialization error

goroutine 242 [running]:
...
github.com/mongodb/mongodb-kubernetes-operator/pkg/authentication/scramcredentials.md5Hex
```

To address this, the patch swaps MD5 with SHA-256, a FIPS-approved algorithm that works seamlessly in the same context.

I validated this by deploying a TLS-secured `MongoDBCommunity` ReplicaSet using a patched FIPS-compatible MongoDB image and a Helm-based setup that includes `cert-manager` for issuing certs. The change allows the operator to successfully create SCRAM credentials without triggering FIPS-related crashes.

### All Submissions:

* [X] Have you opened an Issue before filing this PR?
* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
