### PR TITLE
feat: container resources customization

### DIFF
--- a/api/v1/mongodbcommunity_types.go
+++ b/api/v1/mongodbcommunity_types.go
@@ -132,6 +132,14 @@ type MongoDBCommunitySpec struct {
 	// MemberConfig
 	// +optional
 	MemberConfig []automationconfig.MemberOptions `json:"memberConfig,omitempty"`
+
+	// Resources define the resources for the MongoDB pods.
+	// +kubebuilder:validation:Type=object
+	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +nullable
+
+	Resources ResourcesSpec `json:"resources,omitempty"`
 }
 
 // MapWrapper is a wrapper for a map to be used by other structs.
@@ -1224,4 +1232,23 @@ type MongoDBCommunityList struct {
 
 func init() {
 	SchemeBuilder.Register(&MongoDBCommunity{}, &MongoDBCommunityList{})
+}
+
+// ResourcesSpec specifies the resources for the containers
+type ResourcesSpec struct {
+	// Resources for the container mongod
+	// +optional
+	Mongod *corev1.ResourceRequirements `json:"mongod,omitempty"`
+
+	// Resources for the container agent
+	// +optional
+	Agent *corev1.ResourceRequirements `json:"agent,omitempty"`
+
+	// Resources for the container readiness probe
+	// +optional
+	ReadinessProbe *corev1.ResourceRequirements `json:"readinessProbe,omitempty"`
+
+	// Resources for the container version upgrade hook
+	// +optional
+	VersionUpgradeHook *corev1.ResourceRequirements `json:"versionUpgradeHook,omitempty"`
 }

--- a/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -323,6 +323,232 @@ spec:
                     type: string
                   type: object
                 type: array
+              resources:
+                description: ResourcesSpec specifies the resources for the containers
+                nullable: true
+                properties:
+                  agent:
+                    description: Resources for the container agent
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  mongod:
+                    description: Resources for the container mongod
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  readinessProbe:
+                    description: Resources for the container readiness probe
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  versionUpgradeHook:
+                    description: Resources for the container version upgrade hook
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               security:
                 description: Security configures security features, such as TLS, and
                   authentication settings for a deployment

--- a/controllers/construct/build_statefulset_test.go
+++ b/controllers/construct/build_statefulset_test.go
@@ -67,7 +67,20 @@ func TestManagedSecurityContext(t *testing.T) {
 
 func TestMongod_Container(t *testing.T) {
 	const mongodbImageMock = "fake-mongodbImage"
-	c := container.New(mongodbContainer(mongodbImageMock, []corev1.VolumeMount{}, mdbv1.NewMongodConfiguration()))
+
+	// Create a basic MongoDBCommunity instance without custom resources
+	mdb := &mdbv1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-rs",
+			Namespace: "my-ns",
+		},
+		Spec: mdbv1.MongoDBCommunitySpec{
+			Members: 3,
+			Version: "6.0.5",
+		},
+	}
+
+	c := container.New(mongodbContainer(mongodbImageMock, []corev1.VolumeMount{}, mdbv1.NewMongodConfiguration(), mdb))
 
 	t.Run("Has correct Env vars", func(t *testing.T) {
 		assert.Len(t, c.Env, 1)

--- a/controllers/construct/mongodbstatefulset_test.go
+++ b/controllers/construct/mongodbstatefulset_test.go
@@ -1,9 +1,14 @@
 package construct
 
 import (
+	mdbv1 "github.com/mongodb/mongodb-kubernetes-operator/api/v1"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/container"
+	"github.com/mongodb/mongodb-kubernetes-operator/pkg/kube/resourcerequirements"
 	"github.com/mongodb/mongodb-kubernetes-operator/pkg/readiness/config"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -94,4 +99,377 @@ func TestCollectEnvVars(t *testing.T) {
 			assert.EqualValues(t, tt.expectedEnv, actualEnvVars)
 		})
 	}
+}
+
+func TestGetContainerResources(t *testing.T) {
+	// Test with a nil mdb
+	t.Run("Nil mdb returns default resources", func(t *testing.T) {
+		result := getContainerResources(nil, MongodbName)
+		assert.Equal(t, resourcerequirements.Defaults(), result)
+	})
+
+	// Test with a mdb that doesn't have Resources specified
+	t.Run("Mdb without Resources returns default resources", func(t *testing.T) {
+		mdb := &mdbv1.MongoDBCommunity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-mongodb",
+				Namespace: "my-namespace",
+			},
+			Spec: mdbv1.MongoDBCommunitySpec{
+				Members: 3,
+				Version: "4.4.0",
+			},
+		}
+
+		result := getContainerResources(mdb, MongodbName)
+		assert.Equal(t, resourcerequirements.Defaults(), result)
+	})
+
+	// Create custom resource requirements for testing
+	customMongodRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	customAgentRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("250Mi"),
+		},
+	}
+
+	// Test with a mdb that has Resources specified
+	t.Run("Mdb with Resources specified returns custom resources", func(t *testing.T) {
+		mdb := &mdbv1.MongoDBCommunity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-mongodb",
+				Namespace: "my-namespace",
+			},
+			Spec: mdbv1.MongoDBCommunitySpec{
+				Members: 3,
+				Version: "4.4.0",
+				Resources: mdbv1.ResourcesSpec{
+					Mongod: &customMongodRes,
+					Agent:  &customAgentRes,
+				},
+			},
+		}
+
+		// Test for mongod container
+		mongodResult := getContainerResources(mdb, MongodbName)
+		assert.Equal(t, customMongodRes, mongodResult)
+
+		// Test for agent container
+		agentResult := getContainerResources(mdb, AgentName)
+		assert.Equal(t, customAgentRes, agentResult)
+
+		// Test for a container that doesn't have custom resources specified
+		readinessResult := getContainerResources(mdb, ReadinessProbeContainerName)
+		assert.Equal(t, resourcerequirements.Defaults(), readinessResult)
+	})
+
+	// Test with resources for all container types
+	t.Run("Mdb with all container resources specified", func(t *testing.T) {
+		readinessRes := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		}
+
+		hookRes := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		}
+
+		mdb := &mdbv1.MongoDBCommunity{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-mongodb",
+				Namespace: "my-namespace",
+			},
+			Spec: mdbv1.MongoDBCommunitySpec{
+				Members: 3,
+				Version: "4.4.0",
+				Resources: mdbv1.ResourcesSpec{
+					Mongod:             &customMongodRes,
+					Agent:              &customAgentRes,
+					ReadinessProbe:     &readinessRes,
+					VersionUpgradeHook: &hookRes,
+				},
+			},
+		}
+
+		// Test all container types
+		assert.Equal(t, customMongodRes, getContainerResources(mdb, MongodbName))
+		assert.Equal(t, customAgentRes, getContainerResources(mdb, AgentName))
+		assert.Equal(t, readinessRes, getContainerResources(mdb, ReadinessProbeContainerName))
+		assert.Equal(t, hookRes, getContainerResources(mdb, versionUpgradeHookName))
+
+		// Test for a non-existent container type
+		assert.Equal(t, resourcerequirements.Defaults(), getContainerResources(mdb, "non-existent-container"))
+	})
+}
+
+func TestMongodbContainerWithCustomResources(t *testing.T) {
+	// Create custom resource requirements for mongod
+	customMongodRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	// Create a MongoDBCommunity with custom resources
+	mdb := &mdbv1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-mongodb",
+			Namespace: "my-namespace",
+		},
+		Spec: mdbv1.MongoDBCommunitySpec{
+			Members: 3,
+			Version: "4.4.0",
+			Resources: mdbv1.ResourcesSpec{
+				Mongod: &customMongodRes,
+			},
+		},
+	}
+
+	// Create a mongod configuration
+	mongodConfig := mdbv1.NewMongodConfiguration()
+
+	// Create volume mounts
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "data-volume",
+			MountPath: "/data",
+		},
+	}
+
+	// Test the mongodbContainer function
+	t.Run("mongodbContainer should use custom resources", func(t *testing.T) {
+		// Create the c
+		containerMod := mongodbContainer("mongo:4.4.0", volumeMounts, mongodConfig, mdb)
+
+		// Apply the modification to a c
+		c := &corev1.Container{}
+		containerMod(c)
+
+		// Verify that the c has the custom resources
+		assert.Equal(t, customMongodRes, c.Resources)
+	})
+}
+
+func TestMongodbAgentContainerWithCustomResources(t *testing.T) {
+	// Create custom resource requirements for agent
+	customAgentRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("500Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("250Mi"),
+		},
+	}
+
+	// Create a MongoDBCommunity with custom resources
+	mdb := &mdbv1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-mongodb",
+			Namespace: "my-namespace",
+		},
+		Spec: mdbv1.MongoDBCommunitySpec{
+			Members: 3,
+			Version: "4.4.0",
+			Resources: mdbv1.ResourcesSpec{
+				Agent: &customAgentRes,
+			},
+		},
+	}
+
+	// Create volume mounts
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "data-volume",
+			MountPath: "/data",
+		},
+	}
+
+	// Test the mongodbAgentContainer function
+	t.Run("mongodbAgentContainer should use custom resources", func(t *testing.T) {
+		// Create the c
+		containerMod := mongodbAgentContainer("test-secret", volumeMounts, mdbv1.LogLevelInfo, "/var/log/mongodb-agent.log", 24, "mongo-agent:1.0.0", mdb)
+
+		// Apply the modification to a c
+		c := &corev1.Container{}
+		containerMod(c)
+
+		// Verify that the c has the custom resources
+		assert.Equal(t, customAgentRes, c.Resources)
+	})
+}
+
+func TestReadinessProbeInitWithCustomResources(t *testing.T) {
+	// Create custom resource requirements for readiness probe
+	readinessRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+
+	// Create a MongoDBCommunity with custom resources
+	mdb := &mdbv1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-mongodb",
+			Namespace: "my-namespace",
+		},
+		Spec: mdbv1.MongoDBCommunitySpec{
+			Members: 3,
+			Version: "4.4.0",
+			Resources: mdbv1.ResourcesSpec{
+				ReadinessProbe: &readinessRes,
+			},
+		},
+	}
+
+	// Create volume mounts
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "scripts-volume",
+			MountPath: "/opt/scripts",
+		},
+	}
+
+	// Test the readinessProbeInit function
+	t.Run("readinessProbeInit should use custom resources", func(t *testing.T) {
+		// Create the c
+		containerMod := readinessProbeInit(volumeMounts, "readiness-probe:1.0.0", mdb)
+
+		// Apply the modification to a c
+		c := &corev1.Container{}
+		containerMod(c)
+
+		// Verify that the c has the custom resources
+		assert.Equal(t, readinessRes, c.Resources)
+	})
+}
+
+func TestVersionUpgradeHookInitWithCustomResources(t *testing.T) {
+	// Create custom resource requirements for version upgrade hook
+	hookRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+
+	// Create a MongoDBCommunity with custom resources
+	mdb := &mdbv1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-mongodb",
+			Namespace: "my-namespace",
+		},
+		Spec: mdbv1.MongoDBCommunitySpec{
+			Members: 3,
+			Version: "4.4.0",
+			Resources: mdbv1.ResourcesSpec{
+				VersionUpgradeHook: &hookRes,
+			},
+		},
+	}
+
+	// Create volume mounts
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "hooks-volume",
+			MountPath: "/hooks",
+		},
+	}
+
+	// Test the versionUpgradeHookInit function
+	t.Run("versionUpgradeHookInit should use custom resources", func(t *testing.T) {
+		// Create the c
+		containerMod := versionUpgradeHookInit(volumeMounts, "version-upgrade-hook:1.0.0", mdb)
+
+		// Apply the modification to a c
+		c := &corev1.Container{}
+		containerMod(c)
+
+		// Verify that the c has the custom resources
+		assert.Equal(t, hookRes, c.Resources)
+	})
+}
+
+func TestResourcesArePassedToContainers(t *testing.T) {
+	// Create custom resource requirements for mongod
+	customMongodRes := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	// Create a MongoDBCommunity with custom resources
+	mdb := mdbv1.MongoDBCommunity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-mongodb",
+			Namespace: "my-namespace",
+		},
+		Spec: mdbv1.MongoDBCommunitySpec{
+			Members: 3,
+			Version: "4.4.0",
+			Resources: mdbv1.ResourcesSpec{
+				Mongod: &customMongodRes,
+			},
+		},
+	}
+
+	// Test the mongodbContainer function
+	t.Run("mongodbContainer uses custom resources when provided", func(t *testing.T) {
+		c := container.New(mongodbContainer("mongo:4.4.0", []corev1.VolumeMount{}, mdbv1.NewMongodConfiguration(), &mdb))
+		assert.Equal(t, customMongodRes, c.Resources)
+	})
+
+	// Test the mongodbAgentContainer function
+	t.Run("getContainerResources returns custom resources when provided", func(t *testing.T) {
+		res := getContainerResources(&mdb, MongodbName)
+		assert.Equal(t, customMongodRes, res)
+	})
 }


### PR DESCRIPTION
### Summary:
<!---
Please describe your changes here:
Why did you open this PR? 
What are you trying to accomplish?
what have you done? 
Why in this particular way? 
--->
This pull request introduces support for specifying custom resource requirements for MongoDB pods, enabling fine-grained control over resource allocation for different containers. The changes include updates to the CRD, API types, and controller logic to incorporate this functionality.

### API Enhancements

* Added a new `ResourcesSpec` type in `api/v1/mongodbcommunity_types.go` to define resource requirements for containers (`mongod`, `agent`, `readinessProbe`, and `versionUpgradeHook`). This type is integrated into the `MongoDBCommunitySpec` struct. [[1]](diffhunk://#diff-c6bc0e7df1d5729a036b15d65739171b20a44a39733a0fb33d8f0f1a44b4f5fdR135-R142) [[2]](diffhunk://#diff-c6bc0e7df1d5729a036b15d65739171b20a44a39733a0fb33d8f0f1a44b4f5fdR1236-R1254)

### CRD Updates

* Updated the CRD in `config/crd/bases/mongodbcommunity.mongodb.com_mongodbcommunity.yaml` to include the `resources` field, allowing users to specify resource requirements for individual containers. This includes descriptions and validation rules for `limits` and `requests`.

### Controller Modifications

* Updated the `BuildMongoDBReplicaSetStatefulSetModificationFunction` in `controllers/construct/mongodbstatefulset.go` to handle the new `ResourcesSpec`. This includes passing resource specifications to container creation functions for `mongod`, `agent`, `readinessProbe`, and `versionUpgradeHook` containers. [[1]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5R134-R140) [[2]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5L179-R188) [[3]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5L247-R256)
* Modified container creation functions (`mongodbContainer`, `mongodbAgentContainer`, `versionUpgradeHookInit`, `readinessProbeInit`) to accept and apply resource requirements from the `ResourcesSpec`. [[1]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5L280-R295) [[2]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5L317-R331) [[3]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5L356-R377) [[4]](diffhunk://#diff-8284ea9b248048389785e07541218df64d4189af98664ae8e2b69fa8d5d7f5c5L396-R404)

### Test Updates

* Enhanced the `TestMongod_Container` test in `controllers/construct/build_statefulset_test.go` to include a `MongoDBCommunity` instance without custom resources, ensuring compatibility with the new functionality.

These changes collectively enhance the flexibility and configurability of the MongoDB Kubernetes Operator, allowing users to better manage resource allocation for their deployments.

closes #962 

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
